### PR TITLE
DEV-847 Copy startup script to output bucket

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/calling/germline/GermlineCaller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/germline/GermlineCaller.java
@@ -27,6 +27,7 @@ import com.hartwig.pipeline.execution.vm.unix.UnzipToDirectoryCommand;
 import com.hartwig.pipeline.metadata.SingleSampleRunMetadata;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.report.RunLogComponent;
+import com.hartwig.pipeline.report.StartupScriptComponent;
 import com.hartwig.pipeline.report.ZippedVcfAndIndexComponent;
 import com.hartwig.pipeline.resource.GATKDictAlias;
 import com.hartwig.pipeline.resource.ReferenceGenomeAlias;
@@ -134,6 +135,7 @@ public class GermlineCaller {
         trace.stop();
         return outputBuilder.status(status)
                 .addReportComponents(new RunLogComponent(bucket, NAMESPACE, Folder.from(metadata), resultsDirectory))
+                .addReportComponents(new StartupScriptComponent(bucket, NAMESPACE, Folder.from(metadata)))
                 .addReportComponents(new ZippedVcfAndIndexComponent(bucket,
                         NAMESPACE,
                         Folder.from(metadata),

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/somatic/SomaticCaller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/somatic/SomaticCaller.java
@@ -22,6 +22,7 @@ import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.EntireOutputComponent;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.report.RunLogComponent;
+import com.hartwig.pipeline.report.StartupScriptComponent;
 import com.hartwig.pipeline.report.ZippedVcfAndIndexComponent;
 import com.hartwig.pipeline.resource.GATKDictAlias;
 import com.hartwig.pipeline.resource.ReferenceGenomeAlias;
@@ -145,6 +146,7 @@ public class SomaticCaller {
                         resultsDirectory,
                         s -> s.contains("chromosomes") || s.contains("Makefile") || s.contains("task.complete")))
                 .addReportComponents(new RunLogComponent(runtimeBucket, NAMESPACE, Folder.from(), resultsDirectory))
+                .addReportComponents(new StartupScriptComponent(runtimeBucket, NAMESPACE, Folder.from()))
                 .build();
 
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/structural/StructuralCaller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/structural/StructuralCaller.java
@@ -32,6 +32,7 @@ import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.EntireOutputComponent;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.report.RunLogComponent;
+import com.hartwig.pipeline.report.StartupScriptComponent;
 import com.hartwig.pipeline.report.ZippedVcfAndIndexComponent;
 import com.hartwig.pipeline.resource.Resource;
 import com.hartwig.pipeline.resource.ResourceNames;
@@ -184,6 +185,7 @@ public class StructuralCaller {
                         resultsDirectory,
                         s -> !s.contains("working") || s.endsWith("sorted.bam.sv.bam") || s.endsWith("sorted.bam.sv.bai")))
                 .addReportComponents(new RunLogComponent(runtimeBucket, NAMESPACE, Folder.from(), resultsDirectory))
+                .addReportComponents(new StartupScriptComponent(runtimeBucket, NAMESPACE, Folder.from()))
                 .build();
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/flagstat/Flagstat.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/flagstat/Flagstat.java
@@ -16,6 +16,7 @@ import com.hartwig.pipeline.metadata.SingleSampleRunMetadata;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.report.SingleFileComponent;
+import com.hartwig.pipeline.report.StartupScriptComponent;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 import com.hartwig.pipeline.trace.StageTrace;
@@ -53,6 +54,7 @@ public class Flagstat {
         return FlagstatOutput.builder()
                 .status(status)
                 .addReportComponents(new RunLogComponent(bucket, Flagstat.NAMESPACE, Folder.from(metadata), resultsDirectory))
+                .addReportComponents(new StartupScriptComponent(bucket, NAMESPACE, Folder.from(metadata)))
                 .addReportComponents(new SingleFileComponent(bucket,
                         Flagstat.NAMESPACE,
                         Folder.from(metadata),

--- a/cluster/src/main/java/com/hartwig/pipeline/metrics/BamMetrics.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metrics/BamMetrics.java
@@ -16,6 +16,7 @@ import com.hartwig.pipeline.metadata.SingleSampleRunMetadata;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.report.SingleFileComponent;
+import com.hartwig.pipeline.report.StartupScriptComponent;
 import com.hartwig.pipeline.resource.GATKDictAlias;
 import com.hartwig.pipeline.resource.ReferenceGenomeAlias;
 import com.hartwig.pipeline.resource.Resource;
@@ -69,6 +70,7 @@ public class BamMetrics {
                 .sample(alignmentOutput.sample())
                 .maybeMetricsOutputFile(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(outputFile)))
                 .addReportComponents(new RunLogComponent(bucket, BamMetrics.NAMESPACE, Folder.from(metadata), resultsDirectory))
+                .addReportComponents(new StartupScriptComponent(bucket, NAMESPACE, Folder.from(metadata)))
                 .addReportComponents(new SingleFileComponent(bucket,
                         BamMetrics.NAMESPACE,
                         Folder.from(metadata),

--- a/cluster/src/main/java/com/hartwig/pipeline/report/StartupScriptComponent.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/report/StartupScriptComponent.java
@@ -19,6 +19,6 @@ public class StartupScriptComponent implements ReportComponent {
     @Override
     public void addToReport(final Storage storage, final Bucket reportBucket, final String setName) {
         runtimeBucket.copyOutOf("copy_of_startup_script_used_for_this_run.sh", reportBucket.getName(),
-                String.format("%s/%s%s/%s", setName, folder.name(), namespace, "bootstrap.sh"));
+                String.format("%s/%s%s/%s", setName, folder.name(), namespace, "run.sh"));
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/report/StartupScriptComponent.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/report/StartupScriptComponent.java
@@ -1,0 +1,24 @@
+package com.hartwig.pipeline.report;
+
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.Storage;
+import com.hartwig.pipeline.ResultsDirectory;
+import com.hartwig.pipeline.storage.RuntimeBucket;
+
+public class StartupScriptComponent implements ReportComponent {
+    private final RuntimeBucket runtimeBucket;
+    private final String namespace;
+    private final Folder folder;
+
+    public StartupScriptComponent(final RuntimeBucket runtimeBucket, final String namespace, final Folder folder) {
+        this.runtimeBucket = runtimeBucket;
+        this.namespace = namespace;
+        this.folder = folder;
+    }
+
+    @Override
+    public void addToReport(final Storage storage, final Bucket reportBucket, final String setName) {
+        runtimeBucket.copyOutOf("copy_of_startup_script_used_for_this_run.sh", reportBucket.getName(),
+                String.format("%s/%s%s/%s", setName, folder.name(), namespace, "bootstrap.sh"));
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/snpgenotype/SnpGenotype.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/snpgenotype/SnpGenotype.java
@@ -18,6 +18,7 @@ import com.hartwig.pipeline.metadata.SingleSampleRunMetadata;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.report.SingleFileComponent;
+import com.hartwig.pipeline.report.StartupScriptComponent;
 import com.hartwig.pipeline.resource.GATKDictAlias;
 import com.hartwig.pipeline.resource.ReferenceGenomeAlias;
 import com.hartwig.pipeline.resource.Resource;
@@ -80,6 +81,7 @@ public class SnpGenotype {
         return SnpGenotypeOutput.builder()
                 .status(status)
                 .addReportComponents(new RunLogComponent(bucket, NAMESPACE, Folder.from(metadata), resultsDirectory))
+                .addReportComponents(new StartupScriptComponent(bucket, NAMESPACE, Folder.from(metadata)))
                 .addReportComponents(new SingleFileComponent(bucket,
                         NAMESPACE,
                         Folder.from(metadata),

--- a/cluster/src/test/java/com/hartwig/pipeline/report/StartupScriptComponentTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/report/StartupScriptComponentTest.java
@@ -36,6 +36,6 @@ public class StartupScriptComponentTest {
         verify(runtimeBucket, times(1)).copyOutOf(sourceBlobCaptor.capture(), targetBucketCaptor.capture(), targetBlobCaptor.capture());
         assertThat(sourceBlobCaptor.getValue()).isEqualTo("copy_of_startup_script_used_for_this_run.sh");
         assertThat(targetBucketCaptor.getValue()).isEqualTo(REPORT_BUCKET);
-        assertThat(targetBlobCaptor.getValue()).isEqualTo("test_set/reference/test/bootstrap.sh");
+        assertThat(targetBlobCaptor.getValue()).isEqualTo("test_set/reference/test/run.sh");
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/report/StartupScriptComponentTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/report/StartupScriptComponentTest.java
@@ -1,0 +1,41 @@
+package com.hartwig.pipeline.report;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.Storage;
+import com.hartwig.pipeline.ResultsDirectory;
+import com.hartwig.pipeline.storage.RuntimeBucket;
+import com.hartwig.pipeline.testsupport.MockRuntimeBucket;
+import com.hartwig.pipeline.testsupport.TestInputs;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class StartupScriptComponentTest {
+
+    private static final String REPORT_BUCKET = "report_bucket";
+
+    @Test
+    public void copiesStartupScriptIntoReportBucket() {
+        Storage storage = mock(Storage.class);
+        RuntimeBucket runtimeBucket = MockRuntimeBucket.test().getRuntimeBucket();
+        Bucket reportBucket = mock(Bucket.class);
+        when(reportBucket.getName()).thenReturn(REPORT_BUCKET);
+        ArgumentCaptor<String> sourceBlobCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> targetBucketCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> targetBlobCaptor = ArgumentCaptor.forClass(String.class);
+        StartupScriptComponent victim = new StartupScriptComponent(runtimeBucket,
+                "test",
+                Folder.from(TestInputs.referenceRunMetadata()));
+        victim.addToReport(storage, reportBucket, "test_set");
+        verify(runtimeBucket, times(1)).copyOutOf(sourceBlobCaptor.capture(), targetBucketCaptor.capture(), targetBlobCaptor.capture());
+        assertThat(sourceBlobCaptor.getValue()).isEqualTo("copy_of_startup_script_used_for_this_run.sh");
+        assertThat(targetBucketCaptor.getValue()).isEqualTo(REPORT_BUCKET);
+        assertThat(targetBlobCaptor.getValue()).isEqualTo("test_set/reference/test/bootstrap.sh");
+    }
+}


### PR DESCRIPTION
Useful for debugging, manual re-running and auditing.

The script name is shortened when it is copied to the final output bucket.
