### PR TITLE
DEV-892 Remove all files except status files before bam creation

### DIFF
--- a/bam/src/main/java/com/hartwig/bam/BamCreationPipeline.java
+++ b/bam/src/main/java/com/hartwig/bam/BamCreationPipeline.java
@@ -19,6 +19,7 @@ public abstract class BamCreationPipeline {
 
     public void execute(final Sample sample) {
         LOGGER.info("ADAM BAM creation started for sample [{}]", sample.name());
+        finalBamStore().clear();
         StatusReporter.Status status = StatusReporter.Status.SUCCESS;
         try {
             InputOutput<AlignmentRecordDataset> aligned = executeAndCache(InputOutput.seed(sample), alignment());

--- a/bam/src/main/java/com/hartwig/bam/adam/HDFSBamStore.java
+++ b/bam/src/main/java/com/hartwig/bam/adam/HDFSBamStore.java
@@ -57,11 +57,12 @@ public class HDFSBamStore implements OutputStore<AlignmentRecordDataset> {
     @Override
     public void clear() {
         try {
-            for (FileStatus fileStatus : fileSystem.listStatus(new Path(dataLocation.rootUri()))) {
-                if (!fileStatus.getPath().getName().endsWith(StatusReporter.SUCCESS) && !fileStatus.getPath()
-                        .getName()
-                        .endsWith(StatusReporter.FAILURE)) {
-                    fileSystem.delete(fileStatus.getPath(), true);
+            Path rootPath = new Path(dataLocation.rootUri());
+            if (fileSystem.exists(rootPath)) {
+                for (FileStatus fileStatus : fileSystem.listStatus(rootPath)) {
+                    if (!fileStatus.getPath().getName().endsWith(StatusReporter.SUCCESS) && !fileStatus.getPath().getName().endsWith(StatusReporter.FAILURE)) {
+                        fileSystem.delete(fileStatus.getPath(), true);
+                    }
                 }
             }
         } catch (IOException e) {

--- a/bam/src/main/java/com/hartwig/bam/adam/HDFSBamStore.java
+++ b/bam/src/main/java/com/hartwig/bam/adam/HDFSBamStore.java
@@ -2,11 +2,13 @@ package com.hartwig.bam.adam;
 
 import java.io.IOException;
 
+import com.hartwig.bam.StatusReporter;
 import com.hartwig.io.DataLocation;
 import com.hartwig.io.InputOutput;
 import com.hartwig.io.OutputStore;
 import com.hartwig.patient.Sample;
 
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
@@ -38,13 +40,7 @@ public class HDFSBamStore implements OutputStore<AlignmentRecordDataset> {
     public void store(final InputOutput<AlignmentRecordDataset> inputOutput, String suffix) {
         String storageUri = dataLocation.uri(inputOutput.sample(), suffix);
         LOGGER.info("persisting to... {}", storageUri);
-        JavaSaveArgs saveArgs = new JavaSaveArgs(storageUri,
-                128 * 1024 * 1024,
-                1024 * 1024,
-                CompressionCodecName.GZIP,
-                false,
-                true,
-                false);
+        JavaSaveArgs saveArgs = new JavaSaveArgs(storageUri, 128 * 1024 * 1024, 1024 * 1024, CompressionCodecName.GZIP, false, true, false);
         saveArgs.deferMerging_$eq(!mergeFinalFile);
         inputOutput.payload().save(saveArgs, true);
     }
@@ -61,7 +57,13 @@ public class HDFSBamStore implements OutputStore<AlignmentRecordDataset> {
     @Override
     public void clear() {
         try {
-            fileSystem.delete(new Path(dataLocation.rootUri()), true);
+            for (FileStatus fileStatus : fileSystem.listStatus(new Path(dataLocation.rootUri()))) {
+                if (!fileStatus.getPath().getName().endsWith(StatusReporter.SUCCESS) && !fileStatus.getPath()
+                        .getName()
+                        .endsWith(StatusReporter.FAILURE)) {
+                    fileSystem.delete(fileStatus.getPath(), true);
+                }
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/bam/src/test/java/com/hartwig/bam/adam/HDFSBamStoreTest.java
+++ b/bam/src/test/java/com/hartwig/bam/adam/HDFSBamStoreTest.java
@@ -11,11 +11,13 @@ import com.hartwig.support.hadoop.Hadoop;
 import com.hartwig.testsupport.TestConfigurations;
 import com.hartwig.testsupport.TestRDDs;
 
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.bdgenomics.adam.rdd.read.AlignmentRecordDataset;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.Test;
 
 public class HDFSBamStoreTest {
@@ -23,6 +25,17 @@ public class HDFSBamStoreTest {
     private static final JavaSparkContext SPARK_CONTEXT =
             SparkContexts.create("hdfs-bam-store-test", TestConfigurations.HUNDREDK_READS_HISEQ);
     private static final Sample SAMPLE = Sample.builder("", "test").build();
+    private static final String RESULTS_PATH = System.getProperty("user.dir") + "/results/";
+    private FinalDataLocation dataLocation;
+    private FileSystem fileSystem;
+    private OutputStore<AlignmentRecordDataset> victim;
+
+    @Before
+    public void setUp() throws Exception {
+        fileSystem = Hadoop.localFilesystem();
+        dataLocation = new FinalDataLocation(fileSystem, RESULTS_PATH);
+        victim = new HDFSBamStore(dataLocation, fileSystem, true);
+    }
 
     @AfterClass
     public static void afterClass() {
@@ -31,11 +44,20 @@ public class HDFSBamStoreTest {
 
     @Test
     public void savesBamAndChecksIfItExists() throws Exception {
-        FileSystem fileSystem = Hadoop.localFilesystem();
-        FinalDataLocation dataLocation = new FinalDataLocation(fileSystem, System.getProperty("user.dir") + "/results/");
-        OutputStore<AlignmentRecordDataset> victim = new HDFSBamStore(dataLocation, fileSystem, true);
         victim.store(InputOutput.of(SAMPLE, TestRDDs.alignmentRecordDataset("qc/CPCT12345678R.bam", SPARK_CONTEXT)));
         assertThat(victim.exists(SAMPLE)).isTrue();
         fileSystem.delete(new Path(dataLocation.uri(SAMPLE, "")), true);
+    }
+
+    @Test
+    public void clearsEverythingInStoreExceptStatusFiles() throws Exception{
+        fileSystem.create(new Path(RESULTS_PATH + "/file1.txt"));
+        fileSystem.create(new Path(RESULTS_PATH + "/Gunzip_SUCCESS"));
+        fileSystem.create(new Path(RESULTS_PATH + "/BamCreation_FAILURE"));
+        victim.clear();
+
+        FileStatus[] fileStatuses = fileSystem.listStatus(new Path(RESULTS_PATH));
+        assertThat(fileStatuses).hasSize(2);
+        fileSystem.delete(new Path(RESULTS_PATH), true);
     }
 }

--- a/bam/src/test/java/com/hartwig/bam/adam/HDFSBamStoreTest.java
+++ b/bam/src/test/java/com/hartwig/bam/adam/HDFSBamStoreTest.java
@@ -2,6 +2,8 @@ package com.hartwig.bam.adam;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
+
 import com.hartwig.bam.runtime.spark.SparkContexts;
 import com.hartwig.io.FinalDataLocation;
 import com.hartwig.io.InputOutput;
@@ -50,7 +52,8 @@ public class HDFSBamStoreTest {
     }
 
     @Test
-    public void clearsEverythingInStoreExceptStatusFiles() throws Exception{
+    public void clearsEverythingInStoreExceptStatusFiles() throws Exception {
+        deleteAll();
         fileSystem.create(new Path(RESULTS_PATH + "/file1.txt"));
         fileSystem.create(new Path(RESULTS_PATH + "/Gunzip_SUCCESS"));
         fileSystem.create(new Path(RESULTS_PATH + "/BamCreation_FAILURE"));
@@ -58,6 +61,12 @@ public class HDFSBamStoreTest {
 
         FileStatus[] fileStatuses = fileSystem.listStatus(new Path(RESULTS_PATH));
         assertThat(fileStatuses).hasSize(2);
-        fileSystem.delete(new Path(RESULTS_PATH), true);
+        deleteAll();
+    }
+
+    private void deleteAll() throws IOException {
+        for (FileStatus fileStatus : fileSystem.listStatus(new Path(RESULTS_PATH))) {
+            fileSystem.delete(fileStatus.getPath(), true);
+        }
     }
 }


### PR DESCRIPTION
Removes all files not suffixed with _SUCCESS or _FAILURE before starting
the bam creation.