### PR TITLE
DEV-852 Upgrade ADAM to 0.28

### DIFF
--- a/bam/src/main/java/com/hartwig/bam/ADAMKryo.java
+++ b/bam/src/main/java/com/hartwig/bam/ADAMKryo.java
@@ -14,7 +14,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.spark.internal.io.FileCommitProtocol;
 import org.apache.spark.serializer.KryoRegistrator;
 import org.bdgenomics.adam.algorithms.consensus.Consensus;
-import org.bdgenomics.adam.converters.FastaConverter;
+import org.bdgenomics.adam.converters.FastaDescriptionLine;
 import org.bdgenomics.adam.models.IndelTable;
 import org.bdgenomics.adam.models.ReadGroup;
 import org.bdgenomics.adam.models.ReadGroupDictionary;
@@ -37,7 +37,6 @@ import org.bdgenomics.adam.serialization.AvroSerializer;
 import org.bdgenomics.adam.util.ReferenceContigMap;
 import org.bdgenomics.formats.avro.AlignmentRecord;
 import org.bdgenomics.formats.avro.Fragment;
-import org.bdgenomics.formats.avro.NucleotideContigFragment;
 import org.bdgenomics.formats.avro.ProcessingStep;
 import org.bdgenomics.formats.avro.Strand;
 import org.bdgenomics.formats.avro.Variant;
@@ -55,6 +54,7 @@ import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.ValidationStringency;
 import scala.collection.convert.Wrappers$;
 import scala.collection.immutable.RedBlackTree;
+import scala.collection.immutable.TreeMap;
 
 public class ADAMKryo implements KryoRegistrator {
 
@@ -83,8 +83,6 @@ public class ADAMKryo implements KryoRegistrator {
             kryo.register(Class.class);
             kryo.register(FileCommitProtocol.TaskCommitMessage.class);
             kryo.register(Class.forName("scala.collection.immutable.Set$EmptySet$", false, getClass().getClassLoader()));
-            kryo.register(FastaConverter.FastaDescriptionLine.class);
-            kryo.register(NucleotideContigFragment.class);
             kryo.register(IndelTable.class);
             kryo.register(ReferenceContigMap.class);
             kryo.register(TargetSet.class);
@@ -138,6 +136,9 @@ public class ADAMKryo implements KryoRegistrator {
             kryo.register(MultiplePrimaryAlignments.class);
             kryo.register(MultiplePrimaryAlignments.ReadOrdinal.class);
             kryo.register(ImmutableMultiplePrimaryAlignments.class);
+            kryo.register(FastaDescriptionLine.class);
+            kryo.register(TreeMap.class);
+            kryo.register(Class.forName("scala.math.Ordering$Long$", false, getClass().getClassLoader()));
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/dataproc/GoogleClusterConfig.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/dataproc/GoogleClusterConfig.java
@@ -25,6 +25,7 @@ class GoogleClusterConfig {
 
     private static final String IDLE_TTL = "600s";
     private static final int DISK_SIZE_GB = 1000;
+    private static final String LATEST_DATAPROC_IMAGE = "1.4";
     private final ClusterConfig config;
 
     private GoogleClusterConfig(final ClusterConfig config) {
@@ -69,12 +70,12 @@ class GoogleClusterConfig {
     }
 
     private static SoftwareConfig softwareConfig() {
-        return new SoftwareConfig().setProperties(ImmutableMap.<String, String>builder().put("dataproc:dataproc.logging.stackdriver.enable",
-                "false")
-                .put("yarn:yarn.nodemanager.vmem-check-enabled", "false")
-                .put("yarn:yarn.nodemanager.pmem-check-enabled", "false")
-                .put("dataproc:dataproc.allow.zero.workers", "true")
-                .build());
+        return new SoftwareConfig().setImageVersion(LATEST_DATAPROC_IMAGE)
+                .setProperties(ImmutableMap.<String, String>builder().put("dataproc:dataproc.logging.stackdriver.enable", "false")
+                        .put("yarn:yarn.nodemanager.vmem-check-enabled", "false")
+                        .put("yarn:yarn.nodemanager.pmem-check-enabled", "false")
+                        .put("dataproc:dataproc.allow.zero.workers", "true")
+                        .build());
     }
 
     @NotNull

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <slf4j-api.version>1.7.25</slf4j-api.version>
         <spark.version>2.3.0</spark.version>
         <commons-io.version>2.4</commons-io.version>
-        <adam.version>0.26.0</adam.version>
+        <adam.version>0.28.0</adam.version>
         <cannoli.version>0.1.0</cannoli.version>
         <parquet-hadoop.version>1.8.2</parquet-hadoop.version>
         <jackson.version>2.9.5</jackson.version>


### PR DESCRIPTION
Only one small thing to port, in 28 there is no longer a special fasta
datamodel, so using Sequence instead of NucleotideContigFragment.

Also using the latest dataproc image to take advantage of Spark 2.4.