### PR TITLE
DEV-849 Add shallow seq config support

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
@@ -42,6 +42,8 @@ public interface Arguments {
 
     boolean runTertiary();
 
+    boolean shallow();
+
     DefaultsProfile profile();
 
     Mode mode();
@@ -144,6 +146,7 @@ public interface Arguments {
                     .runSomaticCaller(true)
                     .runStructuralCaller(true)
                     .runTertiary(true)
+                    .shallow(false)
                     .sampleId(EMPTY)
                     .setId(EMPTY)
                     .toolsBucket(DEFAULT_PRODUCTION_COMMON_TOOLS_BUCKET)
@@ -173,6 +176,7 @@ public interface Arguments {
                     .runSomaticCaller(true)
                     .runTertiary(true)
                     .runStructuralCaller(true)
+                    .shallow(false)
                     .rclonePath(NOT_APPLICABLE)
                     .rcloneS3RemoteDownload(NOT_APPLICABLE)
                     .rcloneS3RemoteUpload(NOT_APPLICABLE)

--- a/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
@@ -58,6 +58,7 @@ public class CommandLineOptions {
     private static final String SBP_RUN_ID_FLAG = "sbp_run_id";
     private static final String PRIVATE_NETWORK_FLAG = "private_network";
     private static final String CMEK_FLAG = "cmek";
+    private static final String SHALLOW_FLAG = "shallow";
 
     private static Options options() {
         return new Options().addOption(profile())
@@ -106,7 +107,10 @@ public class CommandLineOptions {
                 .addOption(toolsBucket())
                 .addOption(patientReportBucket())
                 .addOption(privateNetwork())
-                .addOption(cmek());
+                .addOption(cmek())
+                .addOption(optionWithBooleanArg(SHALLOW_FLAG,
+                        "Run with ShallowSeq configuration.Germline and health checker are disabled and purple is run with low coverage "
+                                + "options."));
     }
 
     private static Option cmek() {
@@ -273,6 +277,7 @@ public class CommandLineOptions {
                     .patientReportBucket(commandLine.getOptionValue(PATIENT_REPORT_BUCKET_FLAG, defaults.patientReportBucket()))
                     .privateNetwork(privateNetwork(commandLine, defaults))
                     .cmek(cmek(commandLine, defaults))
+                    .shallow(booleanOptionWithDefault(commandLine, SHALLOW_FLAG, defaults.shallow()))
                     .profile(defaults.profile())
                     .build();
         } catch (ParseException e) {

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/germline/GermlineCaller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/germline/GermlineCaller.java
@@ -70,7 +70,7 @@ public class GermlineCaller {
 
     public GermlineCallerOutput run(SingleSampleRunMetadata metadata, AlignmentOutput alignmentOutput) {
 
-        if (!arguments.runGermlineCaller()) {
+        if (!arguments.runGermlineCaller() || arguments.shallow()) {
             return GermlineCallerOutput.builder().status(PipelineStatus.SKIPPED).build();
         }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/healthcheck/HealthChecker.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/healthcheck/HealthChecker.java
@@ -52,7 +52,7 @@ public class HealthChecker {
 
     public HealthCheckOutput run(SomaticRunMetadata metadata, AlignmentPair pair, BamMetricsOutput metricsOutput,
             BamMetricsOutput mateMetricsOutput, AmberOutput amberOutput, PurpleOutput purpleOutput) {
-        if (!arguments.runTertiary()) {
+        if (!arguments.runTertiary() || arguments.shallow()) {
             return HealthCheckOutput.builder().status(PipelineStatus.SKIPPED).build();
         }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/purple/Purple.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/purple/Purple.java
@@ -83,7 +83,8 @@ public class Purple {
                 somaticVcfDownload.getLocalTargetPath(),
                 structuralVcfDownload.getLocalTargetPath(),
                 svRecoveryVcfDownload.getLocalTargetPath(),
-                VmDirectories.TOOLS + "/circos/" + Versions.CIRCOS + "/bin/circos"));
+                VmDirectories.TOOLS + "/circos/" + Versions.CIRCOS + "/bin/circos",
+                arguments.shallow()));
         bash.addCommand(new OutputUpload(GoogleStorageLocation.of(runtimeBucket.name(), resultsDirectory.path())));
         PipelineStatus status = computeEngine.submit(runtimeBucket, VirtualMachineJobDefinition.purple(bash, resultsDirectory));
         trace.stop();

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/purple/PurpleApplicationCommand.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/purple/PurpleApplicationCommand.java
@@ -1,39 +1,72 @@
 package com.hartwig.pipeline.tertiary.purple;
 
-import com.google.common.collect.Lists;
+import static com.google.common.collect.Lists.newArrayList;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import com.hartwig.pipeline.execution.vm.Bash;
 import com.hartwig.pipeline.execution.vm.JavaJarCommand;
 import com.hartwig.pipeline.execution.vm.VmDirectories;
 import com.hartwig.pipeline.tools.Versions;
 
+import org.jetbrains.annotations.NotNull;
+
 class PurpleApplicationCommand extends JavaJarCommand {
     PurpleApplicationCommand(String referenceSampleName, String tumorSampleName, String amberDirectory, String cobaltDirectory,
-            String gcProfile, String somaticVcf, String structuralVcf, String svRecoveryVcf, String circosPath) {
+            String gcProfile, String somaticVcf, String structuralVcf, String svRecoveryVcf, String circosPath, boolean isShallow) {
         super("purple",
                 Versions.PURPLE,
                 "purple.jar",
                 "8G",
-                Lists.newArrayList("-reference",
-                        referenceSampleName,
-                        "-tumor",
+                combine(arguments(referenceSampleName,
                         tumorSampleName,
-                        "-output_dir",
-                        VmDirectories.OUTPUT,
-                        "-amber",
                         amberDirectory,
-                        "-cobalt",
                         cobaltDirectory,
-                        "-gc_profile",
                         gcProfile,
-                        "-somatic_vcf",
                         somaticVcf,
-                        "-structural_vcf",
                         structuralVcf,
-                        "-sv_recovery_vcf",
                         svRecoveryVcf,
-                        "-circos",
-                        circosPath,
-                        "-threads",
-                        Bash.allCpus()));
+                        circosPath), shallowArguments(isShallow)));
+    }
+
+    private static List<String> combine(List<String> first, List<String> second) {
+        first.addAll(second);
+        return first;
+    }
+
+    private static List<String> shallowArguments(final boolean isShallow) {
+        if (isShallow) {
+            return newArrayList("-highly_diploid_percentage", "0.88", "-somatic_min_total", "100", "-somatic_min_purity_spread", "0.1");
+        }
+        return new ArrayList<>();
+    }
+
+    @NotNull
+    private static ArrayList<String> arguments(final String referenceSampleName, final String tumorSampleName, final String amberDirectory,
+            final String cobaltDirectory, final String gcProfile, final String somaticVcf, final String structuralVcf,
+            final String svRecoveryVcf, final String circosPath) {
+        return newArrayList("-reference",
+                referenceSampleName,
+                "-tumor",
+                tumorSampleName,
+                "-output_dir",
+                VmDirectories.OUTPUT,
+                "-amber",
+                amberDirectory,
+                "-cobalt",
+                cobaltDirectory,
+                "-gc_profile",
+                gcProfile,
+                "-somatic_vcf",
+                somaticVcf,
+                "-structural_vcf",
+                structuralVcf,
+                "-sv_recovery_vcf",
+                svRecoveryVcf,
+                "-circos",
+                circosPath,
+                "-threads",
+                Bash.allCpus());
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/purple/PurpleApplicationCommand.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/purple/PurpleApplicationCommand.java
@@ -13,6 +13,11 @@ import com.hartwig.pipeline.tools.Versions;
 import org.jetbrains.annotations.NotNull;
 
 class PurpleApplicationCommand extends JavaJarCommand {
+
+    private static final String LOW_COVERAGE_DIPLOID_PERCENTAGE = "0.88";
+    private static final String LOW_COVERAGE_SOMATIC_MIN_TOTAL = "100";
+    private static final String LOW_COVERAGE_SOMATIC_MIN_PURITY_SPREAD = "0.1";
+
     PurpleApplicationCommand(String referenceSampleName, String tumorSampleName, String amberDirectory, String cobaltDirectory,
             String gcProfile, String somaticVcf, String structuralVcf, String svRecoveryVcf, String circosPath, boolean isShallow) {
         super("purple",
@@ -27,19 +32,7 @@ class PurpleApplicationCommand extends JavaJarCommand {
                         somaticVcf,
                         structuralVcf,
                         svRecoveryVcf,
-                        circosPath), shallowArguments(isShallow)));
-    }
-
-    private static List<String> combine(List<String> first, List<String> second) {
-        first.addAll(second);
-        return first;
-    }
-
-    private static List<String> shallowArguments(final boolean isShallow) {
-        if (isShallow) {
-            return newArrayList("-highly_diploid_percentage", "0.88", "-somatic_min_total", "100", "-somatic_min_purity_spread", "0.1");
-        }
-        return new ArrayList<>();
+                        circosPath), maybeShallowArguments(isShallow)));
     }
 
     @NotNull
@@ -68,5 +61,22 @@ class PurpleApplicationCommand extends JavaJarCommand {
                 circosPath,
                 "-threads",
                 Bash.allCpus());
+    }
+
+    private static List<String> maybeShallowArguments(final boolean isShallow) {
+        if (isShallow) {
+            return newArrayList("-highly_diploid_percentage",
+                    LOW_COVERAGE_DIPLOID_PERCENTAGE,
+                    "-somatic_min_total",
+                    LOW_COVERAGE_SOMATIC_MIN_TOTAL,
+                    "-somatic_min_purity_spread",
+                    LOW_COVERAGE_SOMATIC_MIN_PURITY_SPREAD);
+        }
+        return new ArrayList<>();
+    }
+
+    private static List<String> combine(List<String> first, List<String> second) {
+        first.addAll(second);
+        return first;
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/germline/GermlineCallerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/germline/GermlineCallerTest.java
@@ -70,6 +70,16 @@ public class GermlineCallerTest {
     }
 
     @Test
+    public void returnsSkippedWhenShallowEnabled() {
+        victim = new GermlineCaller(Arguments.testDefaultsBuilder().shallow(true).build(),
+                computeEngine,
+                storage,
+                ResultsDirectory.defaultDirectory());
+        GermlineCallerOutput output = victim.run(referenceRunMetadata(), referenceAlignmentOutput());
+        assertThat(output.status()).isEqualTo(PipelineStatus.SKIPPED);
+    }
+
+    @Test
     public void returnsStatusFailedWhenJobFailsOnComputeEngine() {
         when(computeEngine.submit(any(), any())).thenReturn(PipelineStatus.FAILED);
         assertThat(victim.run(referenceRunMetadata(), referenceAlignmentOutput()).status()).isEqualTo(PipelineStatus.FAILED);

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/healthcheck/HealthCheckerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/healthcheck/HealthCheckerTest.java
@@ -64,6 +64,16 @@ public class HealthCheckerTest {
     }
 
     @Test
+    public void returnsSkippedWhenShallow() {
+        victim = new HealthChecker(Arguments.testDefaultsBuilder().shallow(true).build(),
+                computeEngine,
+                storage,
+                ResultsDirectory.defaultDirectory());
+        HealthCheckOutput output = runVictim();
+        assertThat(output.status()).isEqualTo(PipelineStatus.SKIPPED);
+    }
+
+    @Test
     public void returnsHealthCheckerOutputDirectory() {
         when(computeEngine.submit(any(), any())).thenReturn(PipelineStatus.SUCCESS);
         HealthCheckOutput output = runVictim();

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/purple/PurpleTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/purple/PurpleTest.java
@@ -87,6 +87,18 @@ public class PurpleTest {
     }
 
     @Test
+    public void runsPurpleWithLowCoverageArgsWhenShallow() {
+        victim = new Purple(Arguments.builder().from(ARGUMENTS).shallow(true).build(),
+                computeEngine,
+                storage,
+                ResultsDirectory.defaultDirectory());
+        ArgumentCaptor<VirtualMachineJobDefinition> jobDefinitionArgumentCaptor = captureAndReturnSuccess();
+        runVictim();
+        assertThat(jobDefinitionArgumentCaptor.getValue().startupCommand().asUnixString()).contains(
+                " -highly_diploid_percentage 0.88 -somatic_min_total 100 -somatic_min_purity_spread 0.1");
+    }
+
+    @Test
     public void downloadsInputVcfsCobaltAndAmberOutput() {
         ArgumentCaptor<VirtualMachineJobDefinition> jobDefinitionArgumentCaptor = captureAndReturnSuccess();
         runVictim();


### PR DESCRIPTION
Implemented as its own flag (-shallow true) as it doesn't quite fit as
a mode or profile.

When enabled will turn off germline and health check, and add some extra
args to purple for low coverage.