### PR TITLE
DEV-1074 Fix single-run metadata handling

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
@@ -15,12 +15,6 @@ public interface Arguments extends CommonArguments {
         DEVELOPMENT_DOCKER
     }
 
-    enum Mode {
-        FULL,
-        SINGLE_SAMPLE,
-        SOMATIC
-    }
-
     boolean cleanup();
 
     boolean upload();
@@ -40,8 +34,6 @@ public interface Arguments extends CommonArguments {
     boolean runTertiary();
 
     DefaultsProfile profile();
-
-    Mode mode();
 
     String version();
 
@@ -104,7 +96,6 @@ public interface Arguments extends CommonArguments {
         if (profile.equals(DefaultsProfile.PRODUCTION)) {
             return ImmutableArguments.builder()
                     .profile(profile)
-                    .mode(DEFAULT_MODE)
                     .rclonePath(DEFAULT_PRODUCTION_RCLONE_PATH)
                     .rcloneGcpRemote(DEFAULT_PRODUCTION_RCLONE_GCP_REMOTE)
                     .rcloneS3RemoteDownload(DEFAULT_PRODUCTION_RCLONE_S3_REMOTE)
@@ -141,7 +132,6 @@ public interface Arguments extends CommonArguments {
         } else if (profile.equals(DefaultsProfile.DEVELOPMENT)) {
             return ImmutableArguments.builder()
                     .profile(profile)
-                    .mode(DEFAULT_MODE)
                     .region(DEFAULT_DEVELOPMENT_REGION)
                     .project(DEFAULT_DEVELOPMENT_PROJECT)
                     .version(DEFAULT_DEVELOPMENT_VERSION)
@@ -178,7 +168,6 @@ public interface Arguments extends CommonArguments {
         } else if (profile.equals(DefaultsProfile.DEVELOPMENT_DOCKER)) {
             return ImmutableArguments.builder()
                     .profile(profile)
-                    .mode(DEFAULT_MODE)
                     .region(DEFAULT_DEVELOPMENT_REGION)
                     .project(DEFAULT_DEVELOPMENT_PROJECT)
                     .version(DEFAULT_DEVELOPMENT_VERSION)
@@ -220,7 +209,6 @@ public interface Arguments extends CommonArguments {
         return System.getProperty("user.dir");
     }
 
-    Mode DEFAULT_MODE = Mode.SINGLE_SAMPLE;
     String DEFAULT_PRODUCTION_RCLONE_PATH = "/usr/bin";
     String DEFAULT_PRODUCTION_RCLONE_GCP_REMOTE = "gs";
     String DEFAULT_PRODUCTION_RCLONE_S3_REMOTE = "s3";

--- a/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
@@ -49,7 +49,6 @@ public class CommandLineOptions {
     private static final String ARCHIVE_BUCKET_FLAG = "archive_bucket";
     private static final String ARCHIVE_PROJECT_FLAG = "archive_project";
     private static final String ARCHIVE_PRIVATE_KEY_FLAG = "archive_private_key_path";
-    private static final String MODE_FLAG = "mode";
     private static final String SET_ID_FLAG = "set_id";
     private static final String SBP_RUN_ID_FLAG = "sbp_run_id";
     private static final String PRIVATE_NETWORK_FLAG = "private_network";
@@ -59,7 +58,6 @@ public class CommandLineOptions {
 
     private static Options options() {
         return new Options().addOption(profile())
-                .addOption(mode())
                 .addOption(privateKey())
                 .addOption(version())
                 .addOption(sampleDirectory())
@@ -136,10 +134,6 @@ public class CommandLineOptions {
         return optionWithArg(SET_ID_FLAG,
                 "The id of the set for which to run a somatic pipeline. A set represents a valid reference/tumor pair (ie CPCT12345678). "
                         + "Can only be used when mode is somatic and the single sample pipelines have been run for each sample");
-    }
-
-    private static Option mode() {
-        return optionWithArg(MODE_FLAG, "What mode in which to run the pipeline, single_sample and somatic are supported.");
     }
 
     private static Option patientReportBucket() {

--- a/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
@@ -1,16 +1,11 @@
 package com.hartwig.pipeline;
 
-import java.util.Optional;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.*;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
 
 public class CommandLineOptions {
 
@@ -257,7 +252,6 @@ public class CommandLineOptions {
             CommandLine commandLine = defaultParser.parse(options(), args);
             Arguments defaults = Arguments.defaults(commandLine.getOptionValue(PROFILE_FLAG, DEFAULT_PROFILE));
             return Arguments.builder()
-                    .mode(Arguments.Mode.valueOf(commandLine.getOptionValue(MODE_FLAG, defaults.mode().name()).toUpperCase()))
                     .setId(commandLine.getOptionValue(SET_ID_FLAG, defaults.setId()))
                     .privateKeyPath(commandLine.getOptionValue(PRIVATE_KEY_FLAG, defaults.privateKeyPath()))
                     .version(commandLine.getOptionValue(VERSION_FLAG, defaults.version()))

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/SomaticMetadataApiProvider.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/SomaticMetadataApiProvider.java
@@ -5,18 +5,18 @@ import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.sbpapi.SbpRestApi;
 import com.hartwig.pipeline.transfer.google.GoogleArchiver;
 
-public class SetMetadataApiProvider {
+public class SomaticMetadataApiProvider {
 
     private final Arguments arguments;
     private final Storage storage;
 
-    private SetMetadataApiProvider(final Arguments arguments, final Storage storage) {
+    private SomaticMetadataApiProvider(final Arguments arguments, final Storage storage) {
         this.arguments = arguments;
         this.storage = storage;
     }
 
-    public static SetMetadataApiProvider from(final Arguments arguments, final Storage storage) {
-        return new SetMetadataApiProvider(arguments, storage);
+    public static SomaticMetadataApiProvider from(final Arguments arguments, final Storage storage) {
+        return new SomaticMetadataApiProvider(arguments, storage);
     }
 
     public SomaticMetadataApi get() {

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/SomaticRunMetadata.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/SomaticRunMetadata.java
@@ -1,11 +1,11 @@
 package com.hartwig.pipeline.metadata;
 
-import java.util.Optional;
-
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-
 import org.immutables.value.Value;
+
+import java.util.Optional;
 
 @JsonSerialize(as = ImmutableSomaticRunMetadata.class)
 @Value.Immutable
@@ -27,6 +27,11 @@ public interface SomaticRunMetadata extends RunMetadata {
 
     static String truncate(final String sample) {
         return sample.length() > MAX_SAMPLE_LENGTH ? sample.substring(0, MAX_SAMPLE_LENGTH) : sample;
+    }
+
+    @JsonIgnore
+    default boolean isSingleSample() {
+        return maybeTumor().map(s -> Boolean.FALSE).orElse(Boolean.TRUE);
     }
 
     default SingleSampleRunMetadata tumor() {

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/SomaticRunMetadata.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/SomaticRunMetadata.java
@@ -30,6 +30,7 @@ public interface SomaticRunMetadata extends RunMetadata {
     }
 
     @JsonIgnore
+    @Value.Derived
     default boolean isSingleSample() {
         return maybeTumor().map(s -> Boolean.FALSE).orElse(Boolean.TRUE);
     }

--- a/cluster/src/test/java/com/hartwig/pipeline/metadata/SomaticRunMetadataTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/metadata/SomaticRunMetadataTest.java
@@ -1,19 +1,18 @@
 package com.hartwig.pipeline.metadata;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import com.hartwig.pipeline.sbpapi.ObjectMappers;
+import org.junit.Test;
 
 import java.util.Optional;
 
-import com.hartwig.pipeline.sbpapi.ObjectMappers;
-import com.hartwig.pipeline.testsupport.TestInputs;
-
-import org.junit.Test;
+import static com.hartwig.pipeline.testsupport.TestInputs.defaultSomaticRunMetadata;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SomaticRunMetadataTest {
 
     @Test
     public void serializeToJsonBothTumorAndReference() throws Exception {
-        SomaticRunMetadata victim = TestInputs.defaultSomaticRunMetadata();
+        SomaticRunMetadata victim = defaultSomaticRunMetadata();
         assertThat(ObjectMappers.get().writeValueAsString(victim)).isEqualTo(
                 "{\"runName\":\"run\",\"reference\":{\"sampleName\":\"reference\",\"sampleId\":\"reference\",\"type\":\"REFERENCE\"},"
                         + "\"tumor\":{\"sampleName\":\"tumor\",\"sampleId\":\"tumor\",\"type\":\"TUMOR\"}}");
@@ -22,8 +21,20 @@ public class SomaticRunMetadataTest {
     @Test
     public void serializeToJsonSingleSample() throws Exception {
         SomaticRunMetadata victim =
-                SomaticRunMetadata.builder().from(TestInputs.defaultSomaticRunMetadata()).maybeTumor(Optional.empty()).build();
+                SomaticRunMetadata.builder().from(defaultSomaticRunMetadata()).maybeTumor(Optional.empty()).build();
         assertThat(ObjectMappers.get().writeValueAsString(victim)).isEqualTo("{\"runName\":\"run\",\"reference\":{\"sampleName\":"
                 + "\"reference\",\"sampleId\":\"reference\",\"type\":\"REFERENCE\"},\"tumor\":null}");
+    }
+
+    @Test
+    public void returnsSingleSampleWhenTumorIsNotSet() {
+        SomaticRunMetadata victim = SomaticRunMetadata.builder().from(defaultSomaticRunMetadata()).maybeTumor(Optional.empty()).build();
+        assertThat(victim.isSingleSample()).isTrue();
+    }
+
+    @Test
+    public void returnsNotSingleSampleWhenTumorIsPresent() {
+        SomaticRunMetadata victim = defaultSomaticRunMetadata();
+        assertThat(victim.isSingleSample()).isFalse();
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/smoke/SmokeTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/smoke/SmokeTest.java
@@ -1,16 +1,5 @@
 package com.hartwig.pipeline.smoke;
 
-import static java.lang.String.format;
-
-import static com.hartwig.pipeline.testsupport.Assertions.assertThatOutput;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.ImmutableList;
 import com.hartwig.pipeline.Arguments;
@@ -23,13 +12,21 @@ import com.hartwig.pipeline.sbpapi.SbpSet;
 import com.hartwig.pipeline.storage.GSUtil;
 import com.hartwig.pipeline.storage.GSUtilCloudCopy;
 import com.hartwig.pipeline.testsupport.Resources;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.hartwig.pipeline.testsupport.Assertions.assertThatOutput;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Category(value = IntegrationTest.class)
 public class SmokeTest {
@@ -78,7 +75,6 @@ public class SmokeTest {
                 .version(version)
                 .cloudSdkPath(CLOUD_SDK_PATH)
                 .setId(SET_ID)
-                .mode(Arguments.Mode.FULL)
                 .runId(runId)
                 .runGermlineCaller(false)
                 .sbpApiRunId(SBP_RUN_ID)


### PR DESCRIPTION
Make the location of metadata depend upon the contents of the API rather
than the command line arguments. Also remove the appropriate command-line
arguments which I understand should no longer be used in the field.