### PR TITLE
DEV-988 Remove pre-emptible flag from job definition

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/ComputeEngine.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/ComputeEngine.java
@@ -56,7 +56,7 @@ public class ComputeEngine implements CloudExecutor<VirtualMachineJobDefinition>
     private final InstanceLifecycleManager lifecycleManager;
     private final BucketCompletionWatcher bucketWatcher;
 
-    public ComputeEngine(final Arguments arguments, final Compute compute, final Consumer<List<Zone>> zoneRandomizer,
+    ComputeEngine(final Arguments arguments, final Compute compute, final Consumer<List<Zone>> zoneRandomizer,
             InstanceLifecycleManager lifecycleManager, BucketCompletionWatcher bucketWatcher) {
         this.arguments = arguments;
         this.compute = compute;
@@ -97,7 +97,7 @@ public class ComputeEngine implements CloudExecutor<VirtualMachineJobDefinition>
                 Instance instance = lifecycleManager.newInstance();
                 instance.setName(vmName);
                 instance.setZone(currentZone.getName());
-                if (arguments.usePreemptibleVms() && jobDefinition.preemptible()) {
+                if (arguments.usePreemptibleVms()) {
                     instance.setScheduling(new Scheduling().setPreemptible(true));
                 }
                 instance.setMachineType(machineType(currentZone.getName(), jobDefinition.performanceProfile().uri(), project));

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
@@ -19,11 +19,6 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
 
     ResultsDirectory namespacedResults();
 
-    @Value.Default
-    default boolean preemptible() {
-        return true;
-    }
-
     @Override
     @Value.Default
     default VirtualMachinePerformanceProfile performanceProfile() {
@@ -65,7 +60,6 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
                 .name("gridss")
                 .startupCommand(startupScript)
                 .performanceProfile(VirtualMachinePerformanceProfile.custom(24, 120))
-                .preemptible(false)
                 .namespacedResults(resultsDirectory)
                 .build();
     }


### PR DESCRIPTION
As gridss was the only vm "disabled", no need for the distinction.