### PR TITLE
DEV-839 Add QC_FAILED status for health checker

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/cleanup/Cleanup.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/cleanup/Cleanup.java
@@ -29,7 +29,7 @@ public class Cleanup {
     }
 
     public void run(SomaticRunMetadata metadata) {
-        LOGGER.info("Cleaning up all transient resources on successful somatic pipeline run (runtime buckets and dataproc jobs)");
+        LOGGER.info("Cleaning up all transient resources on complete somatic pipeline run (runtime buckets and dataproc jobs)");
         String referenceSampleName = metadata.reference().sampleId();
         String tumorSampleName = metadata.tumor().sampleId();
         Run referenceRun = Run.from(referenceSampleName, arguments);

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/PipelineStatus.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/PipelineStatus.java
@@ -4,6 +4,7 @@ public enum PipelineStatus {
 
     SUCCESS,
     FAILED,
+    QC_FAILED,
     SKIPPED,
     UNKNOWN
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/healthcheck/HealthChecker.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/healthcheck/HealthChecker.java
@@ -106,7 +106,7 @@ public class HealthChecker {
                 status = PipelineStatus.SUCCESS;
             } else if (healthCheckStatus.getName().endsWith("HealthCheckFailed")) {
                 LOGGER.warn("Health check reported failure. Check run.log in health checker out for reason");
-                status = PipelineStatus.FAILED;
+                status = PipelineStatus.QC_FAILED;
             } else {
                 LOGGER.warn(
                         "Health check completed with unknown status [{}]. Failing the run. Check run.log in health checker out for more "

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/healthcheck/HealthCheckerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/healthcheck/HealthCheckerTest.java
@@ -82,8 +82,7 @@ public class HealthCheckerTest {
         runVictim();
         System.out.println(jobDefinitionArgumentCaptor.getValue().startupCommand().asUnixString());
         assertThat(jobDefinitionArgumentCaptor.getValue().startupCommand().asUnixString()).contains(
-                "java -Xmx10G -jar /data/tools/health-checker/" + Versions.HEALTH_CHECKER
-                        + "/health-checker.jar -reference reference "
+                "java -Xmx10G -jar /data/tools/health-checker/" + Versions.HEALTH_CHECKER + "/health-checker.jar -reference reference "
                         + "-tumor tumor -metrics_dir /data/input/metrics -amber_dir /data/input/amber -purple_dir /data/input/purple "
                         + "-output_dir /data/output");
     }
@@ -111,7 +110,7 @@ public class HealthCheckerTest {
     public void returnsStatusFailsWhenHealthCheckerReportsFailure() {
         when(computeEngine.submit(any(), any())).thenReturn(PipelineStatus.SUCCESS);
         returnHealthCheck(bucket, "tumor.HealthCheckFailed");
-        assertThat(runVictim().status()).isEqualTo(PipelineStatus.FAILED);
+        assertThat(runVictim().status()).isEqualTo(PipelineStatus.QC_FAILED);
     }
 
     private void returnHealthCheck(final Bucket bucket, final String status) {


### PR DESCRIPTION
This allows us to mark a run as failed for the SBP API call without
skipping cleanups as we do on a tech failure.

Also added a status check in PipelineMain to exit 1 on tech failures
from remote jobs (vms and dataproc).