### PR TITLE
DEV-832 Fail if no bucket defined in run

### DIFF
--- a/cluster/src/test/resources/sbp_api/get_run.json
+++ b/cluster/src/test/resources/sbp_api/get_run.json
@@ -21,7 +21,7 @@
   "ref_sample": "CPCT02290012R",
   "slaStart": null,
   "name": "170724_HMFregCPCT_FR13999246_FR13999144_CPCT02290012",
-  "bucket": null,
+  "bucket": "hmf_output_2019-27",
   "sbp_id": 7048,
   "tumor_sample": "CPCT02290012T",
   "entity_id": 122,

--- a/cluster/src/test/resources/sbp_api/get_run_no_bucket.json
+++ b/cluster/src/test/resources/sbp_api/get_run_no_bucket.json
@@ -21,7 +21,7 @@
   "ref_sample": "CPCT02290012R",
   "slaStart": null,
   "name": "170724_HMFregCPCT_FR13999246_FR13999144_CPCT02290012",
-  "bucket": "custom",
+  "bucket": null,
   "sbp_id": 7048,
   "tumor_sample": "CPCT02290012T",
   "entity_id": 122,


### PR DESCRIPTION
This change will ensure we always use an externally defined end bucket
for the SBP transfer, by failing if its not there.