### PR TITLE
DEV-854 Simple bcl2fastq application using compute engine

### DIFF
--- a/cluster/images/standard.cmds
+++ b/cluster/images/standard.cmds
@@ -22,6 +22,7 @@ sudo chmod a+x /data/tools/bcftools/1.3.1/bcftools
 sudo chmod a+x /data/tools/snpEff/4.3s/snpEff.sh
 sudo chmod a+x /data/tools/bwa/0.7.17/bwa
 sudo chmod a+x /data/tools/sambamba/0.6.5/sambamba
+sudo chmod a+x /data/tools/bcl2fastq/2.20.0.422/bcl2fastq
 sudo cpanm install Clone
 sudo cpanm install Config::General
 sudo cpanm install Font::TTF::Font

--- a/cluster/src/main/java/com/hartwig/bcl2fastq/Arguments.java
+++ b/cluster/src/main/java/com/hartwig/bcl2fastq/Arguments.java
@@ -1,0 +1,15 @@
+package com.hartwig.bcl2fastq;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface Arguments {
+
+    String inputBucket();
+
+    String flowcell();
+
+    static ImmutableArguments.Builder builder(){
+        return ImmutableArguments.builder();
+    }
+}

--- a/cluster/src/main/java/com/hartwig/bcl2fastq/Bcl2Fastq.java
+++ b/cluster/src/main/java/com/hartwig/bcl2fastq/Bcl2Fastq.java
@@ -1,0 +1,38 @@
+package com.hartwig.bcl2fastq;
+
+import com.google.cloud.storage.Storage;
+import com.hartwig.pipeline.ResultsDirectory;
+import com.hartwig.pipeline.execution.vm.BashStartupScript;
+import com.hartwig.pipeline.execution.vm.ComputeEngine;
+import com.hartwig.pipeline.execution.vm.OutputUpload;
+import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
+import com.hartwig.pipeline.execution.vm.VmDirectories;
+import com.hartwig.pipeline.storage.GoogleStorageLocation;
+import com.hartwig.pipeline.storage.RuntimeBucket;
+
+public class Bcl2Fastq {
+
+    private final Storage storage;
+    private final ComputeEngine computeEngine;
+    private final Arguments arguments;
+    private final ResultsDirectory resultsDirectory;
+
+    Bcl2Fastq(final Storage storage, final ComputeEngine computeEngine, final Arguments arguments,
+            final ResultsDirectory resultsDirectory) {
+        this.storage = storage;
+        this.computeEngine = computeEngine;
+        this.arguments = arguments;
+        this.resultsDirectory = resultsDirectory;
+    }
+
+    public void run() {
+        FlowcellMetadata metadata = FlowcellMetadata.from(arguments);
+        RuntimeBucket bucket = RuntimeBucket.from(storage, "bcl2fastq", metadata, com.hartwig.pipeline.Arguments.defaults("development"));
+        BashStartupScript bash = BashStartupScript.of(bucket.name());
+        BclDownload bclDownload = new BclDownload(arguments.inputBucket(), arguments.flowcell());
+        bash.addCommand(bclDownload)
+                .addCommand(new Bcl2FastqCommand(bclDownload.getLocalTargetPath(), VmDirectories.OUTPUT))
+                .addCommand(new OutputUpload(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path())));
+        computeEngine.submit(bucket, VirtualMachineJobDefinition.bcl2fastq(bash, resultsDirectory));
+    }
+}

--- a/cluster/src/main/java/com/hartwig/bcl2fastq/Bcl2FastqCommand.java
+++ b/cluster/src/main/java/com/hartwig/bcl2fastq/Bcl2FastqCommand.java
@@ -1,0 +1,21 @@
+package com.hartwig.bcl2fastq;
+
+import com.hartwig.pipeline.calling.command.VersionedToolCommand;
+import com.hartwig.pipeline.tools.Versions;
+
+class Bcl2FastqCommand extends VersionedToolCommand {
+
+    Bcl2FastqCommand(final String workingDirectory, final String outputDirectory) {
+        super("bcl2fastq",
+                "bcl2fastq",
+                Versions.BCL2FASTQ,
+                "-R",
+                workingDirectory,
+                "-o",
+                outputDirectory,
+                "--ignore-missing-bcls",
+                "--ignore-missing-filter",
+                "--ignore-missing-positions",
+                "--ignore-missing-controls");
+    }
+}

--- a/cluster/src/main/java/com/hartwig/bcl2fastq/BclDownload.java
+++ b/cluster/src/main/java/com/hartwig/bcl2fastq/BclDownload.java
@@ -1,0 +1,11 @@
+package com.hartwig.bcl2fastq;
+
+import com.hartwig.pipeline.execution.vm.InputDownload;
+import com.hartwig.pipeline.storage.GoogleStorageLocation;
+
+public class BclDownload extends InputDownload {
+
+    public BclDownload(final String bclBucket, final String flowcellIdentifier) {
+        super(GoogleStorageLocation.of(bclBucket, flowcellIdentifier, true));
+    }
+}

--- a/cluster/src/main/java/com/hartwig/bcl2fastq/FlowcellMetadata.java
+++ b/cluster/src/main/java/com/hartwig/bcl2fastq/FlowcellMetadata.java
@@ -1,0 +1,14 @@
+package com.hartwig.bcl2fastq;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface FlowcellMetadata {
+
+    @Value.Parameter
+    String flowcellId();
+
+    static FlowcellMetadata from (Arguments arguments){
+        return ImmutableFlowcellMetadata.of(arguments.flowcell());
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/InputDownload.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/InputDownload.java
@@ -25,7 +25,7 @@ public class InputDownload implements BashCommand {
 
     @Override
     public String asBash() {
-        return format("gsutil -qm cp -n gs://%s/%s%s %s%s",
+        return format("gsutil -qm cp -r -n gs://%s/%s%s %s%s",
                 sourceLocation.bucket(),
                 sourceLocation.path(),
                 sourceLocation.isDirectory() ? "/*" : "",

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
@@ -116,4 +116,13 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
                 .namespacedResults(resultsDirectory)
                 .build();
     }
+
+    static VirtualMachineJobDefinition bcl2fastq(BashStartupScript startupScript, ResultsDirectory resultsDirectory) {
+        return ImmutableVirtualMachineJobDefinition.builder()
+                .name("bcl2fastq")
+                .startupCommand(startupScript)
+                .performanceProfile(VirtualMachinePerformanceProfile.custom(96, 90))
+                .namespacedResults(resultsDirectory)
+                .build();
+    }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/storage/RuntimeBucket.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/storage/RuntimeBucket.java
@@ -10,6 +10,7 @@ import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageClass;
 import com.google.common.collect.Lists;
+import com.hartwig.bcl2fastq.FlowcellMetadata;
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.alignment.Run;
 import com.hartwig.pipeline.metadata.SingleSampleRunMetadata;
@@ -26,6 +27,11 @@ public class RuntimeBucket {
     private final Bucket bucket;
     private final String namespace;
     private final Run run;
+
+    public static RuntimeBucket from(final Storage storage, final String namespace, final FlowcellMetadata flowcellMetadata,
+            final Arguments arguments) {
+        return createBucketIfNeeded(storage, namespace, arguments, Run.from(flowcellMetadata.flowcellId(), arguments));
+    }
 
     public static RuntimeBucket from(final Storage storage, final String namespace, final SingleSampleRunMetadata metadata,
             final Arguments arguments) {
@@ -44,7 +50,7 @@ public class RuntimeBucket {
             final Run run) {
         Bucket bucket = storage.get(run.id());
         if (bucket == null) {
-            LOGGER.debug("Creating runtime bucket [{}] in Google Storage", run.id());
+            LOGGER.info("Creating runtime bucket [{}] in Google Storage", run.id());
             BucketInfo.Builder builder =
                     BucketInfo.newBuilder(run.id()).setStorageClass(StorageClass.REGIONAL).setLocation(arguments.region());
             arguments.cmek().ifPresent(key -> {

--- a/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 
 public interface Versions {
 
+    String BCL2FASTQ = "2.20.0.422";
     String BWA = "0.7.17";
     String SAMBAMBA = "0.6.5";
     String GATK = "3.8.0";

--- a/cluster/src/test/java/com/hartwig/bcl2fastq/Bcl2FastqTest.java
+++ b/cluster/src/test/java/com/hartwig/bcl2fastq/Bcl2FastqTest.java
@@ -1,0 +1,27 @@
+package com.hartwig.bcl2fastq;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Storage;
+import com.hartwig.pipeline.Arguments;
+import com.hartwig.pipeline.ResultsDirectory;
+import com.hartwig.pipeline.credentials.CredentialProvider;
+import com.hartwig.pipeline.execution.vm.ComputeEngine;
+import com.hartwig.pipeline.storage.StorageProvider;
+
+import org.junit.Test;
+
+public class Bcl2FastqTest {
+
+    @Test
+    public void runsBcl2Fastq() throws Exception {
+        Arguments arguments = Arguments.defaults("development");
+        GoogleCredentials credentials = CredentialProvider.from(arguments).get();
+        Storage storage = StorageProvider.from(arguments, credentials).get();
+        Bcl2Fastq victim = new Bcl2Fastq(storage,
+                ComputeEngine.from(arguments, credentials),
+                com.hartwig.bcl2fastq.Arguments.builder().flowcell("tiny").inputBucket("bcl-input").build(),
+                ResultsDirectory.defaultDirectory());
+        victim.run();
+    }
+
+}


### PR DESCRIPTION
First pass, new application which runs bcl2fastq. Functionally it does
the following:
- Copy down the bcl file by the flowcell id
- Run bcl2fastq
- Copy all fastq back to a runtime bucket for the flowcell

In the future it'll have to distribute the different patients to their
respective runtime buckets.

Some awkward reuse of arguments, in the end we'll either have to
continue with a monilith argument class or extract the common ones into
a shared interface. Probably a few things we'll want to make more
shareable package-wise (or maybe separate modules).