### PR TITLE
DEV-831 Delete source files after SBP transfer

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/SetMetadataApiProvider.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/SetMetadataApiProvider.java
@@ -6,7 +6,7 @@ import java.time.ZoneId;
 import com.google.cloud.storage.Storage;
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.sbpapi.SbpRestApi;
-import com.hartwig.pipeline.transfer.ResultsPublisherProvider;
+import com.hartwig.pipeline.transfer.SbpFileTransferProvider;
 
 public class SetMetadataApiProvider {
 
@@ -26,7 +26,7 @@ public class SetMetadataApiProvider {
         return arguments.sbpApiRunId().<SomaticMetadataApi>map(setId -> new SbpSomaticMetadataApi(arguments,
                 setId,
                 SbpRestApi.newInstance(arguments),
-                ResultsPublisherProvider.from(arguments, storage).get(),
+                SbpFileTransferProvider.from(arguments, storage).get(),
                 LocalDateTime.now(ZoneId.of("UTC")))).orElse(new LocalSetMetadataApi(arguments));
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/transfer/SbpFileTransferProvider.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/transfer/SbpFileTransferProvider.java
@@ -8,17 +8,17 @@ import com.hartwig.pipeline.storage.CloudCopy;
 import com.hartwig.pipeline.storage.RCloneCloudCopy;
 import com.hartwig.pipeline.storage.S3;
 
-public class ResultsPublisherProvider {
+public class SbpFileTransferProvider {
     private final Arguments arguments;
     private final Storage storage;
 
-    private ResultsPublisherProvider(Arguments arguments, final Storage storage) {
+    private SbpFileTransferProvider(Arguments arguments, final Storage storage) {
         this.arguments = arguments;
         this.storage = storage;
     }
 
-    public static ResultsPublisherProvider from(final Arguments arguments, final Storage storage) {
-        return new ResultsPublisherProvider(arguments, storage);
+    public static SbpFileTransferProvider from(final Arguments arguments, final Storage storage) {
+        return new SbpFileTransferProvider(arguments, storage);
     }
 
     public SbpFileTransfer get() {
@@ -32,7 +32,7 @@ public class ResultsPublisherProvider {
 
         try {
             Bucket sourceBucket = storage.get(arguments.patientReportBucket());
-            return new SbpFileTransfer(cloudCopy, sbpS3, sbpRestApi, sourceBucket, ContentTypeCorrection.get());
+            return new SbpFileTransfer(cloudCopy, sbpS3, sbpRestApi, sourceBucket, ContentTypeCorrection.get(), arguments);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Delete all the blobs that were transferred to SBP, using the existing
cleanup flag to disable if required.

Rename provider to match provided class.