### PR TITLE
DEV-1052 Add logs to aligner

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
@@ -102,6 +102,7 @@ public class CommandLineOptions {
                 .addOption(optionWithBooleanArg(RUN_SOMATIC_CALLER_FLAG, "Run somatic calling (strelka) on a VM"))
                 .addOption(optionWithBooleanArg(RUN_STRUCTURAL_CALLER_FLAG, "Run structural calling (gridss) on a VM"))
                 .addOption(optionWithBooleanArg(RUN_TERTIARY_FLAG, "Run tertiary analysis algorithms (amber, cobalt, purple)"))
+                .addOption(optionWithBooleanArg(RUN_SNP_GENOTYPER_FLAG, "Run snp genotyper for QC against genotyping"))
                 .addOption(serviceAccountEmail())
                 .addOption(resourceBucket())
                 .addOption(toolsBucket())
@@ -344,7 +345,7 @@ public class CommandLineOptions {
         if (!value.equals("true") && !value.equals("false")) {
             throw new ParseException(flag + " is a flag and only accepts true|false");
         }
-        return Boolean.valueOf(value);
+        return Boolean.parseBoolean(value);
     }
 
     private static Optional<String> runId(CommandLine commandLine) {

--- a/cluster/src/main/java/com/hartwig/pipeline/report/RunLogComponent.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/report/RunLogComponent.java
@@ -5,8 +5,10 @@ import com.hartwig.pipeline.storage.RuntimeBucket;
 
 public class RunLogComponent extends SingleFileComponent {
 
+    private static final String LOG_FILE = "run.log";
+
     public RunLogComponent(final RuntimeBucket runtimeBucket, final String namespace, final Folder folder,
             final ResultsDirectory resultsDirectory) {
-        super(runtimeBucket, namespace, folder, "run.log", "run.log", resultsDirectory);
+        super(runtimeBucket, namespace, folder, LOG_FILE, LOG_FILE, resultsDirectory);
     }
 }


### PR DESCRIPTION
Add run log components for each lane alignment and the merge to the
report components. The lane logs will be in namespaced subdirectories
for each lane, as they are in the runtime bucket.