### PR TITLE
DEV-905 Separate shallow runtimes and always cleanup

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/RunTag.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/RunTag.java
@@ -2,7 +2,11 @@ package com.hartwig.pipeline;
 
 public class RunTag {
 
-    public static String apply(Arguments arguments, String id){
-        return arguments.runId().map(runId -> id + "-" + runId).orElse(id);
+    public static String apply(Arguments arguments, String id) {
+        return arguments.runId().map(runId -> maybeWithShallow(arguments, id) + "-" + runId).orElse(maybeWithShallow(arguments, id));
+    }
+
+    private static String maybeWithShallow(final Arguments arguments, final String id) {
+        return arguments.shallow() ? id + "-shallow" : id;
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/RunTag.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/RunTag.java
@@ -2,11 +2,7 @@ package com.hartwig.pipeline;
 
 public class RunTag {
 
-    public static String apply(Arguments arguments, String id) {
-        return arguments.runId().map(runId -> maybeWithShallow(arguments, id) + "-" + runId).orElse(maybeWithShallow(arguments, id));
-    }
-
-    private static String maybeWithShallow(final Arguments arguments, final String id) {
-        return arguments.shallow() ? id + "-shallow" : id;
+    public static String apply(Arguments arguments, String id){
+        return arguments.runId().map(runId -> id + "-" + runId).orElse(id);
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/Run.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/Run.java
@@ -16,7 +16,9 @@ public interface Run {
     String id();
 
     static Run from(String sampleName, Arguments arguments) {
-        return ImmutableRun.of(format("run-%s", RunTag.apply(arguments, sampleName.toLowerCase())).replace("_", "-"));
+        return ImmutableRun.of(format("run-%s%s",
+                RunTag.apply(arguments, sampleName.toLowerCase()),
+                arguments.shallow() ? "-shallow" : "").replace("_", "-"));
     }
 
     static Run from(String reference, String tumor, Arguments arguments) {

--- a/cluster/src/main/java/com/hartwig/pipeline/cleanup/Cleanup.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/cleanup/Cleanup.java
@@ -54,7 +54,7 @@ public class Cleanup {
     }
 
     private void cleanupSample(final SingleSampleRunMetadata metadata) {
-        if (!somaticMetadataApi.hasDependencies(metadata.sampleName())) {
+        if (!somaticMetadataApi.hasDependencies(metadata.sampleName()) || arguments.shallow()) {
             Run run = Run.from(metadata.sampleId(), arguments);
             deleteBucket(run.id());
             deleteStagingDirectory(metadata);
@@ -72,7 +72,7 @@ public class Cleanup {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-        }else {
+        } else {
             LOGGER.info("Skipping cleanup of sample [{}], it has other dependent runs.", metadata.sampleName());
         }
     }

--- a/cluster/src/test/java/com/hartwig/pipeline/alignment/RunTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/alignment/RunTest.java
@@ -43,4 +43,22 @@ public class RunTest {
         Run victim = Run.from("very-long-reference-sample-name", "very-long-tumor-sample-name-NNNNN", Arguments.testDefaults());
         assertThat(victim.id().length()).isLessThanOrEqualTo(35);
     }
+
+    @Test
+    public void appendsShallowOnShallowSingleSampleRuns() {
+        Run victim = Run.from(REFERENCE_SAMPLE, Arguments.testDefaultsBuilder().shallow(true).build());
+        assertThat(victim.id()).isEqualTo("run-reference-shallow");
+    }
+
+    @Test
+    public void appendsShallowOnShallowSomaticRuns() {
+        Run victim = Run.from(REFERENCE_SAMPLE, TUMOR_SAMPLE, Arguments.testDefaultsBuilder().shallow(true).build());
+        assertThat(victim.id()).isEqualTo("run-reference-tumor-shallow");
+    }
+
+    @Test
+    public void appendsShallowOnShallowBeforeRunTag() {
+        Run victim = Run.from(REFERENCE_SAMPLE, TUMOR_SAMPLE, Arguments.testDefaultsBuilder().shallow(true).runId("override").build());
+        assertThat(victim.id()).isEqualTo("run-reference-tumor-shallow-override");
+    }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/alignment/RunTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/alignment/RunTest.java
@@ -59,6 +59,6 @@ public class RunTest {
     @Test
     public void appendsShallowOnShallowBeforeRunTag() {
         Run victim = Run.from(REFERENCE_SAMPLE, TUMOR_SAMPLE, Arguments.testDefaultsBuilder().shallow(true).runId("override").build());
-        assertThat(victim.id()).isEqualTo("run-reference-tumor-shallow-override");
+        assertThat(victim.id()).isEqualTo("run-reference-tumor-override-shallow");
     }
 }


### PR DESCRIPTION
Solves the issue of accidental reuse of shallow data by deleting the
shallow buckets even if a dependency is detected on the sample by
another run. The dependency is likely from a different sequencing.

Also appends 'shallow' to each shallow runtime resource. Not strictly
required given the above, but should make it a little easier to see on
first inspection what is running.