### PR TITLE
DEV-1094 Upload dispatcher log on completion

### DIFF
--- a/batch/src/main/java/com/hartwig/batch/input/InputBundle.java
+++ b/batch/src/main/java/com/hartwig/batch/input/InputBundle.java
@@ -1,12 +1,17 @@
 package com.hartwig.batch.input;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 import static java.lang.String.format;
 
+@JsonSerialize
 public class InputBundle {
+    @JsonProperty
     private List<InputFileDescriptor> inputs;
 
     public InputBundle(Collection<InputFileDescriptor> inputs) {

--- a/batch/src/main/java/com/hartwig/batch/input/InputFileDescriptor.java
+++ b/batch/src/main/java/com/hartwig/batch/input/InputFileDescriptor.java
@@ -1,13 +1,18 @@
 package com.hartwig.batch.input;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
 @Value.Immutable
+@JsonSerialize(as = ImmutableInputFileDescriptor.class)
 public abstract class InputFileDescriptor {
     @Value.Parameter
+    @JsonProperty("key")
     public abstract String name();
 
     @Value.Parameter
+    @JsonProperty("value")
     public abstract String remoteFilename();
 
     @Value.Parameter

--- a/cluster/src/main/java/com/hartwig/pipeline/storage/RuntimeBucket.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/storage/RuntimeBucket.java
@@ -1,8 +1,5 @@
 package com.hartwig.pipeline.storage;
 
-import java.io.InputStream;
-import java.util.List;
-
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Bucket;
@@ -14,9 +11,11 @@ import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.CommonArguments;
 import com.hartwig.pipeline.alignment.Run;
 import com.hartwig.pipeline.metadata.RunMetadata;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.util.List;
 
 public class RuntimeBucket {
 
@@ -116,6 +115,10 @@ public class RuntimeBucket {
 
     public String runId() {
         return runId;
+    }
+
+    public Bucket getUnderlyingBucket() {
+        return bucket;
     }
 
     @Override


### PR DESCRIPTION
Also improve the logging to include the versions as we do with the
pipeline. Further the mapping between the VM label ("number" in the
batch) and the input is now pushed to the runtime bucket at startup
so the operator can get an idea of what is going on while the run is
still happening.

The namespacing for the output has been refined so that all of the
output for a particular VM instance goes into its own directory rather
than one big directory as that does not work very well for involved
outputs.