### PR TITLE
DEV-873 Wait for single sample results when staging final pipeline

### DIFF
--- a/cluster/src/test/java/com/hartwig/pipeline/report/FullSomaticResultsTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/report/FullSomaticResultsTest.java
@@ -1,0 +1,86 @@
+package com.hartwig.pipeline.report;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.gax.paging.Page;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.CopyWriter;
+import com.google.cloud.storage.Storage;
+import com.hartwig.pipeline.Arguments;
+import com.hartwig.pipeline.testsupport.TestBlobs;
+import com.hartwig.pipeline.testsupport.TestInputs;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class FullSomaticResultsTest {
+
+    private static final String OUTPUT_BUCKET = "output-bucket";
+    private Storage storage;
+    private FullSomaticResults victim;
+    private Bucket outputBucket;
+
+    @Before
+    public void setUp() throws Exception {
+        storage = mock(Storage.class);
+        Arguments arguments = Arguments.testDefaultsBuilder().patientReportBucket(OUTPUT_BUCKET).build();
+        victim = new FullSomaticResults(storage, arguments, 1);
+        outputBucket = mock(Bucket.class);
+        when(storage.get(OUTPUT_BUCKET)).thenReturn(outputBucket);
+    }
+
+    @Test
+    public void copiesSingleSampleReferenceAndTumorBucketIntoSomatic() {
+
+        Blob reference = returnSampleFromBucket(outputBucket, "reference");
+        Blob tumor = returnSampleFromBucket(outputBucket, "tumor");
+
+        ArgumentCaptor<Storage.CopyRequest> copyRequestArgumentCaptor = ArgumentCaptor.forClass(Storage.CopyRequest.class);
+        final CopyWriter copyWriter = mock(CopyWriter.class);
+        when(copyWriter.getResult()).thenReturn(reference).thenReturn(tumor);
+        when(storage.copy(copyRequestArgumentCaptor.capture())).thenReturn(copyWriter);
+
+        victim.compose(TestInputs.defaultSomaticRunMetadata());
+
+        assertThat(copyRequestArgumentCaptor.getAllValues().get(0).getSource().getName()).isEqualTo("reference/reference/output.txt");
+        assertThat(copyRequestArgumentCaptor.getAllValues().get(0).getTarget().getName()).isEqualTo("run/reference/output.txt");
+
+        assertThat(copyRequestArgumentCaptor.getAllValues().get(1).getSource().getName()).isEqualTo("tumor/tumor/output.txt");
+        assertThat(copyRequestArgumentCaptor.getAllValues().get(1).getTarget().getName()).isEqualTo("run/tumor/output.txt");
+    }
+
+    @Test
+    public void waitsForSampleInMetadataIfNotExists() {
+        Blob reference = returnSampleOnSecondAttempt(outputBucket, "reference");
+        Blob tumor = returnSampleOnSecondAttempt(outputBucket, "tumor");
+        ArgumentCaptor<Storage.CopyRequest> copyRequestArgumentCaptor = ArgumentCaptor.forClass(Storage.CopyRequest.class);
+        final CopyWriter copyWriter = mock(CopyWriter.class);
+        when(copyWriter.getResult()).thenReturn(reference).thenReturn(tumor);
+        when(storage.copy(copyRequestArgumentCaptor.capture())).thenReturn(copyWriter);
+        victim.compose(TestInputs.defaultSomaticRunMetadata());
+        verify(outputBucket, times(4)).list(any());
+    }
+
+    private static Blob returnSampleOnSecondAttempt(final Bucket outputBucket, final String sample) {
+        Blob blob = TestBlobs.blob(sample + "/" + sample + "/output.txt");
+        Page<Blob> page = TestBlobs.pageOf(blob);
+        Page<Blob> empty = TestBlobs.pageOf();
+        when(outputBucket.list(Storage.BlobListOption.prefix(sample))).thenReturn(empty).thenReturn(page);
+        return blob;
+    }
+
+    private static Blob returnSampleFromBucket(final Bucket outputBucket, final String sample) {
+        Blob blob = TestBlobs.blob(sample + "/" + sample + "/output.txt");
+        Page<Blob> page = TestBlobs.pageOf(blob);
+        when(outputBucket.list(Storage.BlobListOption.prefix(sample))).thenReturn(page);
+        return blob;
+    }
+
+}


### PR DESCRIPTION
Adds an infinite retry when composing the full somatic results for both
the reference and tumor pipeline outputs. Infinite because it can be
hours later and we should detect any hanging samples elsewhere.

Also removes the deletion of the single sample staging buckets. This
will allow for reuse of the same single sample run in multiple sets,even
if the other sets have not run yet. Although we will have to find a way
to clean these up in release 5.2.