### PR TITLE
DEV-1032 Fix issues with pre-emption during vm start and error prop.

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/SingleSamplePipeline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/SingleSamplePipeline.java
@@ -72,7 +72,9 @@ public class SingleSamplePipeline {
             report.add(state.add(futurePayload(bamMetricsFuture)));
             report.add(state.add(futurePayload(unifiedGenotyperFuture)));
             report.add(state.add(futurePayload(flagstatOutputFuture)));
-            report.compose(metadata, isStandalone);
+            if(state.shouldProceed()) {
+                report.compose(metadata, isStandalone);
+            }
             eventListener.complete(state);
         }
         return state;

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/SingleSampleEventListener.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/SingleSampleEventListener.java
@@ -1,13 +1,13 @@
 package com.hartwig.pipeline.metadata;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.hartwig.pipeline.PipelineState;
 
 public class SingleSampleEventListener {
 
-    private final Set<CompletionHandler> handlers = new HashSet<>();
+    private final List<CompletionHandler> handlers = new ArrayList<>();
 
     public void register(CompletionHandler completionHandler) {
         handlers.add(completionHandler);
@@ -21,7 +21,7 @@ public class SingleSampleEventListener {
         handlers.forEach(handler -> handler.handleSingleSampleComplete(state));
     }
 
-    public Set<CompletionHandler> getHandlers() {
+    public List<CompletionHandler> getHandlers() {
         return handlers;
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/report/PipelineResults.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/report/PipelineResults.java
@@ -73,7 +73,8 @@ public class PipelineResults {
             try {
                 component.addToReport(storage, reportBucket, name);
             } catch (Exception e) {
-                LOGGER.error(format("Unable add component [%s] to the final patient report.", component.getClass().getSimpleName()), e);
+                throw new RuntimeException(format("Unable add component [%s] to the final patient report.",
+                        component.getClass().getSimpleName()), e);
             }
         });
     }

--- a/cluster/src/test/java/com/hartwig/pipeline/SingleSamplePipelineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/SingleSamplePipelineTest.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -67,7 +68,8 @@ public class SingleSamplePipelineTest {
                 stageRunner,
                 aligner,
                 pipelineResults,
-                Executors.newSingleThreadExecutor(), standalone,
+                Executors.newSingleThreadExecutor(),
+                standalone,
                 ARGUMENTS);
     }
 
@@ -242,6 +244,15 @@ public class SingleSamplePipelineTest {
         initialiseVictim(true);
         victim.run(referenceRunMetadata());
         verify(pipelineResults).compose(any(), eq(true));
+    }
+
+    @Test
+    public void doesnotComposeReportIfStatusIsFailed() throws Exception {
+        pipelineResults = mock(PipelineResults.class);
+        AlignmentOutput alignmentOutput = AlignmentOutput.builder().status(PipelineStatus.FAILED).sample(referenceSample()).build();
+        when(aligner.run(referenceRunMetadata())).thenReturn(alignmentOutput);
+        victim.run(referenceRunMetadata());
+        verify(pipelineResults, never()).compose(any(), eq(true));
     }
 
     private void assertFailed(final PipelineState runOutput) {

--- a/cluster/src/test/java/com/hartwig/pipeline/execution/vm/ComputeEngineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/execution/vm/ComputeEngineTest.java
@@ -242,6 +242,18 @@ public class ComputeEngineTest {
     }
 
     @Test
+    public void triesMultipleZonesWhenUnsupportedOperation() throws Exception {
+        Operation resourcesExhausted = new Operation().setStatus("DONE").setName("insert")
+                .setError(new Operation.Error().setErrors(Collections.singletonList(
+                        new Operation.Error.Errors().setCode(ComputeEngine.UNSUPPORTED_OPERATION_ERROR_CODE))));
+        when(lifecycleManager.deleteOldInstancesAndStart(instance, FIRST_ZONE_NAME, INSTANCE_NAME))
+                .thenReturn(resourcesExhausted, mock(Operation.class));
+        when(bucketWatcher.currentState(any(), any())).thenReturn(State.STILL_WAITING, State.STILL_WAITING, State.SUCCESS);
+        victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
+        verify(lifecycleManager).deleteOldInstancesAndStart(instance, SECOND_ZONE_NAME, INSTANCE_NAME);
+    }
+
+    @Test
     public void setsVmsToPreemptibleWhenFlagEnabled() throws Exception {
         returnSuccess();
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);

--- a/cluster/src/test/java/com/hartwig/pipeline/report/PipelineResultsTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/report/PipelineResultsTest.java
@@ -48,14 +48,12 @@ public class PipelineResultsTest {
         assertThat(secondComponentRan).isTrue();
     }
 
-    @Test
-    public void doesNotFailWhenOneComponentFails() {
+    @Test (expected = RuntimeException.class)
+    public void failsHardWhenOneComponentFails(){
         victim.add(stageOutput(Lists.newArrayList((s, r, setName) -> firstComponentRan = true, (s, r, setName) -> {
             throw new RuntimeException();
         }, (s, r, setName) -> secondComponentRan = true)));
         victim.compose(TestInputs.referenceRunMetadata(), false);
-        assertThat(firstComponentRan).isTrue();
-        assertThat(secondComponentRan).isTrue();
     }
 
     @Test


### PR DESCRIPTION
Checks for the "UNSUPPORTED_OPERATION" error and when encountered, logs
a warning and goes to next zone. Basically the same logic as zone
resources exhausted.

Throw a runtime exception whenever a file is missing compiling the final
results.

The FullPipeline was not checking single sample state past the alignment
We know grab the final state of both single sample pipelines before
reporting the final status.