### PR TITLE
DEV-865: Upgrade GRIDSS to 2.5.1

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/calling/structural/gridss/command/GridssCommand.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/structural/gridss/command/GridssCommand.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 import com.hartwig.pipeline.execution.vm.BashCommand;
 import com.hartwig.pipeline.execution.vm.JavaClassCommand;
+import com.hartwig.pipeline.tools.Versions;
 
 public abstract class GridssCommand implements BashCommand {
     int memoryGb() {
@@ -32,6 +33,7 @@ public abstract class GridssCommand implements BashCommand {
                 "-Dsamjdk.buffer_size=4194304");
 
         String gridssArgs = arguments().stream().map(GridssArgument::asBash).collect(Collectors.joining(" "));
-        return new JavaClassCommand("gridss", "2.4.0", "gridss.jar", className(), format("%dG", memoryGb()), jvmArgs, gridssArgs).asBash();
+        return new JavaClassCommand("gridss", Versions.GRIDSS, "gridss.jar", className(),
+                format("%dG", memoryGb()), jvmArgs, gridssArgs).asBash();
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
@@ -24,7 +24,7 @@ public interface Versions {
     String HEALTH_CHECKER = "3.1";
     String PURPLE = "2.33";
     String CIRCOS = "0.69.6";
-    String GRIDSS = "2.4.0";
+    String GRIDSS = "2.5.1";
 
     static void printAll() {
         Logger logger = LoggerFactory.getLogger(Versions.class);

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/structural/gridss/command/AnnotateUntemplatedSequenceTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/structural/gridss/command/AnnotateUntemplatedSequenceTest.java
@@ -22,6 +22,11 @@ public class AnnotateUntemplatedSequenceTest implements CommonEntities {
     }
 
     @Test
+    public void shouldGenerateCorrectJavaArguments() {
+        GridssCommonArgumentsAssert.assertThat(command).generatesJavaInvocationUpToAndIncludingClassname(className);
+    }
+
+    @Test
     public void shouldReturnClassName() {
         assertThat(command.className()).isEqualTo(className);
     }

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/structural/gridss/command/AnnotateVariantsTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/structural/gridss/command/AnnotateVariantsTest.java
@@ -14,6 +14,7 @@ public class AnnotateVariantsTest implements CommonEntities {
     private String inputVcf;
     private String configurationFile;
     private String blacklist;
+    private String className;
     private String outputVcf;
 
     @Before
@@ -23,12 +24,18 @@ public class AnnotateVariantsTest implements CommonEntities {
         blacklist = "/the/blacklist";
         inputVcf = "input.vcf";
         outputVcf = "/some/path/output_file.vcf";
+        className = "gridss.AnnotateVariants";
         command = new AnnotateVariants(REFERENCE_BAM, TUMOR_BAM, assemblyBam, inputVcf, REFERENCE_GENOME, outputVcf, configurationFile, blacklist);
     }
 
     @Test
+    public void shouldGenerateCorrectJavaArguments() {
+        GridssCommonArgumentsAssert.assertThat(command).generatesJavaInvocationUpToAndIncludingClassname(className);
+    }
+
+    @Test
     public void shouldReturnClassname() {
-        assertThat(command.className()).isEqualTo("gridss.AnnotateVariants");
+        assertThat(command.className()).isEqualTo(className);
     }
 
     @Test

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/structural/gridss/command/AssembleBreakendsTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/structural/gridss/command/AssembleBreakendsTest.java
@@ -12,19 +12,26 @@ public class AssembleBreakendsTest implements CommonEntities {
     private String configurationFile;
     private String blacklist;
     private String assemblyBam;
+    private String className;
 
     @Before
     public void setup() {
         configurationFile = "/some/path/config.properties";
         blacklist = "/blacklist.bed";
         assemblyBam = "/some/path/to/output.bam";
+        className = "gridss.AssembleBreakends";
         command = new AssembleBreakends(REFERENCE_BAM, TUMOR_BAM, assemblyBam, REFERENCE_GENOME,
                 configurationFile, blacklist);
     }
 
     @Test
+    public void shouldGenerateCorrectJavaArguments() {
+        GridssCommonArgumentsAssert.assertThat(command).generatesJavaInvocationUpToAndIncludingClassname(className);
+    }
+
+    @Test
     public void shouldReturnClassName() {
-        assertThat(command.className()).isEqualTo("gridss.AssembleBreakends");
+        assertThat(command.className()).isEqualTo(className);
     }
 
     @Test

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/structural/gridss/command/AssembleSoftClipsToSplitReadsTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/structural/gridss/command/AssembleSoftClipsToSplitReadsTest.java
@@ -1,10 +1,11 @@
 package com.hartwig.pipeline.calling.structural.gridss.command;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.hartwig.pipeline.calling.structural.gridss.CommonEntities;
+
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class AssembleSoftClipsToSplitReadsTest implements CommonEntities {
     private String className;
@@ -14,6 +15,11 @@ public class AssembleSoftClipsToSplitReadsTest implements CommonEntities {
     public void setup() {
         className = "gridss.SoftClipsToSplitReads";
         command = new SoftClipsToSplitReads.ForAssemble(REFERENCE_BAM, REFERENCE_GENOME, OUTPUT_BAM);
+    }
+
+    @Test
+    public void shouldGenerateCorrectJavaArguments() {
+        GridssCommonArgumentsAssert.assertThat(command).generatesJavaInvocationUpToAndIncludingClassname(className);
     }
 
     @Test

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/structural/gridss/command/CollectGridssMetricsTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/structural/gridss/command/CollectGridssMetricsTest.java
@@ -12,21 +12,26 @@ public class CollectGridssMetricsTest implements CommonEntities {
     private String inputBamBasename;
     private String inputBamFullPath;
     private String outputMetricsFilepathPrefix;
-    private String fullOutputMetricsFilepathPrefix;
+    private String className;
 
     @Before
     public void setup() {
         inputBamBasename = "input-file.bam";
         inputBamFullPath = "/full/path/to/" + inputBamBasename;
         outputMetricsFilepathPrefix = "/path/to/metrics/base.name";
-//        fullOutputMetricsFilepathPrefix = format("%s/%s", outputMetricsFilepathPrefix, inputBamBasename);
+        className = "gridss.analysis.CollectGridssMetrics";
         command = new CollectGridssMetrics(inputBamFullPath, outputMetricsFilepathPrefix);
 
     }
 
     @Test
+    public void shouldGenerateCorrectJavaArguments() {
+        GridssCommonArgumentsAssert.assertThat(command).generatesJavaInvocationUpToAndIncludingClassname(className);
+    }
+
+    @Test
     public void shouldReturnClassName() {
-        assertThat(command.className()).isEqualTo("gridss.analysis.CollectGridssMetrics");
+        assertThat(command.className()).isEqualTo(className);
     }
 
     @Test

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/structural/gridss/command/ComputeSamTagsTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/structural/gridss/command/ComputeSamTagsTest.java
@@ -1,26 +1,34 @@
 package com.hartwig.pipeline.calling.structural.gridss.command;
 
+import static java.lang.String.format;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.hartwig.pipeline.calling.structural.gridss.CommonEntities;
+
 import org.junit.Before;
 import org.junit.Test;
 
-import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class ComputeSamTagsTest implements CommonEntities {
     private ComputeSamTags command;
-    private final String CLASSNAME = "gridss.ComputeSamTags";
+    private String className;
     private String expectedOutputFile;
 
     @Before
     public void setup() {
         command = new ComputeSamTags(REFERENCE_BAM, REFERENCE_GENOME, REFERENCE_SAMPLE);
+        className = "gridss.ComputeSamTags";
         expectedOutputFile = format("%s/gridss.tmp.withtags.%s.sv.bam", OUT_DIR, REFERENCE_SAMPLE);
     }
 
     @Test
+    public void shouldGenerateCorrectJavaArguments() {
+        GridssCommonArgumentsAssert.assertThat(command).generatesJavaInvocationUpToAndIncludingClassname(className);
+    }
+
+    @Test
     public void shouldReturnClassname() {
-        assertThat(command.className()).isEqualTo(CLASSNAME);
+        assertThat(command.className()).isEqualTo(className);
     }
 
     @Test

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/structural/gridss/command/ExtractSvReadsTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/structural/gridss/command/ExtractSvReadsTest.java
@@ -15,6 +15,7 @@ public class ExtractSvReadsTest implements CommonEntities {
     private String inputFile;
     private String insertSizeMetrics;
     private ExtractSvReads command;
+    private String className;
 
     @Before
     public void setup() {
@@ -22,13 +23,19 @@ public class ExtractSvReadsTest implements CommonEntities {
         insertSizeMetrics = "insertSizeMetrics";
         String workingDir = format("%s/%s.gridss.working/", VmDirectories.OUTPUT, REFERENCE_SAMPLE);
         metricsOut = format("%s/%s.sv_metrics", workingDir, REFERENCE_SAMPLE);
+        className = "gridss.ExtractSVReads";
 
         command = new ExtractSvReads(inputFile, REFERENCE_SAMPLE, insertSizeMetrics, workingDir);
     }
 
     @Test
+    public void shouldGenerateCorrectJavaArguments() {
+        GridssCommonArgumentsAssert.assertThat(command).generatesJavaInvocationUpToAndIncludingClassname(className);
+    }
+
+    @Test
     public void shouldReturnClassName() {
-        assertThat(command.className()).isEqualTo("gridss.ExtractSVReads");
+        assertThat(command.className()).isEqualTo(className);
     }
 
     @Test

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/structural/gridss/command/GridssCommonArgumentsAssert.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/structural/gridss/command/GridssCommonArgumentsAssert.java
@@ -117,8 +117,10 @@ public class GridssCommonArgumentsAssert extends AbstractAssert<GridssCommonArgu
             }
         }
 
-        if (!actualJvmProperties.trim().endsWith("-cp /data/tools/gridss/2.4.0/gridss.jar")) {
-            failWithMessage("Did not find classpath entry for GRIDSS JAR in invocation: " + invocation);
+        String classpathTokens = "-cp /data/tools/gridss/2.5.1/gridss.jar";
+        if (!actualJvmProperties.trim().endsWith(classpathTokens)) {
+            failWithMessage(format("Did not find classpath entry \"%s\" for GRIDSS JAR in invocation: %s",
+                    classpathTokens, invocation));
         }
 
         return this;

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/structural/gridss/command/IdentifyVariantsTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/structural/gridss/command/IdentifyVariantsTest.java
@@ -15,6 +15,7 @@ public class IdentifyVariantsTest implements CommonEntities {
     private String outputVcf;
     private String configurationFile;
     private String blacklist;
+    private String className;
 
     @Before
     public void setup() {
@@ -22,12 +23,18 @@ public class IdentifyVariantsTest implements CommonEntities {
         configurationFile = "/config.properties";
         blacklist = "/path/to/blacklist.bed";
         outputVcf =  format("%s/sv_calling.vcf", OUT_DIR);
+        className = "gridss.IdentifyVariants";
         command = new IdentifyVariants(REFERENCE_BAM, TUMOR_BAM, assemblyBam, outputVcf, REFERENCE_GENOME, configurationFile, blacklist);
     }
 
     @Test
+    public void shouldGenerateCorrectJavaArguments() {
+        GridssCommonArgumentsAssert.assertThat(command).generatesJavaInvocationUpToAndIncludingClassname(className);
+    }
+
+    @Test
     public void shouldReturnClassName() {
-        assertThat(command.className()).isEqualTo("gridss.IdentifyVariants");
+        assertThat(command.className()).isEqualTo(className);
     }
 
     @Test

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/structural/gridss/command/PreProcessSoftClipsToSplitReadsTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/structural/gridss/command/PreProcessSoftClipsToSplitReadsTest.java
@@ -1,22 +1,30 @@
 package com.hartwig.pipeline.calling.structural.gridss.command;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.hartwig.pipeline.calling.structural.gridss.CommonEntities;
+
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class PreProcessSoftClipsToSplitReadsTest implements CommonEntities {
     private SoftClipsToSplitReads.ForPreprocess command;
+    private String className;
 
     @Before
     public void setup() {
         command = new SoftClipsToSplitReads.ForPreprocess(TUMOR_BAM, REFERENCE_GENOME, OUTPUT_BAM);
+        className = "gridss.SoftClipsToSplitReads";
+    }
+
+    @Test
+    public void shouldGenerateCorrectJavaArguments() {
+        GridssCommonArgumentsAssert.assertThat(command).generatesJavaInvocationUpToAndIncludingClassname(className);
     }
 
     @Test
     public void shouldReturnClassName() {
-        assertThat(command.className()).isEqualTo("gridss.SoftClipsToSplitReads");
+        assertThat(command.className()).isEqualTo(className);
     }
 
     @Test

--- a/cluster/src/test/java/com/hartwig/pipeline/metrics/BamMetricsCommandTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/metrics/BamMetricsCommandTest.java
@@ -40,7 +40,7 @@ public class BamMetricsCommandTest {
     @Test
     public void shouldStartCommandLineWithJarAndOperation() {
         assertThat(actual).startsWith("java -Xmx24G -Dsamjdk.use_async_io_read_samtools=true -Dsamjdk.use_async_io_write_samtools=true "
-                + "-Dsamjdk.use_async_io_write_tribble=true -Dsamjdk.buffer_size=4194304 -cp /data/tools/gridss/2.4.0/gridss.jar "
+                + "-Dsamjdk.use_async_io_write_tribble=true -Dsamjdk.buffer_size=4194304 -cp /data/tools/gridss/2.5.1/gridss.jar "
                 + "picard.cmdline.PicardCommandLine " + OPERATION);
     }
 


### PR DESCRIPTION
Also updated the tests as they weren't checking the GRIDSS version part of their commands.

There's an opportunity for re-use by making the test classes extend from a common ancestor but I'm not really sure how I feel about that. Comments encouraged.