### PR TITLE
DEV-987 Move single sample run info to top level

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/SingleSamplePipeline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/SingleSamplePipeline.java
@@ -31,15 +31,18 @@ public class SingleSamplePipeline {
     private final Aligner aligner;
     private final PipelineResults report;
     private final ExecutorService executorService;
+    private final Boolean isStandalone;
     private final Arguments arguments;
 
     SingleSamplePipeline(final SingleSampleEventListener sampleMetadataApi, final StageRunner<SingleSampleRunMetadata> stageRunner,
-            final Aligner aligner, final PipelineResults report, final ExecutorService executorService, final Arguments arguments) {
+            final Aligner aligner, final PipelineResults report, final ExecutorService executorService, final Boolean isStandalone,
+            final Arguments arguments) {
         this.eventListener = sampleMetadataApi;
         this.stageRunner = stageRunner;
         this.aligner = aligner;
         this.report = report;
         this.executorService = executorService;
+        this.isStandalone = isStandalone;
         this.arguments = arguments;
     }
 
@@ -69,7 +72,7 @@ public class SingleSamplePipeline {
             report.add(state.add(futurePayload(bamMetricsFuture)));
             report.add(state.add(futurePayload(unifiedGenotyperFuture)));
             report.add(state.add(futurePayload(flagstatOutputFuture)));
-            report.compose(metadata);
+            report.compose(metadata, isStandalone);
             eventListener.complete(state);
         }
         return state;

--- a/cluster/src/main/java/com/hartwig/pipeline/report/PipelineResults.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/report/PipelineResults.java
@@ -53,9 +53,9 @@ public class PipelineResults {
         writeComplete(name);
     }
 
-    public void compose(SingleSampleRunMetadata metadata) {
+    public void compose(SingleSampleRunMetadata metadata, Boolean isStandalone) {
         String name = RunTag.apply(arguments, metadata.sampleId());
-        Folder folder = Folder.from(metadata);
+        Folder folder = isStandalone ? Folder.from() : Folder.from(metadata);
         writeMetadata(metadata, name, folder);
         compose(name, folder);
         writeComplete(name);


### PR DESCRIPTION
When a run is invoked as a simple sample "standalone" run, put the run's logs
and associated metadata at the top level of the output directory, rather than
one level further down in the sample's directory.