### PR TITLE
DEV-999 Regig the upload copy

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/OutputUpload.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/OutputUpload.java
@@ -16,7 +16,7 @@ public class OutputUpload implements BashCommand {
     @Override
     public String asBash() {
         return new SubShellCommand(() ->
-                format("cp %s %s && gsutil -qm cp -r %s/ gs://%s/%s",
+                format("cp %s %s && gsutil -qm cp -r %s/* gs://%s/%s/",
                         BashStartupScript.LOG_FILE,
                         VmDirectories.OUTPUT,
                         VmDirectories.OUTPUT,

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/OutputUpload.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/OutputUpload.java
@@ -16,7 +16,7 @@ public class OutputUpload implements BashCommand {
     @Override
     public String asBash() {
         return new SubShellCommand(() ->
-                format("cp %s %s && gsutil -qm cp -r %s/* gs://%s/%s/",
+                format("cp %s %s && gsutil -qm cp -r %s/* gs://%s/%s",
                         BashStartupScript.LOG_FILE,
                         VmDirectories.OUTPUT,
                         VmDirectories.OUTPUT,

--- a/cluster/src/test/java/com/hartwig/pipeline/execution/vm/OutputUploadTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/execution/vm/OutputUploadTest.java
@@ -14,7 +14,7 @@ public class OutputUploadTest implements CommonEntities {
     @Test
     public void createsBaseToCopyAllFilesAndDirsInOutputFolderToOutputBucket() {
         OutputUpload victim = new OutputUpload(GoogleStorageLocation.of("bucket", "results/"));
-        assertThat(victim.asBash()).isEqualTo(format("(cp %s %s && gsutil -qm cp -r %s/ gs://bucket/results/)",
+        assertThat(victim.asBash()).isEqualTo(format("(cp %s %s && gsutil -qm cp -r %s/* gs://bucket/results/)",
                 LOG_FILE, OUT_DIR, OUT_DIR));
     }
 }


### PR DESCRIPTION
My only guess is that we've hit some bug/race condition in gsutil as we
very rarely see this issue.

Trying to remove the possibility of hitting it by copying the contents
with an asterisk rather than a pure recursive copy.