### PR TITLE
DEV-909 Fix bug with VM cleanup across runs

### DIFF
--- a/cluster/src/test/java/com/hartwig/pipeline/execution/vm/ComputeEngineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/execution/vm/ComputeEngineTest.java
@@ -11,12 +11,14 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.model.Image;
 import com.google.api.services.compute.model.Instance;
+import com.google.api.services.compute.model.InstanceList;
 import com.google.api.services.compute.model.Metadata;
 import com.google.api.services.compute.model.NetworkInterface;
 import com.google.api.services.compute.model.Operation;
@@ -81,6 +83,19 @@ public class ComputeEngineTest {
         when(deleteOperation.getStatus()).thenReturn(DONE);
         when(delete.execute()).thenReturn(stopOperation);
         when(instances.delete(ARGUMENTS.project(), FIRST_ZONE_NAME, INSTANCE_NAME)).thenReturn(delete);
+
+        Compute.Instances.List list = mock(Compute.Instances.List.class);
+        InstanceList instanceList = mock(InstanceList.class);
+        Instance one = mock(Instance.class);
+        Instance two = mock(Instance.class);
+        Instance three = mock(Instance.class);
+        when(one.getName()).thenReturn("vm-1");
+        when(two.getName()).thenReturn("vm-2");
+        when(three.getName()).thenReturn("vm-3");
+        List<Instance> existingInstances = Arrays.asList(one, two, three);
+        when(instances.list(any(), any())).thenReturn(list);
+        when(list.execute()).thenReturn(instanceList);
+        when(instanceList.getItems()).thenReturn(existingInstances);
 
         zoneOperations = mock(Compute.ZoneOperations.class);
         zoneOpGet = mock(Compute.ZoneOperations.Get.class);


### PR DESCRIPTION
This commit fixes a bug with the VM cleanup and zone selection logic
which would (usually) cause the run to bail when a VM already existed
from a previous run. In that situation the new run would start and
attempt to launch a new VM, but encounter an HTTP 409 because a VM
with the requested name already exists in the region.

The new zone rotation logic was passing the "previous" zone into the
cleanup code that gets called in the case of the 409, but that would
fail or succeed according to chance, because the previous zone was
regulated by the first invocation. If the wrong previous zone was used
the code would throw because it was not able to find the VM in the
expected zone.

Now the code just looks for a VM of the expected name in any of the
zones in the region and deletes it, without waiting to get a 409, and
before attempting to start anything.