### PR TITLE
DEV-980 Bump jersey to jdk 11 compatible

### DIFF
--- a/cluster/pom.xml
+++ b/cluster/pom.xml
@@ -63,6 +63,10 @@
             <artifactId>jersey-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <google-cloud.version>1.40.0</google-cloud.version>
         <commons-cli.version>1.4</commons-cli.version>
         <google-cloud-nio.version>0.61.0-alpha</google-cloud-nio.version>
-        <jersey.version>2.25</jersey.version>
+        <jersey.version>2.29.1</jersey.version>
         <javax.ws.rs-api.version>2.1</javax.ws.rs-api.version>
         <protobuf-java.version>3.6.1</protobuf-java.version>
         <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
@@ -84,6 +84,11 @@
             <dependency>
                 <groupId>org.glassfish.jersey.core</groupId>
                 <artifactId>jersey-client</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.inject</groupId>
+                <artifactId>jersey-hk2</artifactId>
                 <version>${jersey.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Also requires the addition of the jerser-hk2 module, for some sneaky
service injecting.