### PR TITLE
DEV-903 Propagate QC_FAIL to final pipeline status

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/PipelineState.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/PipelineState.java
@@ -20,10 +20,10 @@ public class PipelineState {
         return stageOutput;
     }
 
-    PipelineState combineWith(PipelineState state){
+    PipelineState combineWith(PipelineState state) {
         if (state != null) {
             state.stageOutputs().forEach(this::add);
-        }else {
+        } else {
             throw new IllegalArgumentException("State from one of the two pipelines was null. Did that pipeline run successfully?");
         }
         return this;
@@ -45,7 +45,7 @@ public class PipelineState {
         return stageOutputs().stream()
                 .filter(Objects::nonNull)
                 .map(StageOutput::status)
-                .filter(status -> status == PipelineStatus.FAILED)
+                .filter(status -> !status.equals(PipelineStatus.SUCCESS) && !status.equals(PipelineStatus.SKIPPED))
                 .findFirst()
                 .orElse(PipelineStatus.SUCCESS);
     }

--- a/cluster/src/test/java/com/hartwig/pipeline/PipelineStateTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/PipelineStateTest.java
@@ -1,0 +1,65 @@
+package com.hartwig.pipeline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.hartwig.pipeline.execution.PipelineStatus;
+import com.hartwig.pipeline.report.ReportComponent;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+public class PipelineStateTest {
+
+    @Test
+    public void statusSuccessWhenAllStatusSuccessOrSkipped() {
+        PipelineState victim = new PipelineState();
+        victim.add(output(PipelineStatus.SUCCESS));
+        victim.add(output(PipelineStatus.SKIPPED));
+        assertThat(victim.shouldProceed()).isTrue();
+        assertThat(victim.status()).isEqualTo(PipelineStatus.SUCCESS);
+    }
+
+    @Test
+    public void statusFailedWhenAnyStatusFails() {
+        PipelineState victim = new PipelineState();
+        victim.add(output(PipelineStatus.SUCCESS));
+        victim.add(output(PipelineStatus.SKIPPED));
+        victim.add(output(PipelineStatus.FAILED));
+        assertThat(victim.shouldProceed()).isFalse();
+        assertThat(victim.status()).isEqualTo(PipelineStatus.FAILED);
+    }
+
+    @Test
+    public void statusFailedWhenAnyStatusQcFails() {
+        PipelineState victim = new PipelineState();
+        victim.add(output(PipelineStatus.SUCCESS));
+        victim.add(output(PipelineStatus.SKIPPED));
+        victim.add(output(PipelineStatus.QC_FAILED));
+        assertThat(victim.shouldProceed()).isFalse();
+        assertThat(victim.status()).isEqualTo(PipelineStatus.QC_FAILED);
+    }
+
+    @NotNull
+    public StageOutput output(final PipelineStatus status) {
+        return new StageOutput() {
+            @Override
+            public String name() {
+                return "test";
+            }
+
+            @Override
+            public PipelineStatus status() {
+                return status;
+            }
+
+            @Override
+            public List<ReportComponent> reportComponents() {
+                return Collections.emptyList();
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
Fixes bug in which we returned a successful pipeline run, even if the
healthchecker failed. We now filter out all status not success or skip,
and whatever's left is returned as the status, or success.

Also adds a few more tests that should cover this in the future.