### PR TITLE
DEV-929 Add linx to pipeline

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/SomaticPipeline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/SomaticPipeline.java
@@ -25,6 +25,7 @@ import com.hartwig.pipeline.tertiary.amber.AmberOutput;
 import com.hartwig.pipeline.tertiary.cobalt.Cobalt;
 import com.hartwig.pipeline.tertiary.cobalt.CobaltOutput;
 import com.hartwig.pipeline.tertiary.healthcheck.HealthChecker;
+import com.hartwig.pipeline.tertiary.linx.Linx;
 import com.hartwig.pipeline.tertiary.purple.Purple;
 import com.hartwig.pipeline.tertiary.purple.PurpleOutput;
 
@@ -99,6 +100,9 @@ public class SomaticPipeline {
                         BamMetricsOutput referenceMetrics = bamMetricsOutputStorage.get(metadata.reference());
                         pipelineResults.add(state.add(stageRunner.run(metadata,
                                 new HealthChecker(referenceMetrics, tumorMetrics, amberOutput, purpleOutput))));
+                        if (state.shouldProceed()) {
+                            state.add(stageRunner.run(metadata, new Linx(purpleOutput)));
+                        }
                         pipelineResults.compose(metadata);
                     }
                 }

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/ResourceDownload.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/ResourceDownload.java
@@ -13,7 +13,7 @@ import com.hartwig.pipeline.storage.RuntimeBucket;
 
 public class ResourceDownload implements BashCommand {
 
-    private static final String RESOURCES_PATH = "/data/resources";
+    public static final String RESOURCES_PATH = "/data/resources";
     private final Resource resource;
     private final ResourceLocation resourceLocation;
 

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
@@ -140,4 +140,13 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
                 .namespacedResults(resultsDirectory)
                 .build();
     }
+
+    static VirtualMachineJobDefinition linx(BashStartupScript startupScript, ResultsDirectory resultsDirectory) {
+        return ImmutableVirtualMachineJobDefinition.builder()
+                .name("linx")
+                .startupCommand(startupScript)
+                .namespacedResults(resultsDirectory)
+                .performanceProfile(VirtualMachinePerformanceProfile.custom(4, 12))
+                .build();
+    }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/LocalSomaticMetadataApi.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/LocalSomaticMetadataApi.java
@@ -24,7 +24,7 @@ public class LocalSomaticMetadataApi implements SomaticMetadataApi {
                         .sampleName(arguments.setId() + "T")
                         .build())
                 .reference(SingleSampleRunMetadata.builder()
-                        .type(SingleSampleRunMetadata.SampleType.TUMOR)
+                        .type(SingleSampleRunMetadata.SampleType.REFERENCE)
                         .sampleId(arguments.setId() + "R")
                         .sampleName(arguments.setId() + "R")
                         .build())

--- a/cluster/src/main/java/com/hartwig/pipeline/resource/ResourceNames.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/resource/ResourceNames.java
@@ -5,7 +5,7 @@ public interface ResourceNames {
     String REFERENCE_GENOME = "reference_genome";
     String DBSNPS = "dbsnps";
     String GENOTYPE_SNPS = "genotype_snps";
-    String GC_PROFILE  = "gc";
+    String GC_PROFILE = "gc";
     String STRELKA_CONFIG = "strelka_config";
     String MAPPABILITY = "mappability";
     String PON = "pon";
@@ -18,4 +18,7 @@ public interface ResourceNames {
     String GONL = "gonl_v5";
     String GRIDSS_CONFIG = "gridss_config";
     String GRIDSS_PON = "gridss_pon";
+    String SV = "sv";
+    String ENSEMBL = "ensembl";
+    String KNOWLEDGEBASES = "knowledgebases";
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/Linx.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/Linx.java
@@ -1,0 +1,103 @@
+package com.hartwig.pipeline.tertiary.linx;
+
+import static com.hartwig.pipeline.resource.ResourceNames.ENSEMBL;
+import static com.hartwig.pipeline.resource.ResourceNames.KNOWLEDGEBASES;
+import static com.hartwig.pipeline.resource.ResourceNames.REFERENCE_GENOME;
+import static com.hartwig.pipeline.resource.ResourceNames.SV;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import com.google.cloud.storage.Storage;
+import com.google.common.collect.ImmutableList;
+import com.hartwig.pipeline.Arguments;
+import com.hartwig.pipeline.ResultsDirectory;
+import com.hartwig.pipeline.execution.PipelineStatus;
+import com.hartwig.pipeline.execution.vm.BashCommand;
+import com.hartwig.pipeline.execution.vm.BashStartupScript;
+import com.hartwig.pipeline.execution.vm.InputDownload;
+import com.hartwig.pipeline.execution.vm.ResourceDownload;
+import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
+import com.hartwig.pipeline.execution.vm.VmDirectories;
+import com.hartwig.pipeline.metadata.SomaticRunMetadata;
+import com.hartwig.pipeline.report.EntireOutputComponent;
+import com.hartwig.pipeline.report.Folder;
+import com.hartwig.pipeline.stages.Stage;
+import com.hartwig.pipeline.storage.RuntimeBucket;
+import com.hartwig.pipeline.tertiary.purple.PurpleOutput;
+
+public class Linx implements Stage<LinxOutput, SomaticRunMetadata> {
+
+    public static final String NAMESPACE = "linx";
+    private final InputDownload purpleOutputDir;
+
+    public Linx(PurpleOutput purpleOutput) {
+        purpleOutputDir = new InputDownload(purpleOutput.outputDirectory());
+    }
+
+    @Override
+    public List<BashCommand> inputs() {
+        return Collections.singletonList(purpleOutputDir);
+    }
+
+    @Override
+    public List<ResourceDownload> resources(final Storage storage, final String resourceBucket, final RuntimeBucket bucket) {
+        return ImmutableList.of(ResourceDownload.from(storage, resourceBucket, REFERENCE_GENOME, bucket),
+                ResourceDownload.from(storage, resourceBucket, SV, bucket),
+                ResourceDownload.from(storage, resourceBucket, KNOWLEDGEBASES, bucket),
+                ResourceDownload.from(storage, resourceBucket, ENSEMBL, bucket));
+    }
+
+    @Override
+    public String namespace() {
+        return NAMESPACE;
+    }
+
+    @Override
+    public List<BashCommand> commands(final SomaticRunMetadata metadata, final Map<String, ResourceDownload> resources) {
+        ResourceDownload svResources = resources.get(SV);
+        ResourceDownload knowledgebases = resources.get(KNOWLEDGEBASES);
+        return Collections.singletonList(new LinxCommand(metadata.tumor().sampleName(),
+                purpleSvVcf(metadata),
+                purpleOutputDir.getLocalTargetPath(),
+                resources.get(REFERENCE_GENOME).find("fasta"),
+                VmDirectories.OUTPUT,
+                svResources.find("fragile_sites_hmf.csv"),
+                svResources.find("line_elements.csv"),
+                svResources.find("heli_rep_origins.bed"),
+                svResources.find("viral_host_ref.csv"),
+                ResourceDownload.RESOURCES_PATH,
+                knowledgebases.find("knownFusionPairs.csv"),
+                knowledgebases.find("knownPromiscuousFive.csv"),
+                knowledgebases.find("knownPromiscuousThree.csv")));
+    }
+
+    private String purpleSvVcf(final SomaticRunMetadata metadata) {
+        return purpleOutputDir.getLocalTargetPath() + "/" + metadata.tumor().sampleName() + ".purple.sv.vcf.gz";
+    }
+
+    @Override
+    public VirtualMachineJobDefinition vmDefinition(final BashStartupScript bash, final ResultsDirectory resultsDirectory) {
+        return VirtualMachineJobDefinition.linx(bash, resultsDirectory);
+    }
+
+    @Override
+    public LinxOutput output(final SomaticRunMetadata metadata, final PipelineStatus jobStatus, final RuntimeBucket bucket,
+            final ResultsDirectory resultsDirectory) {
+        return LinxOutput.builder()
+                .status(jobStatus)
+                .addReportComponents(new EntireOutputComponent(bucket, Folder.from(), NAMESPACE, resultsDirectory))
+                .build();
+    }
+
+    @Override
+    public LinxOutput skippedOutput(final SomaticRunMetadata metadata) {
+        return LinxOutput.builder().status(PipelineStatus.SKIPPED).build();
+    }
+
+    @Override
+    public boolean shouldRun(final Arguments arguments) {
+        return arguments.runTertiary();
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/LinxCommand.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/LinxCommand.java
@@ -1,0 +1,48 @@
+package com.hartwig.pipeline.tertiary.linx;
+
+import com.google.common.collect.ImmutableList;
+import com.hartwig.pipeline.execution.vm.JavaJarCommand;
+import com.hartwig.pipeline.tools.Versions;
+
+class LinxCommand extends JavaJarCommand {
+    LinxCommand(final String sample, final String svVcf, final String purpleDir, final String referenceGenome, final String outputDir,
+            final String fragileSiteFile, final String lineElementFile, final String replicationsOriginsFile, final String viralHostsFile,
+            final String geneTranscriptsDirectory, final String fusionsPairsCsv, final String promiscuousFiveCsv,
+            final String promiscuousThreeCsv) {
+        super("linx",
+                Versions.LINX,
+                "linx.jar",
+                "8G",
+                ImmutableList.<String>builder().add("-sample",
+                        sample,
+                        "-sv_vcf",
+                        svVcf,
+                        "-purple_dir",
+                        purpleDir,
+                        "-ref_genome",
+                        referenceGenome,
+                        "-output_dir",
+                        outputDir,
+                        "-fragile_site_file",
+                        fragileSiteFile,
+                        "-line_element_file",
+                        lineElementFile,
+                        "-replication_origins_file",
+                        replicationsOriginsFile,
+                        "-viral_hosts_file",
+                        viralHostsFile,
+                        "-gene_transcripts_dir",
+                        geneTranscriptsDirectory,
+                        "-check_fusions",
+                        "-fusion_pairs_csv",
+                        fusionsPairsCsv,
+                        "-promiscuous_five_csv",
+                        promiscuousFiveCsv,
+                        "-promiscuous_three_csv",
+                        promiscuousThreeCsv,
+                        "-chaining_sv_limit",
+                        "0",
+                        "-check_drivers",
+                        "-write_vis_data").build());
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/LinxOutput.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/LinxOutput.java
@@ -1,0 +1,18 @@
+package com.hartwig.pipeline.tertiary.linx;
+
+import com.hartwig.pipeline.StageOutput;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface LinxOutput extends StageOutput{
+
+    @Override
+    default String name() {
+        return Linx.NAMESPACE;
+    }
+
+    static ImmutableLinxOutput.Builder builder() {
+        return ImmutableLinxOutput.builder();
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
@@ -25,6 +25,7 @@ public interface Versions {
     String PURPLE = "2.34";
     String CIRCOS = "0.69.6";
     String GRIDSS = "2.5.2";
+    String LINX = "1.4";
 
     static void printAll() {
         Logger logger = LoggerFactory.getLogger(Versions.class);

--- a/cluster/src/test/java/com/hartwig/pipeline/SomaticPipelineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/SomaticPipelineTest.java
@@ -146,27 +146,6 @@ public class SomaticPipelineTest {
     }
 
     @Test
-    public void doesNotRunLinxWhenWhenHealthCheckFails() {
-        bothAlignmentsAvailable();
-        bothMetricsAvailable();
-        when(structuralCaller.run(defaultSomaticRunMetadata(), defaultPair())).thenReturn(structuralCallerOutput());
-        HealthCheckOutput failHealthCheck = HealthCheckOutput.builder().status(PipelineStatus.FAILED).build();
-        when(stageRunner.run(eq(defaultSomaticRunMetadata()), any())).thenReturn(amberOutput())
-                .thenReturn(cobaltOutput())
-                .thenReturn(somaticCallerOutput())
-                .thenReturn(purpleOutput())
-                .thenReturn(failHealthCheck);
-        PipelineState state = victim.run();
-        assertThat(state.stageOutputs()).containsExactlyInAnyOrder(cobaltOutput(),
-                amberOutput(),
-                somaticCallerOutput(),
-                structuralCallerOutput(),
-                purpleOutput(),
-                failHealthCheck);
-        assertThat(state.status()).isEqualTo(PipelineStatus.FAILED);
-    }
-
-    @Test
     public void notifiesSetMetadataApiOnSuccessfulRun() {
         successfulRun();
         victim.run();
@@ -226,7 +205,8 @@ public class SomaticPipelineTest {
                 .thenReturn(cobaltOutput())
                 .thenReturn(somaticCallerOutput())
                 .thenReturn(purpleOutput())
-                .thenReturn(HealthCheckOutput.builder().from(healthCheckerOutput()).status(PipelineStatus.QC_FAILED).build());
+                .thenReturn(HealthCheckOutput.builder().from(healthCheckerOutput()).status(PipelineStatus.QC_FAILED).build())
+                .thenReturn(linxOutput());
         PipelineState state = victim.run();
         assertThat(state.status()).isEqualTo(PipelineStatus.QC_FAILED);
     }

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/linx/LinxTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/linx/LinxTest.java
@@ -1,0 +1,62 @@
+package com.hartwig.pipeline.tertiary.linx;
+
+import static com.hartwig.pipeline.resource.ResourceNames.ENSEMBL;
+import static com.hartwig.pipeline.resource.ResourceNames.KNOWLEDGEBASES;
+import static com.hartwig.pipeline.resource.ResourceNames.REFERENCE_GENOME;
+import static com.hartwig.pipeline.resource.ResourceNames.SV;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import com.hartwig.pipeline.metadata.SomaticRunMetadata;
+import com.hartwig.pipeline.stages.Stage;
+import com.hartwig.pipeline.tertiary.TertiaryStageTest;
+import com.hartwig.pipeline.testsupport.MockResource;
+import com.hartwig.pipeline.testsupport.TestInputs;
+
+import org.junit.Before;
+
+public class LinxTest extends TertiaryStageTest<LinxOutput> {
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        MockResource.addToStorage(storage, REFERENCE_GENOME, "reference.fasta");
+        MockResource.addToStorage(storage, SV, "viral_host_ref.csv", "fragile_sites_hmf.csv", "line_elements.csv", "heli_rep_origins.bed");
+        MockResource.addToStorage(storage, KNOWLEDGEBASES, "knownFusionPairs.csv", "knownPromiscuousFive.csv", "knownPromiscuousThree.csv");
+        MockResource.addToStorage(storage, ENSEMBL, "ensembl_data_cache");
+    }
+
+    @Override
+    protected List<String> expectedInputs() {
+        return Collections.singletonList(input("run-reference-tumor-test/purple/results/", "results"));
+    }
+
+    @Override
+    protected Stage<LinxOutput, SomaticRunMetadata> createVictim() {
+        return new Linx(TestInputs.purpleOutput());
+    }
+
+    @Override
+    protected List<String> expectedResources() {
+        return ImmutableList.of(resource(REFERENCE_GENOME), resource(SV), resource(KNOWLEDGEBASES), resource(ENSEMBL));
+    }
+
+    @Override
+    protected List<String> expectedCommands() {
+        return Collections.singletonList("java -Xmx8G -jar $TOOLS_DIR/linx/1.4/linx.jar -sample tumor -sv_vcf "
+                + "/data/input/results/tumor.purple.sv.vcf.gz -purple_dir /data/input/results -ref_genome /data/resources/reference.fasta "
+                + "-output_dir /data/output -fragile_site_file /data/resources/fragile_sites_hmf.csv -line_element_file "
+                + "/data/resources/line_elements.csv -replication_origins_file /data/resources/heli_rep_origins.bed -viral_hosts_file "
+                + "/data/resources/viral_host_ref.csv -gene_transcripts_dir /data/resources -check_fusions -fusion_pairs_csv "
+                + "/data/resources/knownFusionPairs.csv -promiscuous_five_csv /data/resources/knownPromiscuousFive.csv "
+                + "-promiscuous_three_csv /data/resources/knownPromiscuousThree.csv -chaining_sv_limit 0 -check_drivers -write_vis_data");
+    }
+
+    @Override
+    protected void validateOutput(final LinxOutput output) {
+        // no additional validation
+    }
+}

--- a/cluster/src/test/java/com/hartwig/pipeline/testsupport/TestInputs.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/testsupport/TestInputs.java
@@ -23,6 +23,7 @@ import com.hartwig.pipeline.tertiary.cobalt.Cobalt;
 import com.hartwig.pipeline.tertiary.cobalt.CobaltOutput;
 import com.hartwig.pipeline.tertiary.healthcheck.HealthCheckOutput;
 import com.hartwig.pipeline.tertiary.healthcheck.HealthChecker;
+import com.hartwig.pipeline.tertiary.linx.LinxOutput;
 import com.hartwig.pipeline.tertiary.purple.Purple;
 import com.hartwig.pipeline.tertiary.purple.PurpleOutput;
 
@@ -167,6 +168,12 @@ public class TestInputs {
         return HealthCheckOutput.builder()
                 .status(PipelineStatus.SUCCESS)
                 .maybeOutputDirectory(gsLocation(somaticBucket(HealthChecker.NAMESPACE), RESULTS))
+                .build();
+    }
+
+    public static LinxOutput linxOutput() {
+        return LinxOutput.builder()
+                .status(PipelineStatus.SUCCESS)
                 .build();
     }
 


### PR DESCRIPTION
Creates a new stage, linx. Linx is an HMF tool used to enrich structural
variants with annotations, interpretations and visualizations.

Linx takes purple's SV vcf (originally from gridss) as input as well as
several databases of known variants, genes, etc. In the end its a single
command.

Linx runs after the health check.