### PR TITLE
DEV-821 Add option to specify CMEK

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
@@ -85,6 +85,8 @@ public interface Arguments {
 
     String patientReportBucket();
 
+    Optional<String> cmek();
+
     Optional<Integer> sbpApiSampleId();
 
     Optional<Integer> sbpApiRunId();

--- a/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
@@ -57,6 +57,7 @@ public class CommandLineOptions {
     private static final String SET_ID_FLAG = "set_id";
     private static final String SBP_RUN_ID_FLAG = "sbp_run_id";
     private static final String PRIVATE_NETWORK_FLAG = "private_network";
+    private static final String CMEK_FLAG = "cmek";
 
     private static Options options() {
         return new Options().addOption(profile())
@@ -104,7 +105,13 @@ public class CommandLineOptions {
                 .addOption(resourceBucket())
                 .addOption(toolsBucket())
                 .addOption(patientReportBucket())
-                .addOption(privateNetwork());
+                .addOption(privateNetwork())
+                .addOption(cmek());
+    }
+
+    private static Option cmek() {
+        return optionWithArg(CMEK_FLAG,
+                "The name of the Customer Managed Encryption Key. When this flag is populated all runtime buckets " + "will use this key.");
     }
 
     private static Option privateNetwork() {
@@ -265,6 +272,7 @@ public class CommandLineOptions {
                     .toolsBucket(commandLine.getOptionValue(TOOLS_BUCKET_FLAG, defaults.toolsBucket()))
                     .patientReportBucket(commandLine.getOptionValue(PATIENT_REPORT_BUCKET_FLAG, defaults.patientReportBucket()))
                     .privateNetwork(privateNetwork(commandLine, defaults))
+                    .cmek(cmek(commandLine, defaults))
                     .profile(defaults.profile())
                     .build();
         } catch (ParseException e) {
@@ -275,11 +283,18 @@ public class CommandLineOptions {
         }
     }
 
+    private static Optional<String> cmek(final CommandLine commandLine, final Arguments defaults) {
+        if (commandLine.hasOption(CMEK_FLAG)) {
+            return Optional.of(commandLine.getOptionValue(CMEK_FLAG));
+        }
+        return defaults.cmek();
+    }
+
     private static Optional<String> privateNetwork(final CommandLine commandLine, final Arguments defaults) {
         if (commandLine.hasOption(PRIVATE_NETWORK_FLAG)) {
             return Optional.of(commandLine.getOptionValue(PRIVATE_NETWORK_FLAG));
         }
-        return Optional.empty();
+        return defaults.cmek();
     }
 
     private static Optional<Integer> sbpRunId(final CommandLine commandLine) {

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/DataprocLogComponent.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/DataprocLogComponent.java
@@ -50,7 +50,7 @@ public class DataprocLogComponent implements ReportComponent {
              storage.copy(Storage.CopyRequest.of(alignerBucket.runId(),
                     step.getValue(),
                     BlobId.of(reportBucket.getName(),
-                            format("%s/%s/%s/%s", setName, sampleName, Aligner.NAMESPACE, withLogExtension(step.getKey())))));
+                            format("%s/%s/%s/%s", setName, sampleName, Aligner.NAMESPACE, withLogExtension(step.getKey()))))).getResult();
         }
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/report/FullSomaticResults.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/report/FullSomaticResults.java
@@ -36,7 +36,7 @@ public class FullSomaticResults {
             String pathSplit = blob.getName().substring(blob.getName().indexOf("/") + 1, blob.getName().length());
             storage.copy(Storage.CopyRequest.of(arguments.patientReportBucket(),
                     blob.getName(),
-                    BlobId.of(arguments.patientReportBucket(), metadata.runName() + "/" + pathSplit)));
+                    BlobId.of(arguments.patientReportBucket(), metadata.runName() + "/" + pathSplit))).getResult();
             blob.delete();
         }
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/resource/Resource.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/resource/Resource.java
@@ -43,6 +43,7 @@ public class Resource {
                 String aliased = alias.apply(source.getName());
                 String[] targetPath = aliased.split("/");
                 String targetBlob = String.format("%s/%s", name, targetPath[targetPath.length - 1]);
+                LOGGER.debug("Copying [{}] to [{}]", source.getName(), targetBlob);
                 runtimeBucket.copyInto(commonResourcesBucket, source.getName(), targetBlob);
                 locationBuilder.addFiles(aliased);
             }

--- a/cluster/src/main/java/com/hartwig/pipeline/storage/StorageProvider.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/storage/StorageProvider.java
@@ -21,8 +21,8 @@ public class StorageProvider {
         return builder.setCredentials(credentials)
                 .setProjectId(arguments.project())
                 .setTransportOptions(HttpTransportOptions.newBuilder()
-                        .setConnectTimeout(Integer.MAX_VALUE)
-                        .setReadTimeout(Integer.MAX_VALUE)
+                        .setConnectTimeout(0)
+                        .setReadTimeout(0)
                         .build())
                 .build()
                 .getService();

--- a/cluster/src/main/java/com/hartwig/pipeline/storage/StorageProvider.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/storage/StorageProvider.java
@@ -1,6 +1,7 @@
 package com.hartwig.pipeline.storage;
 
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.hartwig.pipeline.Arguments;
@@ -16,7 +17,15 @@ public class StorageProvider {
     }
 
     public Storage get() {
-        return StorageOptions.newBuilder().setCredentials(credentials).setProjectId(arguments.project()).build().getService();
+        StorageOptions.Builder builder = StorageOptions.newBuilder();
+        return builder.setCredentials(credentials)
+                .setProjectId(arguments.project())
+                .setTransportOptions(HttpTransportOptions.newBuilder()
+                        .setConnectTimeout(Integer.MAX_VALUE)
+                        .setReadTimeout(Integer.MAX_VALUE)
+                        .build())
+                .build()
+                .getService();
     }
 
     public static StorageProvider from(Arguments arguments, GoogleCredentials credentials) {

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/germline/GermlineCallerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/germline/GermlineCallerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.CopyWriter;
 import com.google.cloud.storage.Storage;
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.ResultsDirectory;
@@ -37,6 +38,8 @@ public class GermlineCallerTest {
         final Bucket bucket = mock(Bucket.class);
         when(bucket.getName()).thenReturn(RUNTIME_BUCKET);
         when(storage.get(RUNTIME_BUCKET)).thenReturn(bucket);
+        CopyWriter copyWriter = mock(CopyWriter.class);
+        when(storage.copy(any())).thenReturn(copyWriter);
         MockResource.addToStorage(storage, ResourceNames.REFERENCE_GENOME, "reference.fasta");
         MockResource.addToStorage(storage, ResourceNames.DBNSFP, "dbsnfp.txt.gz");
         MockResource.addToStorage(storage, ResourceNames.GONL, "gonl.vcf.gz");

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/somatic/SomaticCallerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/somatic/SomaticCallerTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.CopyWriter;
 import com.google.cloud.storage.Storage;
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.ResultsDirectory;
@@ -45,6 +46,8 @@ public class SomaticCallerTest {
         Bucket bucket = mock(Bucket.class);
         when(bucket.getName()).thenReturn(RUNTIME_BUCKET);
         when(storage.get(RUNTIME_BUCKET)).thenReturn(bucket);
+        CopyWriter copyWriter = mock(CopyWriter.class);
+        when(storage.copy(any())).thenReturn(copyWriter);
         MockResource.addToStorage(storage, REFERENCE_GENOME, "reference.fasta");
         MockResource.addToStorage(storage, SAGE, "hotspots.tsv", "coding_regions.bed", "SAGE_PON.vcf.gz");
         MockResource.addToStorage(storage, STRELKA_CONFIG, "strelka.ini");

--- a/cluster/src/test/java/com/hartwig/pipeline/storage/RuntimeBucketTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/storage/RuntimeBucketTest.java
@@ -1,5 +1,7 @@
 package com.hartwig.pipeline.storage;
 
+import static java.lang.String.format;
+
 import static com.hartwig.pipeline.testsupport.TestInputs.defaultSomaticRunMetadata;
 import static com.hartwig.pipeline.testsupport.TestInputs.referenceRunMetadata;
 
@@ -135,9 +137,14 @@ public class RuntimeBucketTest {
 
     @Test
     public void usesCmekWhenProvided() {
-        RuntimeBucket.from(storage, NAMESPACE, referenceRunMetadata(), Arguments.testDefaultsBuilder().cmek("key").build());
-        assertThat(bucketInfo.getValue().getDefaultKmsKeyName()).isEqualTo(
-                "projects/hmf-pipeline-development/locations/europe-west4/keyRings/hmf-pipeline-development/cryptoKeys/key");
+        String keyName = "key";
+        Arguments arguments = Arguments.testDefaultsBuilder().cmek(keyName).build();
+        RuntimeBucket.from(storage, NAMESPACE, referenceRunMetadata(), arguments);
+        assertThat(bucketInfo.getValue().getDefaultKmsKeyName()).isEqualTo(format("projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s",
+                arguments.project(),
+                arguments.region(),
+                arguments.project(),
+                keyName));
     }
 
     @Test

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/amber/AmberTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/amber/AmberTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.CopyWriter;
 import com.google.cloud.storage.Storage;
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.ResultsDirectory;
@@ -39,6 +40,8 @@ public class AmberTest {
         final Bucket bucket = mock(Bucket.class);
         when(bucket.getName()).thenReturn(RUNTIME_BUCKET);
         when(storage.get(RUNTIME_BUCKET)).thenReturn(bucket);
+        CopyWriter copyWriter = mock(CopyWriter.class);
+        when(storage.copy(any())).thenReturn(copyWriter);
         MockResource.addToStorage(storage, ResourceNames.REFERENCE_GENOME, "reference.fasta");
         MockResource.addToStorage(storage, ResourceNames.AMBER_PON, "GermlineHetPon.hg19.bed", "GermlineSnp.hg19.bed");
         victim = new Amber(ARGUMENTS, computeEngine, storage, ResultsDirectory.defaultDirectory());

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/cobalt/CobaltTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/cobalt/CobaltTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.CopyWriter;
 import com.google.cloud.storage.Storage;
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.ResultsDirectory;
@@ -39,6 +40,8 @@ public class CobaltTest {
         final Bucket bucket = mock(Bucket.class);
         when(bucket.getName()).thenReturn(RUNTIME_BUCKET);
         when(storage.get(RUNTIME_BUCKET)).thenReturn(bucket);
+        CopyWriter copyWriter = mock(CopyWriter.class);
+        when(storage.copy(any())).thenReturn(copyWriter);
         MockResource.addToStorage(storage, ResourceNames.GC_PROFILE, "gc.cnp");
         victim = new Cobalt(ARGUMENTS, computeEngine, storage, ResultsDirectory.defaultDirectory());
     }

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/healthcheck/HealthCheckerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/healthcheck/HealthCheckerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import com.google.api.gax.paging.Page;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.CopyWriter;
 import com.google.cloud.storage.Storage;
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.ResultsDirectory;
@@ -46,6 +47,8 @@ public class HealthCheckerTest {
         bucket = mock(Bucket.class);
         when(bucket.getName()).thenReturn(RUNTIME_BUCKET);
         when(storage.get(RUNTIME_BUCKET)).thenReturn(bucket);
+        CopyWriter copyWriter = mock(CopyWriter.class);
+        when(storage.copy(any())).thenReturn(copyWriter);
         returnHealthCheck(bucket, "tumor.HealthCheckSucceeded");
         victim = new HealthChecker(ARGUMENTS, computeEngine, storage, ResultsDirectory.defaultDirectory());
     }

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/purple/PurpleTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/purple/PurpleTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.CopyWriter;
 import com.google.cloud.storage.Storage;
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.ResultsDirectory;
@@ -43,6 +44,8 @@ public class PurpleTest {
         final Bucket bucket = mock(Bucket.class);
         when(bucket.getName()).thenReturn(RUNTIME_BUCKET);
         when(storage.get(RUNTIME_BUCKET)).thenReturn(bucket);
+        CopyWriter copyWriter = mock(CopyWriter.class);
+        when(storage.copy(any())).thenReturn(copyWriter);
         MockResource.addToStorage(storage, ResourceNames.REFERENCE_GENOME, "reference.fasta");
         MockResource.addToStorage(storage, ResourceNames.GC_PROFILE, "gc_profile.cnp");
         victim = new Purple(ARGUMENTS, computeEngine, storage, ResultsDirectory.defaultDirectory());


### PR DESCRIPTION
Passed in as an argument, when present all runtime buckets will set the
kms property on creation (note will not change old buckets already using
Google keys).

Also necessary to increase storage timeouts and use the .getResult() to
ensure the the entire copy operation completes.