### PR TITLE
Limit the number of simultaneous job submissions using MAX_STARTS

### DIFF
--- a/sbp/pending-check/run.py
+++ b/sbp/pending-check/run.py
@@ -127,8 +127,11 @@ def start_kubernetes_job(args):
 
 def main():
     samples = HmfApi().get_all(Sample, {'status': 'Pending_PipelineV5'})
+    max_starts = int(os.getenv('MAX_STARTS', '4'))
 
     if len(samples) > 0:
+        log('Scheduling {0} out of {1} samples'.format(max_starts,len(samples)))
+        del(samples[max_starts:])
         for sample in samples:
             start_kubernetes_job({'sbp_sample_id': sample.id})
 


### PR DESCRIPTION
By default the container will submit 4 jobs and exit, it can be overriden by setting the MAX_STARTS environment var