### PR TITLE
DEV-968 Validate the fastq filename before parsing lanes

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/sample/FastqNamingConvention.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/sample/FastqNamingConvention.java
@@ -1,0 +1,16 @@
+package com.hartwig.pipeline.alignment.sample;
+
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+public class FastqNamingConvention implements Predicate<String> {
+
+    @Override
+    public boolean test(final String s) {
+        return Pattern.matches("(.*_){2}S[0-9]+_L[0-9]{3}_R[1-2].*", s);
+    }
+
+    public static boolean apply(final String fastqFileName) {
+        return new FastqNamingConvention().test(fastqFileName);
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/sample/SbpSampleReader.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/sample/SbpSampleReader.java
@@ -87,6 +87,15 @@ public class SbpSampleReader {
     }
 
     private static ImmutableLane lane(final SbpFastQ sbpFastQ) {
+
+        if (!FastqNamingConvention.apply(sbpFastQ.name_r1())) {
+            throw new IllegalArgumentException(String.format(
+                    "Unable to extract flowcell and sample index from fastq name [%s]. Failing this run. Please "
+                            + "rename fastq files to the correct convention "
+                            + "{samplename}_{flowcell}_{sampleindex}_{laneindex}_{pairindex}_{suffix}.fastq.[gz].",
+                    sbpFastQ.name_r1()));
+        }
+
         String bucket = sbpFastQ.bucket();
         if (bucket == null || bucket.isEmpty()) {
             throw new IllegalStateException(format("Bucket for fastq [%s] was null or empty. Has this sample id been cleaned up in S3?",
@@ -103,7 +112,7 @@ public class SbpSampleReader {
                 .directory("")
                 .suffix("")
                 .flowCellId(flowCellId)
-                .index("0")
+                .index(tokens[2])
                 .build();
     }
 

--- a/cluster/src/test/java/com/hartwig/pipeline/alignment/sample/FastqNamingConventionTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/alignment/sample/FastqNamingConventionTest.java
@@ -1,0 +1,57 @@
+package com.hartwig.pipeline.alignment.sample;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class FastqNamingConventionTest {
+
+    @Test
+    public void trueWhenConventionIsMatched() {
+        assertThat(test("CPCT12345678R_HJJLGCCXX_S11_L001_R1_001.fastq.gz")).isTrue();
+    }
+
+    @Test
+    public void missingFlowcell() {
+        assertThat(test("CPCT12345678R_S1_L001_R1_001.fastq.gz")).isFalse();
+    }
+
+    @Test
+    public void missingSample() {
+        assertThat(test("HJJLGCCXX_S1_L001_R1_001.fastq.gz")).isFalse();
+    }
+
+    @Test
+    public void missingSampleIndex() {
+        assertThat(test("CPCT12345678R_HJJLGCCXX_L001_R1_001.fastq.gz")).isFalse();
+    }
+
+    @Test
+    public void missingLaneIndex() {
+        assertThat(test("CPCT12345678R_HJJLGCCXX_S1_R1_001.fastq.gz")).isFalse();
+    }
+
+    @Test
+    public void missingPairId() {
+        assertThat(test("CPCT12345678R_HJJLGCCXX_S1_L001_001.fastq.gz")).isFalse();
+    }
+
+    @Test
+    public void nonNumericSampleIndex() {
+        assertThat(test("CPCT12345678R_HJJLGCCXX_SA_L001_R1_001.fastq.gz")).isFalse();
+    }
+
+    @Test
+    public void nonNumericLaneIndex() {
+        assertThat(test("CPCT12345678R_HJJLGCCXX_SA_LABC_R1_001.fastq.gz")).isFalse();
+    }
+
+    @Test
+    public void impossiblePairEnd() {
+        assertThat(test("CPCT12345678R_HJJLGCCXX_SA_L001_R3_001.fastq.gz")).isFalse();
+    }
+
+    private static boolean test(final String s) {
+        return new FastqNamingConvention().test(s);
+    }
+}

--- a/cluster/src/test/java/com/hartwig/pipeline/alignment/sample/SbpSampleReaderTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/alignment/sample/SbpSampleReaderTest.java
@@ -5,14 +5,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 
 import com.hartwig.patient.Sample;
+import com.hartwig.pipeline.metadata.TestJson;
 import com.hartwig.pipeline.sbpapi.SbpRestApi;
-import com.hartwig.support.test.Resources;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -22,11 +19,12 @@ public class SbpSampleReaderTest {
     private static final int EXISTS = 64;
 
     private static final String SAMPLE_NAME = "CPCT02330029T";
-    private static final String FASTQ_JSON = "sbp_api/get_fastq.json";
-    private static final String FASTQ_JSON_SINGLE_QC_FAILED = "sbp_api/get_fastq_qc_failed.json";
-    private static final String FASTQ_JSON_ALL_QC_FAILED = "sbp_api/get_fastq_all_qc_failed.json";
-    private static final String FASTQ_JSON_SUBDIRECTORIES = "sbp_api/get_fastq_subdirectories.json";
-    private static final String SAMPLE_JSON = "sbp_api/get_sample.json";
+    private static final String FASTQ_JSON = "get_fastq";
+    private static final String FASTQ_JSON_SINGLE_QC_FAILED = "get_fastq_qc_failed";
+    private static final String FASTQ_JSON_ALL_QC_FAILED = "get_fastq_all_qc_failed";
+    private static final String FASTQ_JSON_SUBDIRECTORIES = "get_fastq_subdirectories";
+    private static final String SAMPLE_JSON = "get_sample";
+    private static final String BAD_FASTQ_NAME = "get_fastq_bad_filename";
     private SbpRestApi sbpRestApi;
     private SbpSampleReader victim;
 
@@ -34,7 +32,7 @@ public class SbpSampleReaderTest {
     public void setUp() throws Exception {
         sbpRestApi = mock(SbpRestApi.class);
         victim = new SbpSampleReader(sbpRestApi);
-        when(sbpRestApi.getSample(EXISTS)).thenReturn(testJson(SAMPLE_JSON));
+        when(sbpRestApi.getSample(EXISTS)).thenReturn(TestJson.get(SAMPLE_JSON));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -66,6 +64,14 @@ public class SbpSampleReaderTest {
     }
 
     @Test
+    public void getsFlowcellAndIndexFromFileName()  throws Exception {
+        returnJson(FASTQ_JSON);
+        Sample sample = victim.read(EXISTS);
+        assertThat(sample.lanes().get(0).flowCellId()).isEqualTo("HJKLMALXX");
+        assertThat(sample.lanes().get(0).index()).isEqualTo("S6");
+    }
+
+    @Test
     public void filtersLanesWhichHaveNotPassedQC() throws Exception {
         returnJson(FASTQ_JSON_SINGLE_QC_FAILED);
         Sample sample = victim.read(EXISTS);
@@ -82,17 +88,18 @@ public class SbpSampleReaderTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void throwsIllegalArgumentWhenAllLanesFilteredQc() throws Exception{
+    public void throwsIllegalArgumentWhenAllLanesFilteredQc() throws Exception {
         returnJson(FASTQ_JSON_ALL_QC_FAILED);
-        Sample sample = victim.read(EXISTS);
+        victim.read(EXISTS);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsIllegalArgumentWhenFastqNameIncorrect() throws Exception {
+        returnJson(BAD_FASTQ_NAME);
+        victim.read(EXISTS);
     }
 
     private void returnJson(final String sampleJsonLocation) throws IOException {
-        when(sbpRestApi.getFastQ(EXISTS)).thenReturn(testJson(sampleJsonLocation));
-    }
-
-    @NotNull
-    private String testJson(final String sampleJsonLocation) throws IOException {
-        return new String(Files.readAllBytes(Paths.get(Resources.testResource(sampleJsonLocation))));
+        when(sbpRestApi.getFastQ(EXISTS)).thenReturn(TestJson.get(sampleJsonLocation));
     }
 }

--- a/cluster/src/test/resources/sbp_api/get_fastq_bad_filename.json
+++ b/cluster/src/test/resources/sbp_api/get_fastq_bad_filename.json
@@ -1,0 +1,32 @@
+[
+  {
+    "qc_pass": true,
+    "q30": 55.9669,
+    "sample_id": 64,
+    "id": 91,
+    "name_r1": "not_a_file.fastq.gz",
+    "name_r2": "CPCT02330029T_HJKLMALXX_S6_L001_R2_001.fastq.gz",
+    "lane_id": 58,
+    "bucket": "test",
+    "yld": 59702984,
+    "hash_r2": null,
+    "hash_r1": null,
+    "size_r2": null,
+    "size_r1": null
+  },
+  {
+    "qc_pass": true,
+    "q30": 56.4214,
+    "sample_id": 64,
+    "id": 94,
+    "name_r1": "CPCT02330029T_HJKLMALXX_S6_L002_R1_001.fastq.gz",
+    "name_r2": "CPCT02330029T_HJKLMALXX_S6_L002_R2_001.fastq.gz",
+    "lane_id": 61,
+    "bucket": "test",
+    "yld": 60673310,
+    "hash_r2": null,
+    "hash_r1": null,
+    "size_r2": null,
+    "size_r1": null
+  }
+]


### PR DESCRIPTION
We have a dependency on the file naming of fastq files which is a bit
hidden. If a file was to not follow the convention you'd get odd
failures (like index out of bounds).

This change adds explicit validation of the file naming and fails hard
on a clear exception if the file is unparseable.