### PR TITLE
DEV-885 Skeleton of merging and mark duping

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/AlignerProvider.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/AlignerProvider.java
@@ -28,7 +28,7 @@ import com.hartwig.support.hadoop.Hadoop;
 
 public abstract class AlignerProvider {
 
-    private static final int PERFECT_RATIO = 4;
+    private static final int PERFECT_RATIO = 2;
     private final GoogleCredentials credentials;
     private final Storage storage;
     private final Arguments arguments;

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/AlignmentOutputPaths.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/AlignmentOutputPaths.java
@@ -8,7 +8,7 @@ public class AlignmentOutputPaths {
         return format("%s.bam", name);
     }
 
-    static String sorted(String sample) {
+    public static String sorted(String sample) {
         return bam(format("%s.sorted", sample));
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/merge/IndexedBamLocation.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/merge/IndexedBamLocation.java
@@ -1,0 +1,13 @@
+package com.hartwig.pipeline.alignment.merge;
+
+import com.hartwig.pipeline.storage.GoogleStorageLocation;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface IndexedBamLocation {
+
+    GoogleStorageLocation bam();
+
+    GoogleStorageLocation bai();
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/merge/MergeAndMarkDups.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/merge/MergeAndMarkDups.java
@@ -1,0 +1,81 @@
+package com.hartwig.pipeline.alignment.merge;
+
+import static com.hartwig.pipeline.alignment.AlignmentOutputPaths.bai;
+import static com.hartwig.pipeline.alignment.AlignmentOutputPaths.bam;
+import static com.hartwig.pipeline.alignment.AlignmentOutputPaths.sorted;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.google.cloud.storage.Storage;
+import com.hartwig.pipeline.Arguments;
+import com.hartwig.pipeline.ResultsDirectory;
+import com.hartwig.pipeline.alignment.Aligner;
+import com.hartwig.pipeline.alignment.AlignmentOutput;
+import com.hartwig.pipeline.alignment.AlignmentOutputPaths;
+import com.hartwig.pipeline.execution.PipelineStatus;
+import com.hartwig.pipeline.execution.vm.BashStartupScript;
+import com.hartwig.pipeline.execution.vm.ComputeEngine;
+import com.hartwig.pipeline.execution.vm.InputDownload;
+import com.hartwig.pipeline.execution.vm.OutputUpload;
+import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
+import com.hartwig.pipeline.metadata.SingleSampleRunMetadata;
+import com.hartwig.pipeline.report.Folder;
+import com.hartwig.pipeline.report.SingleFileComponent;
+import com.hartwig.pipeline.storage.GoogleStorageLocation;
+import com.hartwig.pipeline.storage.RuntimeBucket;
+
+public class MergeAndMarkDups {
+
+    private final ComputeEngine computeEngine;
+    private final ResultsDirectory resultsDirectory;
+    private final Storage storage;
+    private final Arguments arguments;
+
+    public MergeAndMarkDups(final ComputeEngine computeEngine, final ResultsDirectory resultsDirectory, final Storage storage,
+            final Arguments arguments) {
+        this.computeEngine = computeEngine;
+        this.resultsDirectory = resultsDirectory;
+        this.storage = storage;
+        this.arguments = arguments;
+    }
+
+    public AlignmentOutput run(SingleSampleRunMetadata metadata, PerLaneAlignmentOutput alignmentOutput) {
+        RuntimeBucket bucket = RuntimeBucket.from(storage, Aligner.NAMESPACE, metadata, arguments);
+        List<InputDownload> laneBams = alignmentOutput.bams()
+                .stream()
+                .flatMap(indexedBamLocation -> Stream.of(new InputDownload(indexedBamLocation.bam()),
+                        new InputDownload(indexedBamLocation.bai())))
+                .collect(Collectors.toList());
+        BashStartupScript bash = BashStartupScript.of(bucket.name());
+        laneBams.forEach(bash::addCommand);
+
+        String outputBamPath = AlignmentOutputPaths.sorted(metadata.sampleName());
+        GoogleStorageLocation outputBamLocation = GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(outputBamPath));
+
+        bash.addCommand(new SambambaMarkdupsCommand(laneBams.stream().map(InputDownload::getLocalTargetPath).collect(Collectors.toList()),
+                outputBamPath)).addCommand(new OutputUpload(outputBamLocation));
+
+        PipelineStatus status = computeEngine.submit(bucket, VirtualMachineJobDefinition.mergeMarkdups(bash, resultsDirectory));
+
+        return AlignmentOutput.builder()
+                .status(status)
+                .maybeFinalBamLocation(outputBamLocation)
+                .maybeFinalBaiLocation(GoogleStorageLocation.of(bucket.name(),
+                        resultsDirectory.path(AlignmentOutputPaths.bai(outputBamPath))))
+                .addReportComponents(new SingleFileComponent(bucket,
+                                Aligner.NAMESPACE,
+                                Folder.from(metadata),
+                                sorted(metadata.sampleName()),
+                                bam(metadata.sampleName()),
+                                resultsDirectory),
+                        new SingleFileComponent(bucket,
+                                Aligner.NAMESPACE,
+                                Folder.from(metadata),
+                                bai(sorted(metadata.sampleName())),
+                                bai(bam(metadata.sampleName())),
+                                resultsDirectory))
+                .build();
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/merge/PerLaneAlignmentOutput.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/merge/PerLaneAlignmentOutput.java
@@ -1,0 +1,8 @@
+package com.hartwig.pipeline.alignment.merge;
+
+import java.util.List;
+
+public interface PerLaneAlignmentOutput {
+
+    List<IndexedBamLocation> bams();
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/merge/SambambaMarkdupsCommand.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/merge/SambambaMarkdupsCommand.java
@@ -1,0 +1,25 @@
+package com.hartwig.pipeline.alignment.merge;
+
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import com.hartwig.pipeline.calling.command.VersionedToolCommand;
+import com.hartwig.pipeline.execution.vm.Bash;
+import com.hartwig.pipeline.tools.Versions;
+
+import org.jetbrains.annotations.NotNull;
+
+class SambambaMarkdupsCommand extends VersionedToolCommand {
+
+    SambambaMarkdupsCommand(final List<String> inputBamPaths, final String outputBamPath) {
+        super("sambamba", "sambamba", Versions.SAMBAMBA, arguments(inputBamPaths, outputBamPath));
+    }
+
+    @NotNull
+    private static String[] arguments(final List<String> inputBamPaths, final String outputBamPath) {
+        List<String> arguments = Lists.newArrayList("-t", Bash.allCpus(), "--overflow-list-size=15000000");
+        arguments.addAll(inputBamPaths);
+        arguments.add(outputBamPath);
+        return arguments.toArray(new String[arguments.size()]);
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/dataproc/ClusterOptimizer.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/dataproc/ClusterOptimizer.java
@@ -26,7 +26,7 @@ public class ClusterOptimizer {
         double totalCpusRequired = totalFileSizeGB * cpuToFastQSizeRatio.cpusPerGB();
         MachineType defaultWorker = MachineType.defaultWorker();
         int numWorkers = new Double(totalCpusRequired / defaultWorker.cpus()).intValue();
-        int numPreemptible = usePreemtibleVms ? numWorkers / 2 : 0;
+        int numPreemptible = usePreemtibleVms ? numWorkers - 2 : 0;
         return DataprocPerformanceProfile.builder()
                 .master(MachineType.defaultMaster())
                 .primaryWorkers(defaultWorker)

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
@@ -116,4 +116,13 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
                 .namespacedResults(resultsDirectory)
                 .build();
     }
+
+    static VirtualMachineJobDefinition mergeMarkdups(BashStartupScript startupScript, ResultsDirectory resultsDirectory) {
+        return ImmutableVirtualMachineJobDefinition.builder()
+                .name("merge-markdups")
+                .startupCommand(startupScript)
+                .performanceProfile(VirtualMachinePerformanceProfile.custom(4, 32))
+                .namespacedResults(resultsDirectory)
+                .build();
+    }
 }


### PR DESCRIPTION
For feedback and input to the alignment phase.

Defines a simple stage which takes a list of indexed/sorted bams as
input, downloads them locally, runs sambamba markdups and returns the
final sorted bam.

Likely this code will be just merged into the the alignment pipeline.