### PR TITLE
DEV-925 Pin rclone to known-working version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 branches:
   only:
-  - master
+  - DEV-925
 sudo: required
 language: java
 services:

--- a/cluster/Dockerfile
+++ b/cluster/Dockerfile
@@ -2,7 +2,7 @@ FROM google/cloud-sdk:slim
 
 RUN apt-get update
 RUN apt-get --yes install openjdk-8-jre
-RUN curl https://downloads.rclone.org/rclone-current-linux-amd64.deb  --output rclone-current-linux-amd64.deb
+RUN curl https://downloads.rclone.org/v1.48.0/rclone-v1.48.0-linux-amd64.deb --output rclone-current-linux-amd64.deb
 RUN dpkg -i rclone-current-linux-amd64.deb
 
 

--- a/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
@@ -108,7 +108,7 @@ public class PipelineMain {
     public static void main(String[] args) {
         try {
             PipelineState state = new PipelineMain().start(CommandLineOptions.from(args));
-            if (state.status() == PipelineStatus.SUCCESS) {
+            if (state.status() != PipelineStatus.FAILED) {
                 System.exit(0);
             } else {
                 System.exit(1);


### PR DESCRIPTION
The current problems we're having with the bucket permissions wasn't
being seen in older builds. Try using the same version of rclone that
was in-use previously to see if it fixes the problem.