### PR TITLE
DEV-965 Use users account if no private key specified

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
@@ -1,8 +1,8 @@
 package com.hartwig.pipeline;
 
-import org.immutables.value.Value;
-
 import java.util.Optional;
+
+import org.immutables.value.Value;
 
 @Value.Immutable
 public interface Arguments extends CommonArguments {
@@ -136,7 +136,6 @@ public interface Arguments extends CommonArguments {
                     .project(DEFAULT_DEVELOPMENT_PROJECT)
                     .version(DEFAULT_DEVELOPMENT_VERSION)
                     .sampleDirectory(DEFAULT_DEVELOPMENT_SAMPLE_DIRECTORY)
-                    .privateKeyPath(DEFAULT_DEVELOPMENT_KEY_PATH)
                     .cloudSdkPath(DEFAULT_DEVELOPMENT_CLOUD_SDK_PATH)
                     .serviceAccountEmail(DEFAULT_DEVELOPMENT_SERVICE_ACCOUNT_EMAIL)
                     .cleanup(true)

--- a/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
@@ -1,11 +1,16 @@
 package com.hartwig.pipeline;
 
-import org.apache.commons.cli.*;
+import java.util.Optional;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Optional;
 
 public class CommandLineOptions {
 
@@ -247,7 +252,7 @@ public class CommandLineOptions {
             Arguments defaults = Arguments.defaults(commandLine.getOptionValue(PROFILE_FLAG, DEFAULT_PROFILE));
             return Arguments.builder()
                     .setId(commandLine.getOptionValue(SET_ID_FLAG, defaults.setId()))
-                    .privateKeyPath(commandLine.getOptionValue(PRIVATE_KEY_FLAG, defaults.privateKeyPath()))
+                    .privateKeyPath(privateKey(commandLine, defaults))
                     .version(commandLine.getOptionValue(VERSION_FLAG, defaults.version()))
                     .sampleDirectory(commandLine.getOptionValue(SAMPLE_DIRECTORY_FLAG, defaults.sampleDirectory()))
                     .sampleId(commandLine.getOptionValue(SAMPLE_ID_FLAG, defaults.sampleId()))
@@ -307,6 +312,13 @@ public class CommandLineOptions {
             return Optional.of(commandLine.getOptionValue(PRIVATE_NETWORK_FLAG));
         }
         return defaults.privateNetwork();
+    }
+
+    private static Optional<String> privateKey(final CommandLine commandLine, final Arguments defaults) {
+        if (commandLine.hasOption(PRIVATE_KEY_FLAG)) {
+            return Optional.of(commandLine.getOptionValue(PRIVATE_KEY_FLAG));
+        }
+        return defaults.privateKeyPath();
     }
 
     private static Optional<String> zone(final CommandLine commandLine, final Arguments defaults) {

--- a/cluster/src/main/java/com/hartwig/pipeline/CommonArguments.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/CommonArguments.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 public interface CommonArguments {
     String project();
 
-    String privateKeyPath();
+    Optional<String> privateKeyPath();
 
     String cloudSdkPath();
 

--- a/cluster/src/main/java/com/hartwig/pipeline/cleanup/Cleanup.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/cleanup/Cleanup.java
@@ -27,7 +27,9 @@ public class Cleanup {
         }
         try {
             LOGGER.info("Cleaning up runtime storage on complete somatic pipeline run");
-            GSUtil.auth(arguments.cloudSdkPath(), arguments.privateKeyPath());
+            if (arguments.privateKeyPath().isPresent()) {
+                GSUtil.auth(arguments.cloudSdkPath(), arguments.privateKeyPath().get());
+            }
             metadata.maybeTumor().ifPresent(tumor -> deleteBucket(Run.from(metadata, arguments).id()));
             cleanupSample(metadata.reference());
             metadata.maybeTumor().ifPresent(this::cleanupSample);

--- a/cluster/src/main/java/com/hartwig/pipeline/credentials/CredentialProvider.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/credentials/CredentialProvider.java
@@ -18,9 +18,13 @@ public class CredentialProvider {
 
     public GoogleCredentials get() throws IOException, InterruptedException {
         GoogleCredentials credentials =
-                GoogleCredentials.fromStream(new FileInputStream(arguments.privateKeyPath())).createScoped(ComputeScopes.all());
+                arguments.privateKeyPath().isPresent() ? GoogleCredentials.fromStream(new FileInputStream(arguments.privateKeyPath().get()))
+                        .createScoped(ComputeScopes.all()) : GoogleCredentials.getApplicationDefault();
+        ;
         GSUtil.configure(false, 4);
-        GSUtil.auth(arguments.cloudSdkPath(), arguments.privateKeyPath());
+        if (arguments.privateKeyPath().isPresent()) {
+            GSUtil.auth(arguments.cloudSdkPath(), arguments.privateKeyPath().get());
+        }
         return credentials;
     }
 


### PR DESCRIPTION
Makes the private key an optional argument, and if not present will use
the users own account to interact with the GCP apis. Note the service
account email is still required.

Not the cleanest use of Optional but as the credentials throw an
exception, this looks better than using map or ifpresent.