### PR TITLE
DEV-970 Make VM status check less chatty

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/InstanceLifecycleManager.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/InstanceLifecycleManager.java
@@ -91,9 +91,9 @@ class InstanceLifecycleManager {
 
     String instanceStatus(String vm, String zone) {
         try {
-            Optional<Instance> instance = findExistingInstance(vm);
-            if (instance.isPresent()) {
-                return instance.get().getStatus();
+            Instance found = compute.instances().get(project, zone, vm).execute();
+            if (found != null) {
+                return found.getStatus();
             } else {
                 throw new IllegalStateException(format("Could not find instance [%s]", vm));
             }


### PR DESCRIPTION
Replace the inefficient compute.instances.list method (loop over all
VMs in all zones until the one with the required name is found) with
a more efficient direct query with the zone and instance name.