### PR TITLE
DEV-1092 Allow VM to specify disk requirements

### DIFF
--- a/batch/src/main/java/com/hartwig/batch/operations/Bam2Fastq.java
+++ b/batch/src/main/java/com/hartwig/batch/operations/Bam2Fastq.java
@@ -27,21 +27,21 @@ public class Bam2Fastq implements BatchOperation {
     @Override
     public VirtualMachineJobDefinition execute(InputBundle inputs, RuntimeBucket bucket, BashStartupScript startupScript, RuntimeFiles executionFlags) {
         InputFileDescriptor descriptor = inputs.get();
-        String localCopyOfBam = format("%s/%s", VmDirectories.OUTPUT, new File(descriptor.remoteFilename()).getName());
+        String localCopyOfBam = format("%s/%s", VmDirectories.INPUT, new File(descriptor.remoteFilename()).getName());
         startupScript.addCommand(() -> descriptor.toCommandForm(localCopyOfBam));
         startupScript.addCommand(new PipeCommands(new SambambaCommand("view", "-H", localCopyOfBam),
                 () -> "grep ^@RG",
                 () -> "grep -cP \"_L00[1-8]_\""
         ));
         List<String> picargs = ImmutableList.of("SamToFastq", "ODIR=" + VmDirectories.OUTPUT, "OPRG=true", "RGT=ID", "NON_PF=true", "RC=true", "I=" + localCopyOfBam);
-        startupScript.addCommand(new JavaJarCommand("picard", "2.18.27", "picard.jar", "12G", picargs));
+        startupScript.addCommand(new JavaJarCommand("picard", "2.18.27", "picard.jar", "16G", picargs));
         startupScript.addCommand(() -> format("rename 's/(.+)_(.+)_(.+)_(.+)_(.+)__(.+)\\.fastq/$1_$2_$3_$4_R$6_$5.fastq/' %s/*.fastq", VmDirectories.OUTPUT));
         startupScript.addCommand(() -> format("pigz %s/*.fastq", VmDirectories.OUTPUT));
         startupScript.addCommand(new OutputUpload(GoogleStorageLocation.of(bucket.name(), "bam2fastq"), executionFlags));
 
         return ImmutableVirtualMachineJobDefinition.builder().name("bam2fastq").startupCommand(startupScript)
-                .namespacedResults(ResultsDirectory.defaultDirectory())
-                .performanceProfile(VirtualMachinePerformanceProfile.custom(8, 16)).build();
+                .namespacedResults(ResultsDirectory.defaultDirectory()).workingDiskSpaceGb(1800)
+                .performanceProfile(VirtualMachinePerformanceProfile.custom(4, 20)).build();
     }
 
     @Override

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/ComputeEngine.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/ComputeEngine.java
@@ -5,7 +5,17 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.compute.Compute;
-import com.google.api.services.compute.model.*;
+import com.google.api.services.compute.model.AccessConfig;
+import com.google.api.services.compute.model.AttachedDisk;
+import com.google.api.services.compute.model.AttachedDiskInitializeParams;
+import com.google.api.services.compute.model.Image;
+import com.google.api.services.compute.model.Instance;
+import com.google.api.services.compute.model.Metadata;
+import com.google.api.services.compute.model.NetworkInterface;
+import com.google.api.services.compute.model.Operation;
+import com.google.api.services.compute.model.Scheduling;
+import com.google.api.services.compute.model.ServiceAccount;
+import com.google.api.services.compute.model.Zone;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.hartwig.pipeline.CommonArguments;
@@ -30,7 +40,6 @@ import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 
 public class ComputeEngine {
-    private static final int NUMBER_OF_375G_LOCAL_SSD_DEVICES = 4;
     private final static String APPLICATION_NAME = "vm-hosted-workload";
     static final String ZONE_EXHAUSTED_ERROR_CODE = "ZONE_RESOURCE_POOL_EXHAUSTED";
     static final String UNSUPPORTED_OPERATION_ERROR_CODE = "UNSUPPORTED_OPERATION";
@@ -100,17 +109,14 @@ public class ComputeEngine {
                 instance.setLabels(Labels.ofRun(bucket.runId(), jobDefinition.name(), arguments));
 
                 addServiceAccount(instance);
-                Image image = attachDisks(compute, instance, jobDefinition.imageFamily(), jobDefinition.imageSizeGb(),
-                        project,
-                        vmName,
-                        currentZone.getName());
+                Image image = attachDisks(compute, instance, jobDefinition, project, vmName, currentZone.getName());
                 LOGGER.info("Submitting compute engine job [{}] using image [{}] in zone [{}]",
                         vmName,
                         image.getName(),
                         currentZone.getName());
                 String startupScript = arguments.useLocalSsds()
                         ? jobDefinition.startupCommand()
-                        .asUnixString(new LocalSsdStorageStrategy(NUMBER_OF_375G_LOCAL_SSD_DEVICES))
+                        .asUnixString(new LocalSsdStorageStrategy(jobDefinition.localSsdCount()))
                         : jobDefinition.startupCommand().asUnixString();
                 addStartupCommand(instance, bucket, flags, startupScript);
                 addNetworkInterface(instance, project);
@@ -195,28 +201,28 @@ public class ComputeEngine {
         instance.setNetworkInterfaces(singletonList(networkInterface));
     }
 
-    private Image attachDisks(Compute compute, Instance instance, String imageFamily, long imageSizeGb, String projectName, String vmName,
-            String zone) throws IOException {
-        Image sourceImage = resolveLatestImage(compute, imageFamily, projectName);
+    private Image attachDisks(Compute compute, Instance instance, VirtualMachineJobDefinition jobDefinition, String projectName, String vmName,
+                              String zone) throws IOException {
+        Image sourceImage = resolveLatestImage(compute, jobDefinition.imageFamily(), projectName);
         AttachedDisk disk = new AttachedDisk();
         disk.setBoot(true);
         disk.setAutoDelete(true);
         AttachedDiskInitializeParams params = new AttachedDiskInitializeParams();
         params.setSourceImage(sourceImage.getSelfLink());
         params.setDiskType(format("%s/zones/%s/diskTypes/pd-ssd", apiBaseUrl(projectName), zone));
-        params.setDiskSizeGb(arguments.useLocalSsds() ? imageSizeGb : 1000L);
+        params.setDiskSizeGb(arguments.useLocalSsds() ? jobDefinition.baseImageDiskSizeGb() : jobDefinition.totalPersistentDiskSizeGb());
         disk.setInitializeParams(params);
         List<AttachedDisk> disks = new ArrayList<>(singletonList(disk));
         if (arguments.useLocalSsds()) {
-            attachLocalSsds(disks, projectName, zone);
+            attachLocalSsds(disks, jobDefinition.localSsdCount(), projectName, zone);
         }
         instance.setDisks(disks);
         compute.instances().attachDisk(projectName, zone, vmName, disk);
         return sourceImage;
     }
 
-    private void attachLocalSsds(List<AttachedDisk> disks, String projectName, String zone) {
-        for (int i = 0; i < NUMBER_OF_375G_LOCAL_SSD_DEVICES; i++) {
+    private void attachLocalSsds(List<AttachedDisk> disks, int deviceCount, String projectName, String zone) {
+        for (int i = 0; i < deviceCount; i++) {
             AttachedDisk disk = new AttachedDisk();
             disk.setBoot(false);
             disk.setAutoDelete(true);

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/InstanceLifecycleManager.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/InstanceLifecycleManager.java
@@ -1,14 +1,5 @@
 package com.hartwig.pipeline.execution.vm;
 
-import static java.lang.String.format;
-
-import java.io.File;
-import java.io.IOException;
-import java.time.Duration;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
 import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.ComputeRequest;
 import com.google.api.services.compute.model.Instance;
@@ -17,13 +8,20 @@ import com.google.api.services.compute.model.Metadata;
 import com.google.api.services.compute.model.Operation;
 import com.google.api.services.compute.model.Zone;
 import com.hartwig.pipeline.CommonArguments;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
 import net.jodah.failsafe.function.CheckedSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
 
 class InstanceLifecycleManager {
     private static final String RUNNING_STATUS = "RUNNING";
@@ -123,7 +121,7 @@ class InstanceLifecycleManager {
             try {
                 Thread.sleep(500);
             } catch (InterruptedException ie) {
-                Thread.interrupted();
+                Thread.currentThread().interrupt();
             }
         }
         return executeWithRetries(() -> compute.zoneOperations().get(projectName, zoneName, asyncOp.getName()).execute());

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
@@ -10,19 +10,44 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
 
     String STANDARD_IMAGE = "pipeline5-" +Versions.imageVersion();
 
+    @Value.Derived
+    default long baseImageDiskSizeGb() {
+        return 100L;
+    }
+
     @Value.Default
     default String imageFamily() {
         return STANDARD_IMAGE;
     }
 
     @Value.Default
-    default long imageSizeGb() {
-        return 100L;
+    default long workingDiskSpaceGb() {
+        return 900L;
     }
 
     BashStartupScript startupCommand();
 
     ResultsDirectory namespacedResults();
+
+    @Value.Derived
+    default long totalPersistentDiskSizeGb() {
+        return baseImageDiskSizeGb() + workingDiskSpaceGb();
+    }
+
+    @Value.Derived
+    default int localSsdCount() {
+        int localSsdDeviceSizeGbb = 375;
+
+        int floor = Math.toIntExact(workingDiskSpaceGb() / localSsdDeviceSizeGbb);
+        long remainder = workingDiskSpaceGb() % localSsdDeviceSizeGbb;
+        if (remainder != 0) {
+            floor++;
+        }
+        if (floor % 2 != 0) {
+            floor++;
+        }
+        return floor;
+    }
 
     @Override
     @Value.Default

--- a/cluster/src/test/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinitionTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinitionTest.java
@@ -1,0 +1,50 @@
+package com.hartwig.pipeline.execution.vm;
+
+import com.hartwig.pipeline.ResultsDirectory;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class VirtualMachineJobDefinitionTest {
+    private static final long BASE_IMAGE_SIZE_GB = 100L;
+    private static final int LOCAL_SSD_DEVICE_CAPACITY_GB = 375;
+
+    private VirtualMachineJobDefinition victim;
+    private ImmutableVirtualMachineJobDefinition.Builder builder;
+
+    @Before
+    public void setup() {
+        BashStartupScript startupScript = mock(BashStartupScript.class);
+        builder = VirtualMachineJobDefinition.builder().startupCommand(startupScript)
+                .namespacedResults(ResultsDirectory.defaultDirectory())
+                .name("victim");
+    }
+
+    @Test
+    public void shouldDeriveTotalSizeForPersistentDisk() {
+        long workingSpace = 900L;
+        victim = builder.workingDiskSpaceGb(workingSpace).build();
+        assertThat(victim.totalPersistentDiskSizeGb()).isEqualTo(workingSpace + BASE_IMAGE_SIZE_GB);
+    }
+
+    @Test
+    public void shouldDeriveLocalSsdCountFromWorkingDiskSpace() {
+        int ssdCount = 4;
+        victim = builder.workingDiskSpaceGb(ssdCount * LOCAL_SSD_DEVICE_CAPACITY_GB - 100).build();
+        assertThat(victim.localSsdCount()).isEqualTo(ssdCount);
+    }
+
+    @Test
+    public void shouldReturnNextHigherEvenNumberIfCalculatedSsdRequirementIsOddToAvoidRuntimeErrorsFromApi() {
+        victim = builder.workingDiskSpaceGb(15 * LOCAL_SSD_DEVICE_CAPACITY_GB - 100).build();
+        assertThat(victim.localSsdCount()).isEqualTo(16);
+    }
+
+    @Test
+    public void shouldReturnExactNumberOfSsdsIfRequiredCapacityIsExactEvenMultipleOfDeviceSize() {
+        victim = builder.workingDiskSpaceGb(6 * LOCAL_SSD_DEVICE_CAPACITY_GB).build();
+        assertThat(victim.localSsdCount()).isEqualTo(6);
+    }
+}


### PR DESCRIPTION
Also decouple the disk size from the type so that whether local SSDs
or persistent storage is chosen an appropriate size will be selected
based upon the requirements of the job definition.

Also slightly amend the Bam2Fastq job to take advantage of the changes
and also hike its memory as some jobs were failing due to GC overhead
exceeding the setpoint.