### PR TITLE
DEV-910 Refactor compute engine code

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
@@ -108,7 +108,7 @@ public class PipelineMain {
     public static void main(String[] args) {
         try {
             PipelineState state = new PipelineMain().start(CommandLineOptions.from(args));
-            if (state.status() == PipelineStatus.SUCCESS) {
+            if (state.status() != PipelineStatus.FAILED) {
                 System.exit(0);
             } else {
                 System.exit(1);

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/BucketCompletionWatcher.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/BucketCompletionWatcher.java
@@ -1,0 +1,49 @@
+package com.hartwig.pipeline.execution.vm;
+
+import java.time.Duration;
+import java.util.List;
+
+import com.google.cloud.storage.Blob;
+import com.hartwig.pipeline.storage.RuntimeBucket;
+
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
+
+public class BucketCompletionWatcher {
+    enum State {
+        SUCCESS,
+        FAILURE,
+        STILL_WAITING
+    }
+
+    State waitForCompletion(RuntimeBucket bucket, VirtualMachineJobDefinition jobDefinition) {
+        return Failsafe.with(new RetryPolicy<>().withMaxRetries(-1).withDelay(Duration.ofSeconds(5)).handleResult(null)).get(() -> {
+            State currentState = currentState(bucket, jobDefinition);
+            if (currentState.equals(State.STILL_WAITING)) {
+                return null;
+            } else {
+                return currentState;
+            }
+        });
+    }
+
+    State currentState(RuntimeBucket bucket, VirtualMachineJobDefinition jobDefinition) {
+        if (bucketContainsFile(bucket, jobDefinition.startupCommand().failureFlag())) {
+            return State.FAILURE;
+        } else if (bucketContainsFile(bucket, jobDefinition.startupCommand().successFlag())) {
+            return State.SUCCESS;
+        }
+        return State.STILL_WAITING;
+    }
+
+    private boolean bucketContainsFile(RuntimeBucket bucket, String filename) {
+        List<Blob> objects = bucket.list();
+        for (Blob blob : objects) {
+            String name = blob.getName();
+            if (name.equals(bucket.getNamespace() + "/" + filename)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/ComputeEngine.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/ComputeEngine.java
@@ -4,7 +4,6 @@ import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 
 import java.io.IOException;
-import java.net.HttpURLConnection;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
@@ -12,12 +11,10 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
-import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.compute.Compute;
-import com.google.api.services.compute.ComputeRequest;
 import com.google.api.services.compute.model.AccessConfig;
 import com.google.api.services.compute.model.AttachedDisk;
 import com.google.api.services.compute.model.AttachedDiskInitializeParams;
@@ -31,7 +28,6 @@ import com.google.api.services.compute.model.ServiceAccount;
 import com.google.api.services.compute.model.Zone;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.cloud.storage.Blob;
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.execution.CloudExecutor;
 import com.hartwig.pipeline.execution.PipelineStatus;
@@ -43,7 +39,6 @@ import org.slf4j.LoggerFactory;
 
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
-import net.jodah.failsafe.function.CheckedSupplier;
 
 public class ComputeEngine implements CloudExecutor<VirtualMachineJobDefinition> {
     private final static String APPLICATION_NAME = "vm-hosted-workload";
@@ -55,15 +50,23 @@ public class ComputeEngine implements CloudExecutor<VirtualMachineJobDefinition>
     private final Arguments arguments;
     private final Compute compute;
     private final Consumer<List<Zone>> zoneRandomizer;
+    private final InstanceLifecycleManager lifecycleManager;
+    private final BucketCompletionWatcher bucketWatcher;
 
-    public ComputeEngine(final Arguments arguments, final Compute compute, final Consumer<List<Zone>> zoneRandomizer) {
+    public ComputeEngine(final Arguments arguments, final Compute compute, final Consumer<List<Zone>> zoneRandomizer,
+            InstanceLifecycleManager lifecycleManager, BucketCompletionWatcher bucketWatcher) {
         this.arguments = arguments;
         this.compute = compute;
         this.zoneRandomizer = zoneRandomizer;
+        this.lifecycleManager = lifecycleManager;
+        this.bucketWatcher = bucketWatcher;
     }
 
     public static ComputeEngine from(final Arguments arguments, final GoogleCredentials credentials) throws Exception {
-        return new ComputeEngine(arguments, initCompute(credentials), Collections::shuffle);
+        Compute compute = initCompute(credentials);
+        return new ComputeEngine(arguments, compute, Collections::shuffle,
+                new InstanceLifecycleManager(arguments, compute),
+                new BucketCompletionWatcher());
     }
 
     @Override
@@ -71,36 +74,30 @@ public class ComputeEngine implements CloudExecutor<VirtualMachineJobDefinition>
         String vmName = bucket.runId() + "-" + jobDefinition.name();
         PipelineStatus status = PipelineStatus.FAILED;
         try {
-            if (bucketContainsFile(bucket, jobDefinition.startupCommand().successFlag())) {
+            BucketCompletionWatcher.State currentState = bucketWatcher.currentState(bucket, jobDefinition);
+            if (currentState == BucketCompletionWatcher.State.SUCCESS) {
                 LOGGER.info("Compute engine job [{}] already exists, and succeeded. Skipping job.", vmName);
                 return PipelineStatus.SKIPPED;
-            } else if (bucketContainsFile(bucket, jobDefinition.startupCommand().failureFlag())) {
+            } else if (currentState == BucketCompletionWatcher.State.FAILURE) {
                 LOGGER.info("Compute engine job [{}] already exists, but failed. Deleting state and restarting.", vmName);
                 bucket.delete(jobDefinition.startupCommand().failureFlag());
                 bucket.delete(jobDefinition.namespacedResults().path());
             }
 
-            List<Zone> zones = compute.zones()
-                    .list(arguments.project())
-                    .execute()
-                    .getItems()
-                    .stream()
-                    .filter(zone -> zone.getRegion().endsWith(arguments.region()))
-                    .collect(Collectors.toList());
+            String project = arguments.project();
+            List<Zone> zones = fetchZones();
             zoneRandomizer.accept(zones);
             int index = 0;
             boolean keepTrying = !zones.isEmpty();
-            Zone previousZone = zones.stream().findFirst().orElse(new Zone());
             while (keepTrying) {
-                Zone nextZone = zones.get(index % zones.size());
-                Instance instance = new Instance();
+                Zone currentZone = zones.get(index % zones.size());
+                Instance instance = lifecycleManager.newInstance();
                 instance.setName(vmName);
-                instance.setZone(nextZone.getName());
-                if (arguments.usePreemptibleVms()) {
+                instance.setZone(currentZone.getName());
+                if (arguments.usePreemptibleVms() && jobDefinition.preemptibleCompatible()) {
                     instance.setScheduling(new Scheduling().setPreemptible(true));
                 }
-                String project = arguments.project();
-                instance.setMachineType(machineType(nextZone.getName(), jobDefinition.performanceProfile().uri(), project));
+                instance.setMachineType(machineType(currentZone.getName(), jobDefinition.performanceProfile().uri(), project));
 
                 instance.setLabels(Labels.ofRun(bucket.runId(), jobDefinition.name(), arguments));
 
@@ -111,34 +108,35 @@ public class ComputeEngine implements CloudExecutor<VirtualMachineJobDefinition>
                         project,
                         vmName,
                         jobDefinition.performanceProfile().diskGb(),
-                        nextZone.getName());
+                        currentZone.getName());
                 LOGGER.info("Submitting compute engine job [{}] using image [{}] in zone [{}]",
                         jobDefinition.name(),
                         image.getName(),
-                        nextZone.getName());
+                        currentZone.getName());
                 addStartupCommand(instance, bucket, jobDefinition.startupCommand());
                 addNetworkInterface(instance, project);
 
-                Operation result = deleteOldInstancesAndStart(compute, instance, project, previousZone, nextZone, vmName);
+                Operation result = lifecycleManager.deleteOldInstancesAndStart(instance, currentZone.getName(), vmName);
                 if (result.getError() == null) {
                     LOGGER.debug("Successfully initialised [{}]", vmName);
-                    status = waitForCompletion(bucket, jobDefinition, nextZone, instance);
+                    status = waitForCompletion(bucket, jobDefinition, currentZone, instance);
                     if (status != PipelineStatus.PREEMPTED) {
-                        stop(project, nextZone.getName(), vmName);
+                        lifecycleManager.stop(currentZone.getName(), vmName);
                         if (status == PipelineStatus.SUCCESS) {
-                            delete(project, nextZone.getName(), vmName);
+                            lifecycleManager.delete(currentZone.getName(), vmName);
                         } else {
-                            disableStartupScript(instance, nextZone.getName());
+                            lifecycleManager.disableStartupScript(currentZone.getName(), instance.getName());
                         }
-                        LOGGER.info("Compute engine job [{}] is complete with status [{}]", jobDefinition.name(), status);
+                        LOGGER.info("Compute engine job [{}] is complete with operationStatus [{}]", jobDefinition.name(), status);
                         keepTrying = false;
+                    } else {
+                        LOGGER.info("Instance [{}] in [{}] was pre-empted", vmName, currentZone.getName());
                     }
                 } else if (result.getError().getErrors().stream().anyMatch(error -> error.getCode().equals(ZONE_EXHAUSTED_ERROR_CODE))) {
-                    LOGGER.warn("Zone [{}] has insufficient resources to fulfill the request. Trying next zone", nextZone.getName());
+                    LOGGER.warn("Zone [{}] has insufficient resources to fulfill the request. Trying next zone", currentZone.getName());
                 } else {
                     throw new RuntimeException(result.getError().toPrettyString());
                 }
-                previousZone = nextZone;
                 index++;
             }
         } catch (Exception e) {
@@ -147,15 +145,6 @@ public class ComputeEngine implements CloudExecutor<VirtualMachineJobDefinition>
             return PipelineStatus.FAILED;
         }
         return status;
-    }
-
-    private void disableStartupScript(final Instance instance, final String zone) throws Exception {
-        String latestFingerprint =
-                compute.instances().get(arguments.project(), zone, instance.getName()).execute().getMetadata().getFingerprint();
-        executeSynchronously(compute.instances()
-                        .setMetadata(arguments.project(), zone, instance.getName(), new Metadata().setFingerprint(latestFingerprint)),
-                arguments.project(),
-                zone);
     }
 
     private static Compute initCompute(final GoogleCredentials credentials) throws Exception {
@@ -233,94 +222,39 @@ public class ComputeEngine implements CloudExecutor<VirtualMachineJobDefinition>
         return format("%s/zones/%s/machineTypes/%s", apiBaseUrl(projectName), zone, type);
     }
 
-    private Operation deleteOldInstancesAndStart(Compute compute, Instance instance, String projectName, Zone previousZone, Zone newZone,
-            String vmName) throws Exception {
-        Compute.Instances.Insert insert = compute.instances().insert(projectName, newZone.getName(), instance);
-        try {
-            return executeSynchronously(insert, projectName, newZone.getName());
-        } catch (Exception e) {
-            if (e.getCause() instanceof GoogleJsonResponseException) {
-                GoogleJsonResponseException gjre = (GoogleJsonResponseException) e.getCause();
-                if (HttpURLConnection.HTTP_CONFLICT == gjre.getDetails().getCode()) {
-                    LOGGER.info("Found existing [{}] instance; deleting and restarting", vmName);
-                    Operation delete = executeSynchronously(compute.instances().delete(projectName, previousZone.getName(), vmName),
-                            projectName,
-                            previousZone.getName());
-                    if (delete.getError() == null) {
-                        return executeSynchronously(insert, projectName, newZone.getName());
-                    } else {
-                        throw new RuntimeException(delete.getError().toPrettyString());
-                    }
-                } else {
-                    throw gjre;
-                }
-            } else {
-                throw e;
-            }
-        }
-    }
-
-    private Operation executeSynchronously(ComputeRequest<Operation> request, String projectName, String zoneName) throws Exception {
-        Operation syncOp = executeWithRetries(request::execute);
-        String logId = format("Operation [%s:%s]", syncOp.getOperationType(), syncOp.getName());
-        LOGGER.debug("{} is executing synchronously", logId);
-        while ("RUNNING" .equals(fetchJobStatus(compute, syncOp.getName(), projectName, zoneName))) {
-            LOGGER.debug("{} not done yet", logId);
-            try {
-                Thread.sleep(500);
-            } catch (InterruptedException ie) {
-                Thread.interrupted();
-            }
-        }
-
-        return executeWithRetries(() -> compute.zoneOperations().get(projectName, zoneName, syncOp.getName()).execute());
-    }
-
-    private String fetchJobStatus(Compute compute, String jobName, String projectName, String zoneName) {
-        return executeWithRetries(() -> compute.zoneOperations().get(projectName, zoneName, jobName).execute()).getStatus();
-    }
-
-    private Operation executeWithRetries(final CheckedSupplier<Operation> operationCheckedSupplier) {
-        return Failsafe.with(new RetryPolicy<>().handle(IOException.class).withDelay(Duration.ofSeconds(5)).withMaxRetries(5))
-                .get(operationCheckedSupplier);
-    }
-
-    private boolean bucketContainsFile(RuntimeBucket bucket, String filename) {
-        List<Blob> objects = bucket.list();
-        for (Blob blob : objects) {
-            String name = blob.getName();
-            if (name.equals(bucket.getNamespace() + "/" + filename)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     private PipelineStatus waitForCompletion(RuntimeBucket bucket, VirtualMachineJobDefinition jobDefinition, Zone zone,
             Instance instance) {
+        LOGGER.debug("Waiting for completion of {}", instance.getName());
         return Failsafe.with(new RetryPolicy<>().withMaxRetries(-1).withDelay(Duration.ofSeconds(5)).handleResult(null)).get(() -> {
-            if (bucketContainsFile(bucket, jobDefinition.startupCommand().successFlag())) {
+            LOGGER.debug("Checking bucket for state");
+            BucketCompletionWatcher.State bucketState = bucketWatcher.currentState(bucket, jobDefinition);
+            if (bucketState.equals(BucketCompletionWatcher.State.SUCCESS)) {
                 return PipelineStatus.SUCCESS;
-            } else if (bucketContainsFile(bucket, jobDefinition.startupCommand().failureFlag())) {
+            } else if (bucketState.equals(BucketCompletionWatcher.State.FAILURE)) {
                 return PipelineStatus.FAILED;
             }
-            if (compute.instances()
-                    .get(arguments.project(), zone.getName(), instance.getName())
-                    .execute()
-                    .getStatus()
-                    .equals(PREEMPTED_INSTANCE)) {
-                LOGGER.warn("Instance [{}] was preempted. Restarting in next zone", instance.getName());
-                return PipelineStatus.PREEMPTED;
+            LOGGER.debug("Bucket does not contain any state yet, checking instance");
+            try {
+                String status = lifecycleManager.instanceStatus(instance.getName(), zone.getName());
+                LOGGER.debug("Execution state of [{}]: [{}]", instance.getName(), status);
+                switch (status.trim()) {
+                    case PREEMPTED_INSTANCE: return PipelineStatus.PREEMPTED;
+                    default: return null;
+                }
+            } catch (Exception e) {
+                LOGGER.debug("Caught exception when looking for operationStatus, will continue to wait", e);
+                return null;
             }
-            return null;
         });
     }
 
-    private void stop(String projectName, String zoneName, String vmName) throws Exception {
-        executeSynchronously(compute.instances().stop(projectName, zoneName, vmName), projectName, zoneName);
-    }
-
-    private void delete(String projectName, String zoneName, String vmName) throws Exception {
-        executeSynchronously(compute.instances().delete(projectName, zoneName, vmName), projectName, zoneName);
+    private List<Zone> fetchZones() throws IOException {
+        return compute.zones()
+                .list(arguments.project())
+                .execute()
+                .getItems()
+                .stream()
+                .filter(zone -> zone.getRegion().endsWith(arguments.region()))
+                .collect(Collectors.toList());
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/InstanceLifecycleManager.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/InstanceLifecycleManager.java
@@ -1,0 +1,146 @@
+package com.hartwig.pipeline.execution.vm;
+
+import static java.lang.String.format;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.google.api.services.compute.Compute;
+import com.google.api.services.compute.ComputeRequest;
+import com.google.api.services.compute.model.Instance;
+import com.google.api.services.compute.model.InstanceList;
+import com.google.api.services.compute.model.Metadata;
+import com.google.api.services.compute.model.Operation;
+import com.google.api.services.compute.model.Zone;
+import com.hartwig.pipeline.Arguments;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
+import net.jodah.failsafe.function.CheckedSupplier;
+
+class InstanceLifecycleManager {
+    private static final String RUNNING_STATUS = "RUNNING";
+    private static final Logger LOGGER = LoggerFactory.getLogger(InstanceLifecycleManager.class);
+
+    private final String project;
+    private final Compute compute;
+    private final String region;
+
+    public InstanceLifecycleManager(final Arguments arguments, final Compute compute) {
+        this.project = arguments.project();
+        this.region = arguments.region();
+        this.compute = compute;
+    }
+
+    Instance newInstance() {
+        return new Instance();
+    }
+
+    Optional<Instance> findExistingInstance(String vmName) throws IOException {
+        for (String zone : fetchZones().stream().map(z -> z.getName()).collect(Collectors.toList())) {
+            InstanceList instances = compute.instances().list(project, zone).execute();
+            if (instances.getItems() != null) {
+                for (Instance instance : instances.getItems()) {
+                    if (instance.getName().equals(vmName)) {
+                        return Optional.of(instance);
+                    }
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    Operation deleteOldInstancesAndStart(Instance instance, String zone, String vmName) throws IOException {
+        findExistingInstance(vmName).ifPresent(i -> {
+            try {
+                String shortZone = new File(i.getZone()).getName();
+                LOGGER.debug("Removing existing VM instance [{}] in [{}]", i.getName(), shortZone);
+                Operation delete = executeSynchronously(compute.instances().delete(project, shortZone, vmName), project, shortZone);
+                if (delete.getError() != null) {
+                    throw new RuntimeException(delete.getError().toPrettyString());
+                }
+            } catch (Exception e) {
+                throw new RuntimeException("Could not delete existing [" + vmName + "] instance", e);
+            }
+        });
+        try {
+            return executeSynchronously(compute.instances().insert(project, zone, instance), project, zone);
+        } catch (IOException ioe) {
+            throw new RuntimeException("Could not initialise insert operation!", ioe);
+        }
+    }
+
+    void delete(String zone, String vm) {
+        executeSynchronously(getWithRetries(() -> compute.instances().delete(project, zone, vm)), project, zone);
+    }
+
+    void stop(String zone, String vm) {
+        executeSynchronously(getWithRetries(() -> compute.instances().stop(project, zone, vm)), project, zone);
+    }
+
+    String operationStatus(String jobName, String zoneName) {
+        return executeWithRetries(() -> compute.zoneOperations().get(project, zoneName, jobName).execute()).getStatus();
+    }
+
+    String instanceStatus(String vm, String zone) {
+        try {
+            Optional<Instance> instance = findExistingInstance(vm);
+            if (instance.isPresent()) {
+                return instance.get().getStatus();
+            } else {
+                throw new IllegalStateException(format("Could not find instance [%s]", vm));
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to fetch instance status!", e);
+        }
+    }
+
+    void disableStartupScript(final String zone, final String vm) throws IOException {
+        String latestFingerprint =
+                compute.instances().get(project, zone, vm).execute().getMetadata().getFingerprint();
+        executeSynchronously(compute.instances()
+                        .setMetadata(project, zone, vm, new Metadata().setFingerprint(latestFingerprint)), project, zone);
+    }
+
+    private ComputeRequest<Operation> getWithRetries(final CheckedSupplier<ComputeRequest<Operation>> supplier) {
+        return Failsafe.with(new RetryPolicy<>().handle(Exception.class).withDelay(Duration.ofSeconds(5)).withMaxRetries(5))
+                .get(supplier);
+    }
+
+    private Operation executeSynchronously(ComputeRequest<Operation> request, String projectName, String zoneName) {
+        Operation asyncOp = executeWithRetries(request::execute);
+        String logId = format("Operation [%s:%s]", asyncOp.getOperationType(), asyncOp.getName());
+        LOGGER.debug("{} is executing synchronously", logId);
+        while (RUNNING_STATUS.equals(operationStatus(asyncOp.getName(), zoneName))) {
+            LOGGER.debug("{} not done yet", logId);
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException ie) {
+                Thread.interrupted();
+            }
+        }
+        return executeWithRetries(() -> compute.zoneOperations().get(projectName, zoneName, asyncOp.getName()).execute());
+    }
+
+    private Operation executeWithRetries(final CheckedSupplier<Operation> operationCheckedSupplier) {
+        return Failsafe.with(new RetryPolicy<>().handle(IOException.class).withDelay(Duration.ofSeconds(5)).withMaxRetries(5))
+                .get(operationCheckedSupplier);
+    }
+
+    private List<Zone> fetchZones() throws IOException {
+        return compute.zones()
+                .list(project)
+                .execute()
+                .getItems()
+                .stream()
+                .filter(zone -> zone.getRegion().endsWith(region))
+                .collect(Collectors.toList());
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
@@ -19,6 +19,11 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
 
     ResultsDirectory namespacedResults();
 
+    @Value.Default
+    default boolean preemptibleCompatible() {
+        return true;
+    }
+
     @Override
     @Value.Default
     default VirtualMachinePerformanceProfile performanceProfile() {
@@ -60,6 +65,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
                 .name("gridss")
                 .startupCommand(startupScript)
                 .performanceProfile(VirtualMachinePerformanceProfile.custom(24, 120))
+                .preemptibleCompatible(false)
                 .namespacedResults(resultsDirectory)
                 .build();
     }

--- a/cluster/src/test/java/com/hartwig/pipeline/execution/vm/BucketCompletionWatcherTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/execution/vm/BucketCompletionWatcherTest.java
@@ -1,0 +1,102 @@
+package com.hartwig.pipeline.execution.vm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.cloud.ReadChannel;
+import com.google.cloud.storage.Blob;
+import com.hartwig.pipeline.execution.vm.BucketCompletionWatcher.State;
+import com.hartwig.pipeline.testsupport.MockRuntimeBucket;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class BucketCompletionWatcherTest {
+    private static final String NAMESPACE = "test/";
+    private static final String FAILURE_FLAG = "job.failure";
+    private static final String SUCCESS_FLAG = "job.success";
+
+    private MockRuntimeBucket runtimeBucket;
+    private List<Blob> blobs;
+    private Blob mockBlob;
+    private VirtualMachineJobDefinition job;
+    private BucketCompletionWatcher victim;
+
+    @Before
+    public void setup() {
+        runtimeBucket = MockRuntimeBucket.test();
+        blobs = new ArrayList<>();
+        mockBlob = mock(Blob.class);
+        when(runtimeBucket.getRuntimeBucket().list()).thenReturn(blobs);
+
+        victim = new BucketCompletionWatcher();
+
+        job = mock(VirtualMachineJobDefinition.class);
+        final BashStartupScript startupCommand = mock(BashStartupScript.class);
+        when(job.startupCommand()).thenReturn(startupCommand);
+        when(startupCommand.successFlag()).thenReturn(SUCCESS_FLAG);
+        when(startupCommand.failureFlag()).thenReturn(FAILURE_FLAG);
+    }
+
+    @Test
+    public void shouldReturnFailureStateIfBucketContainsFailureFlag() {
+        mockFlagFile(FAILURE_FLAG);
+        assertThat(victim.currentState(runtimeBucket.getRuntimeBucket(), job)).isEqualTo(State.FAILURE);
+    }
+
+    @Test
+    public void shouldReturnSuccessStateIfBucketContainsSuccessFlag() {
+        mockFlagFile(SUCCESS_FLAG);
+        assertThat(victim.currentState(runtimeBucket.getRuntimeBucket(), job)).isEqualTo(State.SUCCESS);
+    }
+
+    @Test
+    public void shouldReturnStillWaitingIfBucketContainsNeitherFlag() {
+        assertThat(victim.currentState(runtimeBucket.getRuntimeBucket(), job)).isEqualTo(State.STILL_WAITING);
+    }
+
+    @Test
+    public void shouldWaitAndEventuallyReturnFailureState() {
+        mockFlagFile(FAILURE_FLAG);
+        when(runtimeBucket.getRuntimeBucket().list()).thenReturn(new ArrayList<>(), blobs);
+        assertThat(victim.waitForCompletion(runtimeBucket.getRuntimeBucket(), job)).isEqualTo(State.FAILURE);
+        verify(runtimeBucket.getRuntimeBucket(), atLeast(2)).list();
+    }
+
+    @Test
+    public void shouldWaitAndEventuallyReturnSuccessState() {
+        mockFlagFile(SUCCESS_FLAG);
+        when(runtimeBucket.getRuntimeBucket().list()).thenReturn(new ArrayList<>(), blobs);
+        assertThat(victim.waitForCompletion(runtimeBucket.getRuntimeBucket(), job)).isEqualTo(State.SUCCESS);
+        verify(runtimeBucket.getRuntimeBucket(), atLeast(2)).list();
+    }
+
+    private void mockFlagFile(String flagFile) {
+        mockReadChannel(mockBlob, NAMESPACE + flagFile);
+        blobs.add(mockBlob);
+        when(runtimeBucket.getRuntimeBucket().get(flagFile)).thenReturn(mockBlob);
+        when(runtimeBucket.getRuntimeBucket().list()).thenReturn(blobs);
+    }
+
+    private void mockReadChannel(final Blob mockBlob, final String name) {
+        ReadChannel mockReadChannel = mock(ReadChannel.class);
+        try {
+            when(mockReadChannel.read(any())).thenReturn(-1);
+        } catch (IOException ioe) {
+            fail("Unexpected exception", ioe);
+        }
+        when(mockBlob.getName()).thenReturn(name);
+        when(mockBlob.getSize()).thenReturn(1L);
+        when(mockBlob.reader()).thenReturn(mockReadChannel);
+        when(mockBlob.getMd5()).thenReturn("");
+    }
+}

--- a/cluster/src/test/java/com/hartwig/pipeline/execution/vm/ComputeEngineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/execution/vm/ComputeEngineTest.java
@@ -10,24 +10,22 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.model.Image;
 import com.google.api.services.compute.model.Instance;
-import com.google.api.services.compute.model.Metadata;
 import com.google.api.services.compute.model.NetworkInterface;
 import com.google.api.services.compute.model.Operation;
+import com.google.api.services.compute.model.Scheduling;
 import com.google.api.services.compute.model.Zone;
 import com.google.api.services.compute.model.ZoneList;
-import com.google.cloud.ReadChannel;
-import com.google.cloud.storage.Blob;
 import com.google.common.collect.Lists;
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.ResultsDirectory;
 import com.hartwig.pipeline.execution.PipelineStatus;
+import com.hartwig.pipeline.execution.vm.BucketCompletionWatcher.State;
 import com.hartwig.pipeline.testsupport.MockRuntimeBucket;
 
 import org.junit.Before;
@@ -39,7 +37,6 @@ public class ComputeEngineTest {
 
     private static final Arguments ARGUMENTS = Arguments.testDefaults();
     private static final ResultsDirectory RESULTS_DIRECTORY = ResultsDirectory.defaultDirectory();
-    private static final String NAMESPACE = "test/";
     private static final String INSTANCE_NAME = "test-test";
     private static final String DONE = "DONE";
     private static final String FIRST_ZONE_NAME = "europe-west4-a";
@@ -48,11 +45,13 @@ public class ComputeEngineTest {
     private MockRuntimeBucket runtimeBucket;
     private Compute compute;
     private ImmutableVirtualMachineJobDefinition jobDefinition;
+    private Instance instance;
     private Compute.Instances instances;
     private Compute.ZoneOperations zoneOperations;
-    private Compute.Instances.Insert insert;
     private Compute.ZoneOperations.Get zoneOpGet;
     private ArgumentCaptor<Instance> instanceArgumentCaptor;
+    private InstanceLifecycleManager lifecycleManager;
+    private BucketCompletionWatcher bucketWatcher;
 
     @Before
     public void setUp() throws Exception {
@@ -62,12 +61,14 @@ public class ComputeEngineTest {
         when(images.getFromFamily(ARGUMENTS.project(), VirtualMachineJobDefinition.STANDARD_IMAGE)).thenReturn(getFromFamily);
 
         instanceArgumentCaptor = ArgumentCaptor.forClass(Instance.class);
-        insert = mock(Compute.Instances.Insert.class);
         Operation insertOperation = mock(Operation.class);
         when(insertOperation.getName()).thenReturn("insert");
         instances = mock(Compute.Instances.class);
-        when(instances.insert(eq(ARGUMENTS.project()), eq(FIRST_ZONE_NAME), instanceArgumentCaptor.capture())).thenReturn(insert);
-        when(insert.execute()).thenReturn(insertOperation);
+        lifecycleManager = mock(InstanceLifecycleManager.class);
+        instance = mock(Instance.class);
+        when(lifecycleManager.newInstance()).thenReturn(instance);
+        when(lifecycleManager.deleteOldInstancesAndStart(instanceArgumentCaptor.capture(), any(), any())).thenReturn(insertOperation);
+        when(instance.getName()).thenReturn(INSTANCE_NAME);
         Compute.Instances.Stop stop = mock(Compute.Instances.Stop.class);
         Operation stopOperation = mock(Operation.class);
         when(stopOperation.getName()).thenReturn("stop");
@@ -100,8 +101,8 @@ public class ComputeEngineTest {
         when(zones.list(ARGUMENTS.project())).thenReturn(zonesList);
         when(compute.zones()).thenReturn(zones);
 
-        victim = new ComputeEngine(ARGUMENTS, compute, z -> {
-        });
+        bucketWatcher = mock(BucketCompletionWatcher.class);
+        victim = new ComputeEngine(ARGUMENTS, compute, z -> {}, lifecycleManager, bucketWatcher);
         runtimeBucket = MockRuntimeBucket.test();
         jobDefinition = VirtualMachineJobDefinition.builder()
                 .name("test")
@@ -135,71 +136,49 @@ public class ComputeEngineTest {
     @Test
     public void disablesStartupScriptWhenScriptFailsRemotely() throws Exception {
         returnFailed();
-        ArgumentCaptor<Metadata> newMetadataCaptor = ArgumentCaptor.forClass(Metadata.class);
-        Compute.Instances.SetMetadata setMetadata = mock(Compute.Instances.SetMetadata.class);
-        Operation setMetadataOperation = mock(Operation.class);
-        String opName = "setMetadata";
-        when(setMetadataOperation.getName()).thenReturn(opName);
-        when(setMetadataOperation.getStatus()).thenReturn(DONE);
-        when(setMetadata.execute()).thenReturn(setMetadataOperation);
-        when(instances.setMetadata(eq(ARGUMENTS.project()),
-                eq(FIRST_ZONE_NAME),
-                eq(INSTANCE_NAME),
-                newMetadataCaptor.capture())).thenReturn(setMetadata);
-        when(zoneOperations.get(ARGUMENTS.project(), FIRST_ZONE_NAME, opName)).thenReturn(zoneOpGet);
-
-        Compute.Instances.Get get = mock(Compute.Instances.Get.class);
-        String fingerprint = "fingerprint";
-        Instance latest = new Instance().setMetadata(new Metadata().setFingerprint(fingerprint));
-        when(get.execute()).thenReturn(latest);
-        when(instances.get(ARGUMENTS.project(), FIRST_ZONE_NAME, INSTANCE_NAME)).thenReturn(get);
-
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
-        assertThat(newMetadataCaptor.getValue().getItems()).isNull();
-        assertThat(newMetadataCaptor.getValue().getFingerprint()).isEqualTo(fingerprint);
+        verify(lifecycleManager).disableStartupScript(FIRST_ZONE_NAME, INSTANCE_NAME);
     }
 
     @Test
     public void shouldSkipJobWhenSuccessFlagFileAlreadyExists() {
-        runtimeBucket = runtimeBucket.with(successBlob(), 1);
+        when(bucketWatcher.currentState(any(), any())).thenReturn(State.SUCCESS);
         assertThat(victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition)).isEqualTo(PipelineStatus.SKIPPED);
         verifyNoMoreInteractions(compute);
     }
 
     @Test
     public void shouldDeleteStateWhenFailureFlagExists() {
-        runtimeBucket = runtimeBucket.with(failureBlob(), 1);
+        when(bucketWatcher.currentState(any(), any())).thenReturn(State.FAILURE);
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
         verify(runtimeBucket.getRuntimeBucket(), times(1)).delete(BashStartupScript.JOB_FAILED_FLAG);
         verify(runtimeBucket.getRuntimeBucket(), times(1)).delete("results");
     }
 
     @Test
-    public void deletesVmWhenJobIsSuccessful() throws Exception {
+    public void deletesVmAfterJobIsSuccessful() throws Exception {
         returnSuccess();
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
-        verify(instances, times(1)).delete(ARGUMENTS.project(), FIRST_ZONE_NAME, INSTANCE_NAME);
+        verify(lifecycleManager).delete(FIRST_ZONE_NAME, INSTANCE_NAME);
     }
 
+
     @Test
-    public void retriesStopDeleteOperationsOnFailures() throws Exception {
+    public void stopsInstanceUponCompletion() throws Exception {
         returnSuccess();
-        Compute.Instances.Delete goingToFailOnce = mock(Compute.Instances.Delete.class);
-        Operation operation = mock(Operation.class);
-        when(goingToFailOnce.execute()).thenThrow(new IOException()).thenReturn(operation);
-        when(instances.delete(ARGUMENTS.project(), FIRST_ZONE_NAME, INSTANCE_NAME)).thenReturn(goingToFailOnce);
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
-        verify(goingToFailOnce, times(2)).execute();
+        verify(lifecycleManager).stop(FIRST_ZONE_NAME, INSTANCE_NAME);
     }
 
     @Test
     public void usesPublicNetworkIfNoPrivateSpecified() throws Exception {
         returnSuccess();
-        ArgumentCaptor<Instance> instanceArgumentCaptor = ArgumentCaptor.forClass(Instance.class);
+        ArgumentCaptor<List<NetworkInterface>> captor = ArgumentCaptor.forClass(List.class);
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
-        verify(instances).insert(any(), any(), instanceArgumentCaptor.capture());
-        List<NetworkInterface> networkInterfaces = instanceArgumentCaptor.getValue().getNetworkInterfaces();
-        assertThat(networkInterfaces).hasSize(1);
+
+        verify(instance).setNetworkInterfaces(captor.capture());
+        List<NetworkInterface> networkInterfaces = captor.getValue();
+        assertThat(networkInterfaces.size()).isEqualTo(1);
         assertThat(networkInterfaces.get(0).getNetwork()).isEqualTo(
                 "https://www.googleapis.com/compute/v1/projects/hmf-pipeline-development/global/networks/default");
     }
@@ -208,11 +187,12 @@ public class ComputeEngineTest {
     public void usesPrivateNetworkWhenSpecified() throws Exception {
         returnSuccess();
         victim = new ComputeEngine(Arguments.testDefaultsBuilder().privateNetwork("private").build(), compute, z -> {
-        });
-        ArgumentCaptor<Instance> instanceArgumentCaptor = ArgumentCaptor.forClass(Instance.class);
+        }, lifecycleManager, bucketWatcher);
+        ArgumentCaptor<List<NetworkInterface>> interfaceCaptor = ArgumentCaptor.forClass(List.class);
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
-        verify(instances).insert(any(), any(), instanceArgumentCaptor.capture());
-        List<NetworkInterface> networkInterfaces = instanceArgumentCaptor.getValue().getNetworkInterfaces();
+
+        verify(instance).setNetworkInterfaces(interfaceCaptor.capture());
+        List<NetworkInterface> networkInterfaces = interfaceCaptor.getValue();
         assertThat(networkInterfaces).hasSize(1);
         assertThat(networkInterfaces.get(0).getNetwork()).isEqualTo(
                 "https://www.googleapis.com/compute/v1/projects/hmf-pipeline-development/global/networks/private");
@@ -223,73 +203,40 @@ public class ComputeEngineTest {
 
     @Test
     public void triesMultipleZonesWhenResourcesExhausted() throws Exception {
-        Operation resourcesExhaused = new Operation().setStatus("DONE")
-                .setName("insert")
-                .setError(new Operation.Error().setErrors(Collections.singletonList(new Operation.Error.Errors().setCode(ComputeEngine.ZONE_EXHAUSTED_ERROR_CODE))));
-        when(insert.execute()).thenReturn(resourcesExhaused);
-        when(zoneOpGet.execute()).thenReturn(resourcesExhaused);
+        Operation resourcesExhausted = new Operation().setStatus("DONE").setName("insert")
+                .setError(new Operation.Error().setErrors(Collections.singletonList(
+                        new Operation.Error.Errors().setCode(ComputeEngine.ZONE_EXHAUSTED_ERROR_CODE))));
+        when(lifecycleManager.deleteOldInstancesAndStart(instance, FIRST_ZONE_NAME, INSTANCE_NAME))
+                .thenReturn(resourcesExhausted, mock(Operation.class));
+        when(bucketWatcher.currentState(any(), any())).thenReturn(State.STILL_WAITING, State.STILL_WAITING, State.SUCCESS);
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
-        verify(instances, times(1)).insert(eq(ARGUMENTS.project()), eq(SECOND_ZONE_NAME), any());
+        verify(lifecycleManager).deleteOldInstancesAndStart(instance, SECOND_ZONE_NAME, INSTANCE_NAME);
     }
 
     @Test
     public void setsVmsToPreemptibleWhenFlagEnabled() throws Exception {
         returnSuccess();
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
-        assertThat(instanceArgumentCaptor.getValue().getScheduling().getPreemptible()).isTrue();
+        verify(instance).setScheduling(eq(new Scheduling().setPreemptible(true)));
     }
 
     @Test
     public void restartsPreemptedInstanceInNextZone() throws Exception {
-        returnTerminated();
+        when(lifecycleManager.instanceStatus(any(), any())).thenReturn(ComputeEngine.PREEMPTED_INSTANCE);
+        when(bucketWatcher.currentState(any(), any()))
+                .thenReturn(State.STILL_WAITING, State.STILL_WAITING, State.SUCCESS);
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
-        verify(instances, times(1)).insert(eq(ARGUMENTS.project()), eq(SECOND_ZONE_NAME), any());
+        verify(lifecycleManager).deleteOldInstancesAndStart(instance, FIRST_ZONE_NAME, INSTANCE_NAME);
+        verify(lifecycleManager).deleteOldInstancesAndStart(instance, SECOND_ZONE_NAME, INSTANCE_NAME);
     }
 
     private void returnSuccess() throws IOException {
-        runtimeBucket = runtimeBucket.with(successBlob(), 1);
-        List<Blob> blobs = new ArrayList<>();
-        Blob mockBlob = mock(Blob.class);
-        mockReadChannel(mockBlob, successBlob());
-        blobs.add(mockBlob);
-        when(runtimeBucket.getRuntimeBucket().get(BashStartupScript.JOB_SUCCEEDED_FLAG)).thenReturn(mockBlob);
-        when(runtimeBucket.getRuntimeBucket().list()).thenReturn(new ArrayList<>()).thenReturn(new ArrayList<>()).thenReturn(blobs);
-    }
-
-    private void returnTerminated() throws IOException {
-        runtimeBucket = runtimeBucket.with(successBlob(), 1);
-        Compute.Instances.Get getInstances = mock(Compute.Instances.Get.class);
-        when(getInstances.execute()).thenReturn(new Instance().setStatus(ComputeEngine.PREEMPTED_INSTANCE));
-        when(instances.get(any(), any(), any())).thenReturn(getInstances);
-        when(runtimeBucket.getRuntimeBucket().get(BashStartupScript.JOB_SUCCEEDED_FLAG)).thenReturn(null);
-        when(runtimeBucket.getRuntimeBucket().get(BashStartupScript.JOB_FAILED_FLAG)).thenReturn(null);
-        when(runtimeBucket.getRuntimeBucket().list()).thenReturn(new ArrayList<>());
+        when(bucketWatcher.currentState(any(), any())).thenReturn(State.STILL_WAITING, State.SUCCESS);
+        Operation successOperation = mock(Operation.class);
+        when(lifecycleManager.deleteOldInstancesAndStart(any(), any(), any())).thenReturn(successOperation);
     }
 
     private void returnFailed() throws IOException {
-        runtimeBucket = runtimeBucket.with(failureBlob(), 1);
-        List<Blob> blobs = new ArrayList<>();
-        Blob mockBlob = mock(Blob.class);
-        mockReadChannel(mockBlob, failureBlob());
-        blobs.add(mockBlob);
-        when(runtimeBucket.getRuntimeBucket().get(BashStartupScript.JOB_FAILED_FLAG)).thenReturn(mockBlob);
-        when(runtimeBucket.getRuntimeBucket().list()).thenReturn(new ArrayList<>()).thenReturn(new ArrayList<>()).thenReturn(blobs);
-    }
-
-    private void mockReadChannel(final Blob mockBlob, final String value2) throws IOException {
-        ReadChannel mockReadChannel = mock(ReadChannel.class);
-        when(mockReadChannel.read(any())).thenReturn(-1);
-        when(mockBlob.getName()).thenReturn(value2);
-        when(mockBlob.getSize()).thenReturn(1L);
-        when(mockBlob.reader()).thenReturn(mockReadChannel);
-        when(mockBlob.getMd5()).thenReturn("");
-    }
-
-    private String successBlob() {
-        return NAMESPACE + BashStartupScript.JOB_SUCCEEDED_FLAG;
-    }
-
-    private String failureBlob() {
-        return NAMESPACE + BashStartupScript.JOB_FAILED_FLAG;
+        when(bucketWatcher.currentState(any(), any())).thenReturn(State.STILL_WAITING, State.FAILURE);
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/execution/vm/InstanceLifecycleManagerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/execution/vm/InstanceLifecycleManagerTest.java
@@ -1,0 +1,221 @@
+package com.hartwig.pipeline.execution.vm;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+
+import static com.hartwig.pipeline.SomaticPipelineTest.ARGUMENTS;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import com.google.api.services.compute.Compute;
+import com.google.api.services.compute.model.Instance;
+import com.google.api.services.compute.model.InstanceList;
+import com.google.api.services.compute.model.Operation;
+import com.google.api.services.compute.model.Zone;
+import com.google.api.services.compute.model.ZoneList;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+public class InstanceLifecycleManagerTest {
+    private static final String DONE_STATUS = "DONE";
+
+    private String zoneOne;
+    private String zoneTwo;
+    private String vmName;
+    private Compute compute;
+    private Compute.Instances instances;
+    private InstanceLifecycleManager victim;
+
+    @Before
+    public void setup() {
+        zoneOne = "zone-a";
+        zoneTwo = "zone-b";
+        vmName = "vm-name";
+        compute = mock(Compute.class);
+        instances = mock(Compute.Instances.class);
+        victim = new InstanceLifecycleManager(ARGUMENTS, compute);
+
+        when(compute.instances()).thenReturn(instances);
+    }
+
+    @Test
+    public void shouldReturnExistingInstance() throws Exception {
+        Compute.Instances.List zoneOneInstances = mock(Compute.Instances.List.class);
+        Compute.Instances.List zoneTwoInstances = mock(Compute.Instances.List.class);
+
+        InstanceList zoneOneInstanceList = mock(InstanceList.class);
+        InstanceList zoneTwoInstanceList = mock(InstanceList.class);
+
+        when(instances.list(ARGUMENTS.project(), zoneOne)).thenReturn(zoneOneInstances);
+        when(instances.list(ARGUMENTS.project(), zoneTwo)).thenReturn(zoneTwoInstances);
+
+        when(zoneOneInstances.execute()).thenReturn(zoneOneInstanceList);
+        when(zoneTwoInstances.execute()).thenReturn(zoneTwoInstanceList);
+
+        Instance vmInstance = namedInstance(vmName);
+        Instance someInstance = namedInstance();
+        Instance someOtherInstance = namedInstance();
+        when(zoneOneInstanceList.getItems()).thenReturn(singletonList(someInstance));
+        when(zoneTwoInstanceList.getItems()).thenReturn(asList(someOtherInstance, vmInstance));
+
+        Compute.Zones zones = mock(Compute.Zones.class);
+        Compute.Zones.List zonesList = mock(Compute.Zones.List.class);
+        List<Zone> stubbedZones = asList(zone(zoneOne), zone(zoneTwo));
+        when(zonesList.execute()).thenReturn(new ZoneList().setItems(stubbedZones));
+        when(compute.zones()).thenReturn(zones);
+        when(zones.list(ARGUMENTS.project())).thenReturn(zonesList);
+
+        Optional<Instance> found = victim.findExistingInstance(vmName);
+        assertThat(found).isNotEmpty();
+        assertThat(found.get()).isEqualTo(vmInstance);
+    }
+
+    @Test
+    public void shouldReturnEmptyOptionalIfNamedInstanceDoesNotExist() throws Exception {
+        Compute.Instances.List zoneOneInstances = mock(Compute.Instances.List.class);
+        Compute.Instances.List zoneTwoInstances = mock(Compute.Instances.List.class);
+
+        InstanceList zoneOneInstanceList = mock(InstanceList.class);
+        InstanceList zoneTwoInstanceList = mock(InstanceList.class);
+
+        when(instances.list(ARGUMENTS.project(), zoneOne)).thenReturn(zoneOneInstances);
+        when(instances.list(ARGUMENTS.project(), zoneTwo)).thenReturn(zoneTwoInstances);
+
+        when(zoneOneInstances.execute()).thenReturn(zoneOneInstanceList);
+        when(zoneTwoInstances.execute()).thenReturn(zoneTwoInstanceList);
+
+        List<Instance> zoneOneInstanceItems = singletonList(namedInstance());
+        List<Instance> zoneTwoInstanceItems = asList(namedInstance(), namedInstance());
+        when(zoneOneInstanceList.getItems()).thenReturn(zoneOneInstanceItems);
+        when(zoneTwoInstanceList.getItems()).thenReturn(zoneTwoInstanceItems);
+
+        Compute.Zones zones = mock(Compute.Zones.class);
+        Compute.Zones.List zonesList = mock(Compute.Zones.List.class);
+        List<Zone> stubbedZones = asList(zone(zoneOne), zone(zoneTwo));
+        when(zonesList.execute()).thenReturn(new ZoneList().setItems(stubbedZones));
+        when(compute.zones()).thenReturn(zones);
+        when(zones.list(ARGUMENTS.project())).thenReturn(zonesList);
+
+        Optional<Instance> found = victim.findExistingInstance(vmName);
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    public void shouldDelete() throws Exception {
+        Compute.Instances.Delete delete = mock(Compute.Instances.Delete.class);
+        Operation deleteOperation = mock(Operation.class);
+        String deleteOperationName = "delete";
+
+        when(instances.delete(ARGUMENTS.project(), zoneOne, vmName)).thenReturn(delete);
+        when(delete.execute()).thenReturn(deleteOperation);
+        when(deleteOperation.getName()).thenReturn(deleteOperationName);
+        when(deleteOperation.getStatus()).thenReturn(DONE_STATUS);
+
+        Compute.ZoneOperations zoneOperations = mock(Compute.ZoneOperations.class);
+        Compute.ZoneOperations.Get zoneOpsGet = mock(Compute.ZoneOperations.Get.class);
+        Operation statusOperation = mock(Operation.class);
+        when(compute.zoneOperations()).thenReturn(zoneOperations);
+        when(zoneOperations.get(ARGUMENTS.project(), zoneOne, deleteOperationName)).thenReturn(zoneOpsGet);
+        when(zoneOpsGet.execute()).thenReturn(statusOperation);
+        when(statusOperation.getStatus()).thenReturn(DONE_STATUS);
+
+        victim.delete(zoneOne, vmName);
+        verify(delete).execute();
+    }
+
+    @Test
+    public void shouldRetryDeleteIfNotAtFirstSuccessful() throws IOException {
+        Compute.Instances.Delete delete = mock(Compute.Instances.Delete.class);
+        Operation deleteOperation = mock(Operation.class);
+        String deleteOperationName = "delete";
+
+        when(instances.delete(ARGUMENTS.project(), zoneOne, vmName)).thenThrow(new IOException()).thenReturn(delete);
+        when(delete.execute()).thenReturn(deleteOperation);
+        when(deleteOperation.getName()).thenReturn(deleteOperationName);
+        when(deleteOperation.getStatus()).thenReturn(DONE_STATUS);
+
+        Compute.ZoneOperations zoneOperations = mock(Compute.ZoneOperations.class);
+        Compute.ZoneOperations.Get zoneOpsGet = mock(Compute.ZoneOperations.Get.class);
+        Operation statusOperation = mock(Operation.class);
+        when(compute.zoneOperations()).thenReturn(zoneOperations);
+        when(zoneOperations.get(ARGUMENTS.project(), zoneOne, deleteOperationName)).thenReturn(zoneOpsGet);
+        when(zoneOpsGet.execute()).thenReturn(statusOperation);
+        when(statusOperation.getStatus()).thenReturn(DONE_STATUS);
+
+        victim.delete(zoneOne, vmName);
+        verify(delete).execute();
+    }
+
+    @Test
+    public void shouldStop() throws Exception {
+        Compute.Instances.Stop stop = mock(Compute.Instances.Stop.class);
+        Operation stopOperation = mock(Operation.class);
+        String stopOperationName = "stoperation";
+
+        when(instances.stop(ARGUMENTS.project(), zoneOne, vmName)).thenReturn(stop);
+        when(stop.execute()).thenReturn(stopOperation);
+        when(stopOperation.getName()).thenReturn(stopOperationName);
+        when(stopOperation.getStatus()).thenReturn(DONE_STATUS);
+
+        Compute.ZoneOperations zoneOperations = mock(Compute.ZoneOperations.class);
+        Compute.ZoneOperations.Get zoneOpsGet = mock(Compute.ZoneOperations.Get.class);
+        Operation statusOperation = mock(Operation.class);
+        when(compute.zoneOperations()).thenReturn(zoneOperations);
+        when(zoneOperations.get(ARGUMENTS.project(), zoneOne, stopOperationName)).thenReturn(zoneOpsGet);
+        when(zoneOpsGet.execute()).thenReturn(statusOperation);
+        when(statusOperation.getStatus()).thenReturn(DONE_STATUS);
+
+        victim.stop(zoneOne, vmName);
+        verify(stop).execute();
+    }
+
+    @Test
+    public void shouldRetryStopIfNotAtFirstSuccessful() throws Exception {
+        Compute.Instances.Stop stop = mock(Compute.Instances.Stop.class);
+        Operation stopOperation = mock(Operation.class);
+        String stopOperationName = "stoperation";
+
+        when(instances.stop(ARGUMENTS.project(), zoneOne, vmName)).thenThrow(new IOException()).thenReturn(stop);
+        when(stop.execute()).thenReturn(stopOperation);
+        when(stopOperation.getName()).thenReturn(stopOperationName);
+        when(stopOperation.getStatus()).thenReturn(DONE_STATUS);
+
+        Compute.ZoneOperations zoneOperations = mock(Compute.ZoneOperations.class);
+        Compute.ZoneOperations.Get zoneOpsGet = mock(Compute.ZoneOperations.Get.class);
+        Operation statusOperation = mock(Operation.class);
+        when(compute.zoneOperations()).thenReturn(zoneOperations);
+        when(zoneOperations.get(ARGUMENTS.project(), zoneOne, stopOperationName)).thenReturn(zoneOpsGet);
+        when(zoneOpsGet.execute()).thenReturn(statusOperation);
+        when(statusOperation.getStatus()).thenReturn(DONE_STATUS);
+
+        victim.stop(zoneOne, vmName);
+        verify(stop).execute();
+    }
+
+    private Zone zone(String name) {
+        Zone zone = mock(Zone.class);
+        when(zone.getName()).thenReturn(name);
+        when(zone.getRegion()).thenReturn("someregion-" + ARGUMENTS.region());
+        return zone;
+    }
+
+    private Instance namedInstance() {
+        return namedInstance(null);
+    }
+
+    private Instance namedInstance(String providedName) {
+        String name = providedName == null ? RandomStringUtils.random(10) : providedName;
+        Instance instance = mock(Instance.class);
+        when(instance.getName()).thenReturn(name);
+        return instance;
+    }
+}


### PR DESCRIPTION
Refactor the ComputeEngine code to improve separation of concerns and
make it easier to fix problems. Also correct some stability issues.

Also make it so some jobs won't use pre-emptible VMs.  Regardless of
what the user requests, some VMs are better off without the
pre-emptible VMs because they run too long. For now GRIDSS is the
only one I'm adding this to.