### PR TITLE
DEV-972 Google-based archiver

### DIFF
--- a/cluster/pom.xml
+++ b/cluster/pom.xml
@@ -49,6 +49,10 @@
             <artifactId>google-api-services-compute</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.apis</groupId>
+            <artifactId>google-api-services-storagetransfer</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
         </dependency>

--- a/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
@@ -96,6 +96,12 @@ public interface Arguments {
 
     String patientReportBucket();
 
+    String archiveBucket();
+
+    String archiveProject();
+
+    String archivePrivateKeyPath();
+
     AlignerType alignerType();
 
     Optional<String> cmek();
@@ -165,7 +171,10 @@ public interface Arguments {
                     .setId(EMPTY)
                     .toolsBucket(DEFAULT_PRODUCTION_COMMON_TOOLS_BUCKET)
                     .resourceBucket(DEFAULT_PRODUCTION_RESOURCE_BUCKET)
-                    .patientReportBucket(DEFAULT_PRODUCTION_PATIENT_REPORT_BUCKET);
+                    .patientReportBucket(DEFAULT_PRODUCTION_PATIENT_REPORT_BUCKET)
+                    .archiveBucket(DEFAULT_PRODUCTION_ARCHIVE_BUCKET)
+                    .archiveProject(DEFAULT_PRODUCTION_ARCHIVE_PROJECT)
+                    .archivePrivateKeyPath(DEFAULT_PRODUCTION_ARCHIVE_KEY_PATH);
         } else if (profile.equals(DefaultsProfile.DEVELOPMENT)) {
             return ImmutableArguments.builder()
                     .profile(profile)
@@ -203,7 +212,10 @@ public interface Arguments {
                     .setId(EMPTY)
                     .toolsBucket(DEFAULT_DEVELOPMENT_COMMON_TOOLS_BUCKET)
                     .resourceBucket(DEFAULT_DEVELOPMENT_RESOURCE_BUCKET)
-                    .patientReportBucket(DEFAULT_DEVELOPMENT_PATIENT_REPORT_BUCKET);
+                    .patientReportBucket(DEFAULT_DEVELOPMENT_PATIENT_REPORT_BUCKET)
+                    .archiveBucket(DEFAULT_DEVELOPMENT_ARCHIVE_BUCKET)
+                    .archiveProject(DEFAULT_DEVELOPMENT_ARCHIVE_PROJECT)
+                    .archivePrivateKeyPath(DEFAULT_DEVELOPMENT_ARCHIVE_KEY_PATH);
         } else if (profile.equals(DefaultsProfile.DEVELOPMENT_DOCKER)) {
             return ImmutableArguments.builder()
                     .profile(profile)
@@ -241,7 +253,10 @@ public interface Arguments {
                     .setId(EMPTY)
                     .toolsBucket(DEFAULT_DEVELOPMENT_COMMON_TOOLS_BUCKET)
                     .resourceBucket(DEFAULT_DEVELOPMENT_RESOURCE_BUCKET)
-                    .patientReportBucket(DEFAULT_DEVELOPMENT_PATIENT_REPORT_BUCKET);
+                    .patientReportBucket(DEFAULT_DEVELOPMENT_PATIENT_REPORT_BUCKET)
+                    .archiveBucket(DEFAULT_DEVELOPMENT_ARCHIVE_BUCKET)
+                    .archiveProject(DEFAULT_DEVELOPMENT_ARCHIVE_PROJECT)
+                    .archivePrivateKeyPath(DEFAULT_DEVELOPMENT_ARCHIVE_KEY_PATH);
         }
         throw new IllegalArgumentException(String.format("Unknown profile [%s], please create defaults for this profile.", profile));
     }
@@ -265,12 +280,16 @@ public interface Arguments {
     String DEFAULT_PRODUCTION_RESOURCE_BUCKET = "common-resources-prod";
     String DEFAULT_PRODUCTION_COMMON_TOOLS_BUCKET = "common-tools-prod";
     String DEFAULT_PRODUCTION_PATIENT_REPORT_BUCKET = "pipeline-output-prod";
+    String DEFAULT_PRODUCTION_ARCHIVE_BUCKET = "pipeline-archive-prod";
+    String DEFAULT_PRODUCTION_ARCHIVE_PROJECT = DEFAULT_PRODUCTION_PROJECT;
 
     String DEFAULT_DOCKER_SAMPLE_DIRECTORY = "/samples";
     String DEFAULT_DOCKER_NODE_INIT = "node-init.sh";
     String DEFAULT_DOCKER_JAR_LIB = "/usr/share/pipeline5";
     String DEFAULT_DOCKER_KEY_PATH = "/secrets/bootstrap-key.json";
     String DEFAULT_DOCKER_CLOUD_SDK_PATH = "/usr/lib/google-cloud-sdk/bin";
+
+    String DEFAULT_PRODUCTION_ARCHIVE_KEY_PATH = DEFAULT_DOCKER_KEY_PATH;
 
     String NOT_APPLICABLE = "N/A";
     String DEFAULT_DEVELOPMENT_REGION = "europe-west4";
@@ -285,4 +304,8 @@ public interface Arguments {
     String DEFAULT_DEVELOPMENT_RESOURCE_BUCKET = "common-resources";
     String DEFAULT_DEVELOPMENT_COMMON_TOOLS_BUCKET = "common-tools";
     String DEFAULT_DEVELOPMENT_PATIENT_REPORT_BUCKET = "pipeline-output-dev";
+
+    String DEFAULT_DEVELOPMENT_ARCHIVE_PROJECT = DEFAULT_DEVELOPMENT_PROJECT;
+    String DEFAULT_DEVELOPMENT_ARCHIVE_BUCKET = "pipeline-archive-dev";
+    String DEFAULT_DEVELOPMENT_ARCHIVE_KEY_PATH = DEFAULT_DEVELOPMENT_KEY_PATH;
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
@@ -54,6 +54,9 @@ public class CommandLineOptions {
     private static final String TOOLS_BUCKET_FLAG = "tools_bucket";
     private static final String RESOURCE_BUCKET_FLAG = "resource_bucket";
     private static final String PATIENT_REPORT_BUCKET_FLAG = "patient_report_bucket";
+    private static final String ARCHIVE_BUCKET_FLAG = "archive_bucket";
+    private static final String ARCHIVE_PRIVATE_KEY_FLAG = "archive_private_key_path";
+    private static final String ARCHIVE_PROJECT_FLAG = "archive_project";
     private static final String MODE_FLAG = "mode";
     private static final String SET_ID_FLAG = "set_id";
     private static final String SBP_RUN_ID_FLAG = "sbp_run_id";
@@ -108,8 +111,7 @@ public class CommandLineOptions {
                 .addOption(optionWithBooleanArg(RUN_TERTIARY_FLAG, "Run tertiary analysis algorithms (amber, cobalt, purple)"))
                 .addOption(serviceAccountEmail())
                 .addOption(resourceBucket())
-                .addOption(toolsBucket())
-                .addOption(patientReportBucket())
+                .addOption(toolsBucket()).addOption(patientReportBucket()).addOption(archiveBucket())
                 .addOption(privateNetwork())
                 .addOption(cmek())
                 .addOption(optionWithBooleanArg(SHALLOW_FLAG,
@@ -149,6 +151,10 @@ public class CommandLineOptions {
 
     private static Option patientReportBucket() {
         return optionWithArg(PATIENT_REPORT_BUCKET_FLAG, "Bucket in which to persist the final patient report and accompanying data.");
+    }
+
+    private static Option archiveBucket() {
+        return optionWithArg(ARCHIVE_BUCKET_FLAG, "Bucket to copy output to for data requests.");
     }
 
     private static Option toolsBucket() {
@@ -290,6 +296,9 @@ public class CommandLineOptions {
                     .resourceBucket(commandLine.getOptionValue(RESOURCE_BUCKET_FLAG, defaults.resourceBucket()))
                     .toolsBucket(commandLine.getOptionValue(TOOLS_BUCKET_FLAG, defaults.toolsBucket()))
                     .patientReportBucket(commandLine.getOptionValue(PATIENT_REPORT_BUCKET_FLAG, defaults.patientReportBucket()))
+                    .archiveBucket(commandLine.getOptionValue(ARCHIVE_BUCKET_FLAG, defaults.archiveBucket()))
+                    .archivePrivateKeyPath(commandLine.getOptionValue(ARCHIVE_PRIVATE_KEY_FLAG, defaults.archivePrivateKeyPath()))
+                    .archiveProject(commandLine.getOptionValue(ARCHIVE_PROJECT_FLAG, defaults.archiveProject()))
                     .privateNetwork(privateNetwork(commandLine, defaults))
                     .cmek(cmek(commandLine, defaults))
                     .shallow(booleanOptionWithDefault(commandLine, SHALLOW_FLAG, defaults.shallow()))

--- a/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
@@ -23,6 +23,7 @@ import com.hartwig.pipeline.stages.StageRunner;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 import com.hartwig.pipeline.storage.StorageProvider;
 import com.hartwig.pipeline.tools.Versions;
+import com.hartwig.pipeline.transfer.google.GoogleArchiver;
 
 import org.apache.commons.cli.ParseException;
 import org.slf4j.Logger;
@@ -75,7 +76,7 @@ public class PipelineMain {
                 new OutputStorage<>(ResultsDirectory.defaultDirectory(),
                         arguments,
                         metadata -> RuntimeBucket.from(storage, GermlineCaller.NAMESPACE, metadata, arguments)),
-                somaticMetadataApi,
+                somaticMetadataApi, new GoogleArchiver(arguments),
                 PipelineResultsProvider.from(storage, arguments, Versions.pipelineVersion()).get(),
                 new FullSomaticResults(storage, arguments),
                 CleanupProvider.from(credentials, arguments, storage, somaticMetadataApi).get(),

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/AlignerProvider.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/AlignerProvider.java
@@ -25,7 +25,7 @@ import com.hartwig.pipeline.storage.GSUtilCloudCopy;
 import com.hartwig.pipeline.storage.LocalFileSource;
 import com.hartwig.pipeline.storage.RCloneCloudCopy;
 import com.hartwig.pipeline.storage.SampleUpload;
-import com.hartwig.pipeline.transfer.SbpS3FileSource;
+import com.hartwig.pipeline.transfer.sbp.SbpS3FileSource;
 import com.hartwig.support.hadoop.Hadoop;
 
 public abstract class AlignerProvider {

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/SbpSomaticMetadataApi.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/SbpSomaticMetadataApi.java
@@ -13,7 +13,7 @@ import com.hartwig.pipeline.sbpapi.SbpRestApi;
 import com.hartwig.pipeline.sbpapi.SbpRun;
 import com.hartwig.pipeline.sbpapi.SbpSample;
 import com.hartwig.pipeline.sbpapi.SbpSet;
-import com.hartwig.pipeline.transfer.SbpFileTransfer;
+import com.hartwig.pipeline.transfer.sbp.SbpFileTransfer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,7 +103,7 @@ public class SbpSomaticMetadataApi implements SomaticMetadataApi {
         }
     }
 
-    private Optional<SbpSample> find(final String type, final List<SbpSample> samplesBySet) throws IOException {
+    private Optional<SbpSample> find(final String type, final List<SbpSample> samplesBySet) {
         return samplesBySet.stream().filter(sample -> sample.type().equals(type)).findFirst();
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/SetMetadataApiProvider.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/SetMetadataApiProvider.java
@@ -3,7 +3,7 @@ package com.hartwig.pipeline.metadata;
 import com.google.cloud.storage.Storage;
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.sbpapi.SbpRestApi;
-import com.hartwig.pipeline.transfer.SbpFileTransferProvider;
+import com.hartwig.pipeline.transfer.sbp.SbpFileTransferProvider;
 
 public class SetMetadataApiProvider {
 

--- a/cluster/src/main/java/com/hartwig/pipeline/transfer/google/GoogleArchiver.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/transfer/google/GoogleArchiver.java
@@ -1,0 +1,110 @@
+package com.hartwig.pipeline.transfer.google;
+
+import static java.lang.String.format;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.googleapis.util.Utils;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.services.storagetransfer.v1.Storagetransfer;
+import com.google.api.services.storagetransfer.v1.StoragetransferScopes;
+import com.google.api.services.storagetransfer.v1.model.Date;
+import com.google.api.services.storagetransfer.v1.model.GcsData;
+import com.google.api.services.storagetransfer.v1.model.ListOperationsResponse;
+import com.google.api.services.storagetransfer.v1.model.ObjectConditions;
+import com.google.api.services.storagetransfer.v1.model.Schedule;
+import com.google.api.services.storagetransfer.v1.model.TransferJob;
+import com.google.api.services.storagetransfer.v1.model.TransferOptions;
+import com.google.api.services.storagetransfer.v1.model.TransferSpec;
+import com.google.common.collect.ImmutableList;
+import com.hartwig.pipeline.Arguments;
+import com.hartwig.pipeline.metadata.SomaticRunMetadata;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
+
+public class GoogleArchiver {
+    private static final String APPLICATION_NAME = "google-archive-transfer";
+    private static final Logger LOGGER = LoggerFactory.getLogger(GoogleArchiver.class);
+    private final String sourceBucket;
+    private final String destinationBucket;
+    private final Arguments arguments;
+
+    public GoogleArchiver(Arguments arguments) {
+        this.sourceBucket = arguments.patientReportBucket();
+        this.destinationBucket = arguments.archiveBucket();
+        this.arguments = arguments;
+    }
+
+    public void transfer(SomaticRunMetadata metadata) {
+        HttpTransport http = Utils.getDefaultTransport();
+        JsonFactory jsonFactory = Utils.getDefaultJsonFactory();
+        try {
+            GoogleCredential credential = credentialsFromFile(arguments);
+            HttpRequestInitializer initialiser = new RetryHttpInitializerWrapper(credential);
+            Storagetransfer transfer =
+                    new Storagetransfer.Builder(http, jsonFactory, initialiser).setApplicationName(APPLICATION_NAME).build();
+            runTransfer(transfer, metadata.runName());
+        } catch (IOException ioe) {
+            throw new RuntimeException("Unable to complete transfer to archive folder", ioe);
+        }
+    }
+
+    private void runTransfer(Storagetransfer transfer, String folder) throws IOException {
+        Schedule schedule = new Schedule();
+        Date startDate = new Date();
+        ZonedDateTime utc = ZonedDateTime.now(ZoneId.of("UTC"));
+        startDate.setDay(utc.getDayOfMonth());
+        startDate.setMonth(utc.getMonthValue());
+        startDate.setYear(utc.getYear());
+
+        schedule.setScheduleStartDate(startDate);
+        schedule.setScheduleEndDate(startDate);
+
+        String description = jobDescription(folder, utc);
+        TransferJob job = new TransferJob().setTransferSpec(new TransferSpec().setGcsDataSource(new GcsData().setBucketName(sourceBucket))
+                .setGcsDataSink(new GcsData().setBucketName(destinationBucket))
+                .setObjectConditions(new ObjectConditions().setIncludePrefixes(ImmutableList.of(folder)))
+                .setTransferOptions(new TransferOptions().setDeleteObjectsFromSourceAfterTransfer(false)))
+                .setProjectId(arguments.project())
+                .setSchedule(schedule).setDescription(description)
+                .setStatus("ENABLED");
+        LOGGER.info("Creating transfer job [{}]", description);
+        TransferJob createdJob = transfer.transferJobs().create(job).execute();
+
+        Failsafe.with(new RetryPolicy<>().withMaxRetries(-1).withDelay(Duration.ofSeconds(5)).handleResult(Boolean.FALSE)).get(() -> {
+            ListOperationsResponse transferOperations = transfer.transferOperations()
+                    .list("transferOperations")
+                    .setFilter(format("{\"project_id\": \"%s\", \"job_names\": [\"%s\"]}", arguments.project(), createdJob.getName()))
+                    .execute();
+            if (transferOperations.getOperations().size() > 0) {
+                LOGGER.info("Transfer job [{}] completed", description);
+                return transferOperations.getOperations().get(0).getMetadata().get("status").equals("SUCCESS");
+            }
+            LOGGER.info("Continuing to wait for completion of transfer operation");
+            return Boolean.FALSE;
+        });
+    }
+
+    private String jobDescription(String folder, ZonedDateTime zonedDateTime) {
+        String formattedTime = zonedDateTime.format(DateTimeFormatter.ofPattern("yyyyMMdd-kkmm"));
+        return format("%s-%s---%s_%s", sourceBucket, folder, destinationBucket, formattedTime);
+    }
+
+    private GoogleCredential credentialsFromFile(Arguments arguments) throws IOException {
+        GoogleCredential credential = GoogleCredential.fromStream(FileUtils.openInputStream(new File(arguments.archivePrivateKeyPath())));
+        return credential.createScoped(StoragetransferScopes.all());
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/transfer/google/RetryHttpInitializerWrapper.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/transfer/google/RetryHttpInitializerWrapper.java
@@ -1,0 +1,71 @@
+package com.hartwig.pipeline.transfer.google;
+
+import java.util.logging.Logger;
+
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.http.HttpBackOffIOExceptionHandler;
+import com.google.api.client.http.HttpBackOffUnsuccessfulResponseHandler;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.HttpUnsuccessfulResponseHandler;
+import com.google.api.client.util.ExponentialBackOff;
+import com.google.api.client.util.Sleeper;
+import com.google.common.base.Preconditions;
+
+/**
+ * RetryHttpInitializerWrapper will automatically retry upon RPC failures, preserving the
+ * auto-refresh behavior of the Google Credentials.
+ */
+public class RetryHttpInitializerWrapper implements HttpRequestInitializer {
+
+    private static final Logger LOG = Logger.getLogger(RetryHttpInitializerWrapper.class.getName());
+    private final Credential wrappedCredential;
+    private final Sleeper sleeper;
+    private static final int MILLIS_PER_MINUTE = 60 * 1000;
+
+    /**
+     * A constructor using the default Sleeper.
+     *
+     * @param wrappedCredential the credential used to authenticate with a Google Cloud Platform project
+     */
+    RetryHttpInitializerWrapper(Credential wrappedCredential) {
+        this(wrappedCredential, Sleeper.DEFAULT);
+    }
+
+    /**
+     * A constructor used only for testing.
+     *
+     * @param wrappedCredential the credential used to authenticate with a Google Cloud Platform project
+     * @param sleeper           a user-supplied Sleeper
+     */
+    private RetryHttpInitializerWrapper(Credential wrappedCredential, Sleeper sleeper) {
+        this.wrappedCredential = Preconditions.checkNotNull(wrappedCredential);
+        this.sleeper = sleeper;
+    }
+
+    /**
+     * Initialize an HttpRequest.
+     *
+     * @param request an HttpRequest that should be initialized
+     */
+    public void initialize(HttpRequest request) {
+        request.setReadTimeout(2 * MILLIS_PER_MINUTE); // 2 minutes read timeout
+        final HttpUnsuccessfulResponseHandler backoffHandler =
+                new HttpBackOffUnsuccessfulResponseHandler(new ExponentialBackOff()).setSleeper(sleeper);
+        request.setInterceptor(wrappedCredential);
+        request.setUnsuccessfulResponseHandler((request1, response, supportsRetry) -> {
+            if (wrappedCredential.handleResponse(request1, response, supportsRetry)) {
+                // If credential decides it can handle it, the return code or message indicated
+                // something specific to authentication, and no backoff is desired.
+                return true;
+            } else if (backoffHandler.handleResponse(request1, response, supportsRetry)) {
+                // Otherwise, we defer to the judgement of our internal backoff handler.
+                LOG.info("Retrying " + request1.getUrl().toString());
+                return true;
+            } else {
+                return false;
+            }
+        });
+        request.setIOExceptionHandler(new HttpBackOffIOExceptionHandler(new ExponentialBackOff()).setSleeper(sleeper));
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/transfer/sbp/CloudFile.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/transfer/sbp/CloudFile.java
@@ -1,4 +1,4 @@
-package com.hartwig.pipeline.transfer;
+package com.hartwig.pipeline.transfer.sbp;
 
 import static java.lang.String.format;
 

--- a/cluster/src/main/java/com/hartwig/pipeline/transfer/sbp/ContentTypeCorrection.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/transfer/sbp/ContentTypeCorrection.java
@@ -1,4 +1,4 @@
-package com.hartwig.pipeline.transfer;
+package com.hartwig.pipeline.transfer.sbp;
 
 import java.util.Map;
 

--- a/cluster/src/main/java/com/hartwig/pipeline/transfer/sbp/SbpFileTransfer.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/transfer/sbp/SbpFileTransfer.java
@@ -1,4 +1,4 @@
-package com.hartwig.pipeline.transfer;
+package com.hartwig.pipeline.transfer.sbp;
 
 import static java.lang.String.format;
 

--- a/cluster/src/main/java/com/hartwig/pipeline/transfer/sbp/SbpFileTransferProvider.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/transfer/sbp/SbpFileTransferProvider.java
@@ -1,4 +1,4 @@
-package com.hartwig.pipeline.transfer;
+package com.hartwig.pipeline.transfer.sbp;
 
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;

--- a/cluster/src/main/java/com/hartwig/pipeline/transfer/sbp/SbpS3.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/transfer/sbp/SbpS3.java
@@ -1,4 +1,4 @@
-package com.hartwig.pipeline.transfer;
+package com.hartwig.pipeline.transfer.sbp;
 
 import java.util.Map;
 

--- a/cluster/src/main/java/com/hartwig/pipeline/transfer/sbp/SbpS3FileSource.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/transfer/sbp/SbpS3FileSource.java
@@ -1,4 +1,4 @@
-package com.hartwig.pipeline.transfer;
+package com.hartwig.pipeline.transfer.sbp;
 
 import java.util.function.Function;
 

--- a/cluster/src/test/java/com/hartwig/pipeline/metadata/SbpSomaticMetadataApiTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/metadata/SbpSomaticMetadataApiTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.when;
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.execution.PipelineStatus;
 import com.hartwig.pipeline.sbpapi.SbpRestApi;
-import com.hartwig.pipeline.transfer.SbpFileTransfer;
+import com.hartwig.pipeline.transfer.sbp.SbpFileTransfer;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -35,7 +35,7 @@ public class SbpSomaticMetadataApiTest {
     }
 
     @Test
-    public void retrievesSetMetadataFromSbpRestApi() throws Exception {
+    public void retrievesSetMetadataFromSbpRestApi() {
         when(sbpRestApi.getRun(SET_ID)).thenReturn(TestJson.get("get_run"));
         when(sbpRestApi.getSample(SAMPLE_ID)).thenReturn(TestJson.get("get_samples_by_set"));
         when(sbpRestApi.getSample(SAMPLE_ID)).thenReturn(TestJson.get("get_samples_by_set"));

--- a/cluster/src/test/java/com/hartwig/pipeline/smoke/ManifestAssert.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/smoke/ManifestAssert.java
@@ -1,0 +1,53 @@
+package com.hartwig.pipeline.smoke;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+
+public class ManifestAssert extends AbstractAssert<ManifestAssert, List<String>> {
+    private final String referenceName;
+    private final String tumorName;
+
+    private ManifestAssert(final List<String> linesFromManifest, String referenceName, String tumorName) {
+        super(linesFromManifest, ManifestAssert.class);
+        this.referenceName = referenceName;
+        this.tumorName = tumorName;
+    }
+
+    public static ManifestAssert assertThat(List<String> actualFiles, String referenceName, String tumorName) {
+        return new ManifestAssert(actualFiles, referenceName, tumorName);
+    }
+
+    ManifestAssert hasTheseFiles(String pathToLocalCopyOfManifest, String ignoreManifestPrefix) {
+        try {
+            ArrayList<String> expectedFiles = new ArrayList<>(FileUtils.readLines(new File(pathToLocalCopyOfManifest)));
+            Assertions.assertThat(sanitise(sliceOutFilenames(actual, 1, "")))
+                    .containsOnlyElementsOf(sliceOutFilenames(expectedFiles, 2, ignoreManifestPrefix));
+            return this;
+        } catch (IOException ioe) {
+            throw new RuntimeException(format("Could not open local copy of manifest '%s'", pathToLocalCopyOfManifest));
+        }
+    }
+
+    private List<String> sanitise(List<String> filenames) {
+        return filenames.stream().filter(name -> {
+            String trimmed = name.trim();
+            return !(trimmed.equals("STAGED") || trimmed.equals(format("%s/run.log", referenceName)) || trimmed.equals(format("%s/run.log",
+                    tumorName)));
+        }).collect(toList());
+    }
+
+    private List<String> sliceOutFilenames(List<String> filenames, int filenameIndex, String prefixToRemoveFromFilenames) {
+        return filenames.stream()
+                .map(s -> s.trim().split(" +")[filenameIndex].replaceAll("^" + prefixToRemoveFromFilenames, ""))
+                .collect(toList());
+    }
+}

--- a/cluster/src/test/java/com/hartwig/pipeline/storage/SbpS3FileSourceTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/storage/SbpS3FileSourceTest.java
@@ -2,7 +2,7 @@ package com.hartwig.pipeline.storage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hartwig.pipeline.transfer.SbpS3FileSource;
+import com.hartwig.pipeline.transfer.sbp.SbpS3FileSource;
 
 import org.junit.Test;
 

--- a/cluster/src/test/java/com/hartwig/pipeline/transfer/sbp/CloudFileTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/transfer/sbp/CloudFileTest.java
@@ -1,4 +1,4 @@
-package com.hartwig.pipeline.transfer;
+package com.hartwig.pipeline.transfer.sbp;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/cluster/src/test/java/com/hartwig/pipeline/transfer/sbp/ContentTypeCorrectionTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/transfer/sbp/ContentTypeCorrectionTest.java
@@ -1,4 +1,4 @@
-package com.hartwig.pipeline.transfer;
+package com.hartwig.pipeline.transfer.sbp;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;

--- a/cluster/src/test/java/com/hartwig/pipeline/transfer/sbp/SbpFileTransferTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/transfer/sbp/SbpFileTransferTest.java
@@ -1,4 +1,4 @@
-package com.hartwig.pipeline.transfer;
+package com.hartwig.pipeline.transfer.sbp;
 
 import static java.lang.String.format;
 

--- a/cluster/src/test/java/com/hartwig/pipeline/transfer/sbp/SbpS3Test.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/transfer/sbp/SbpS3Test.java
@@ -1,4 +1,4 @@
-package com.hartwig.pipeline.transfer;
+package com.hartwig.pipeline.transfer.sbp;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <hadoop.version>2.7.7</hadoop.version>
         <google-dataproc-api.version>v1beta2-rev71-1.25.0</google-dataproc-api.version>
         <google-cloud-nio.version>0.61.0-alpha</google-cloud-nio.version>
+        <google-storage-transfer.version>v1-rev20190907-1.30.1</google-storage-transfer.version>
         <avro.version>1.8.2</avro.version>
         <jersey.version>2.25</jersey.version>
         <javax.ws.rs-api.version>2.1</javax.ws.rs-api.version>
@@ -294,6 +295,11 @@
                 <groupId>com.google.apis</groupId>
                 <artifactId>google-api-services-compute</artifactId>
                 <version>${google-compute-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.apis</groupId>
+                <artifactId>google-api-services-storagetransfer</artifactId>
+                <version>${google-storage-transfer.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.oauth-client</groupId>


### PR DESCRIPTION
Use the Google Transfer API to push the results of a run to a different
bucket in GCP for archival purposes.

As part of this, add command line arguments to allow separate credentials
to be supplied for the archive project. In production there will be a
separate project to store the archived runs.