### PR TITLE
DEV-859 Use different disk sizes for different clusters

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/execution/MachineType.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/MachineType.java
@@ -8,12 +8,18 @@ public interface MachineType {
     String GOOGLE_STANDARD_16 = "n1-standard-16";
     String GOOGLE_STANDARD_32 = "n1-standard-32";
     String GOOGLE_HIGHMEM_32 = "n1-highmem-32";
+    int DEFAULT_DISK_SIZE = 500;
 
     String uri();
 
     int memoryGB();
 
     int cpus();
+
+    @Value.Default
+    default int diskSizeGB(){
+        return DEFAULT_DISK_SIZE;
+    }
 
     static MachineType defaultVm() {
         return ImmutableMachineType.builder().uri(GOOGLE_STANDARD_32).memoryGB(120).cpus(32).build();
@@ -24,7 +30,7 @@ public interface MachineType {
     }
 
     static MachineType highMemoryWorker() {
-        return ImmutableMachineType.builder().uri(GOOGLE_HIGHMEM_32).memoryGB(208).cpus(32).build();
+        return ImmutableMachineType.builder().uri(GOOGLE_HIGHMEM_32).memoryGB(208).cpus(32).diskSizeGB(250).build();
     }
 
     static MachineType defaultPreemtibleWorker() {
@@ -32,7 +38,7 @@ public interface MachineType {
     }
 
     static MachineType defaultMaster() {
-        return ImmutableMachineType.builder().uri(GOOGLE_STANDARD_16).memoryGB(60).cpus(16).build();
+        return ImmutableMachineType.builder().uri(GOOGLE_STANDARD_16).memoryGB(60).cpus(16).diskSizeGB(1000).build();
     }
 
     static ImmutableMachineType.Builder builder() {

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/dataproc/GoogleClusterConfig.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/dataproc/GoogleClusterConfig.java
@@ -38,7 +38,7 @@ class GoogleClusterConfig {
 
     static GoogleClusterConfig from(RuntimeBucket runtimeBucket, NodeInitialization nodeInitialization, DataprocPerformanceProfile profile,
             final Arguments arguments) throws FileNotFoundException {
-        DiskConfig diskConfig = diskConfig();
+        DiskConfig diskConfig = diskConfig(profile.primaryWorkers());
         ClusterConfig config = clusterConfig(masterConfig(profile.master()),
                 primaryWorkerConfig(diskConfig, profile.primaryWorkers(), profile.numPrimaryWorkers()),
                 secondaryWorkerConfig(profile, diskConfig, profile.preemtibleWorkers()),
@@ -85,7 +85,7 @@ class GoogleClusterConfig {
     }
 
     private static InstanceGroupConfig masterConfig(final MachineType machineType) {
-        return new InstanceGroupConfig().setMachineTypeUri(machineType.uri()).setNumInstances(1).setDiskConfig(diskConfig());
+        return new InstanceGroupConfig().setMachineTypeUri(machineType.uri()).setNumInstances(1).setDiskConfig(diskConfig(machineType));
     }
 
     private static ClusterConfig clusterConfig(final InstanceGroupConfig masterConfig, final InstanceGroupConfig primaryWorkerConfig,
@@ -108,8 +108,8 @@ class GoogleClusterConfig {
     }
 
     @NotNull
-    private static DiskConfig diskConfig() {
-        return new DiskConfig().setBootDiskType("pd-ssd").setBootDiskSizeGb(DISK_SIZE_GB).setNumLocalSsds(2);
+    private static DiskConfig diskConfig(MachineType machineType) {
+        return new DiskConfig().setBootDiskType("pd-ssd").setBootDiskSizeGb(machineType.diskSizeGB()).setNumLocalSsds(2);
     }
 
     private static InstanceGroupConfig secondaryWorkerConfig(final DataprocPerformanceProfile profile, final DiskConfig diskConfig,


### PR DESCRIPTION
Added disk size to the machine type to allow for different workloads to
declare a different PD disk size. Gunzip uses the default of 500, bam
creation 250 and sort and index 1000. Sort and index will likely be
removed eventually.