### PR TITLE
DEV-1101 Integrate pipeline5 with bcl2fastq on GCP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 branches:
   only:
-    - master
+    - DEV-1101
 sudo: required
 language: java
 jdk:

--- a/bcl2fastq/pom.xml
+++ b/bcl2fastq/pom.xml
@@ -57,7 +57,7 @@
                                 <manifest>
                                     <useUniqueVersions>false</useUniqueVersions>
                                     <addClasspath>true</addClasspath>
-                                    <mainClass>com.hartwig.pipeline.PipelineMain</mainClass>
+                                    <mainClass>com.hartwig.bcl2fastq.Bcl2Fastq</mainClass>
                                     <classpathPrefix>lib/</classpathPrefix>
                                     <addDefaultImplementationEntries>
                                         true

--- a/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/Bcl2Fastq.java
+++ b/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/Bcl2Fastq.java
@@ -77,6 +77,7 @@ class Bcl2Fastq {
                 .startupCommand(bash)
                 .performanceProfile(VirtualMachinePerformanceProfile.custom(96, 90))
                 .namespacedResults(resultsDirectory)
+                .workingDiskSpaceGb(5000)
                 .build();
     }
 

--- a/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/Bcl2Fastq.java
+++ b/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/Bcl2Fastq.java
@@ -16,6 +16,7 @@ import com.hartwig.pipeline.execution.vm.ComputeEngine;
 import com.hartwig.pipeline.execution.vm.OutputUpload;
 import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
 import com.hartwig.pipeline.execution.vm.VmDirectories;
+import com.hartwig.pipeline.storage.GSUtil;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 import com.hartwig.pipeline.storage.StorageProvider;
@@ -58,8 +59,9 @@ class Bcl2Fastq {
 
         new OutputCopy(storage, arguments.outputBucket(), bucket).andThen(new FastqMetadataRegistration(sbpFastqMetadataApi,
                 arguments.outputBucket(),
-                stringOf(bucket, "/run.log"))).accept(new ResultAggregation(bucket.getUnderlyingBucket()).apply(sampleSheet, stats));
+                stringOf(bucket, "/run.log"))).accept(new ResultAggregation(bucket, resultsDirectory).apply(sampleSheet, stats));
 
+        GSUtil.rm(arguments.cloudSdkPath(), bucket.runId());
         LOGGER.info("bcl2fastq complete for flowcell [{}]", arguments.flowcell());
     }
 

--- a/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/Bcl2Fastq.java
+++ b/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/Bcl2Fastq.java
@@ -13,8 +13,10 @@ import com.hartwig.pipeline.ResultsDirectory;
 import com.hartwig.pipeline.credentials.CredentialProvider;
 import com.hartwig.pipeline.execution.vm.BashStartupScript;
 import com.hartwig.pipeline.execution.vm.ComputeEngine;
+import com.hartwig.pipeline.execution.vm.ImmutableVirtualMachineJobDefinition;
 import com.hartwig.pipeline.execution.vm.OutputUpload;
 import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
+import com.hartwig.pipeline.execution.vm.VirtualMachinePerformanceProfile;
 import com.hartwig.pipeline.execution.vm.VmDirectories;
 import com.hartwig.pipeline.storage.GSUtil;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
@@ -49,10 +51,13 @@ class Bcl2Fastq {
         RuntimeBucket bucket = RuntimeBucket.from(storage, "bcl2fastq", metadata, arguments);
         BashStartupScript bash = BashStartupScript.of(bucket.name());
         BclDownload bclDownload = new BclDownload(arguments.inputBucket(), arguments.flowcell());
+        VirtualMachineJobDefinition jobDefinition = jobDefinition(bash);
         bash.addCommand(bclDownload)
-                .addCommand(new Bcl2FastqCommand(bclDownload.getLocalTargetPath(), VmDirectories.OUTPUT))
+                .addCommand(new Bcl2FastqCommand(bclDownload.getLocalTargetPath(),
+                        VmDirectories.OUTPUT,
+                        jobDefinition.performanceProfile().machineType().cpus()))
                 .addCommand(new OutputUpload(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path())));
-        computeEngine.submit(bucket, VirtualMachineJobDefinition.bcl2fastq(bash, resultsDirectory));
+        computeEngine.submit(bucket, jobDefinition);
 
         SampleSheet sampleSheet = new SampleSheetCsv(storage.get(arguments.inputBucket()), arguments.flowcell()).read();
         Stats stats = new StatsJson(stringOf(bucket, "/Stats/Stats.json")).stats();
@@ -63,6 +68,16 @@ class Bcl2Fastq {
 
         GSUtil.rm(arguments.cloudSdkPath(), bucket.runId());
         LOGGER.info("bcl2fastq complete for flowcell [{}]", arguments.flowcell());
+    }
+
+    private ImmutableVirtualMachineJobDefinition jobDefinition(final BashStartupScript bash) {
+        return ImmutableVirtualMachineJobDefinition.builder()
+                .name("bcl2fastq")
+                .imageFamily("bcl2fastq-standard")
+                .startupCommand(bash)
+                .performanceProfile(VirtualMachinePerformanceProfile.custom(96, 90))
+                .namespacedResults(resultsDirectory)
+                .build();
     }
 
     private String stringOf(final RuntimeBucket bucket, final String blobName) {

--- a/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/Bcl2FastqCommand.java
+++ b/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/Bcl2FastqCommand.java
@@ -5,16 +5,19 @@ import com.hartwig.pipeline.tools.Versions;
 
 class Bcl2FastqCommand extends VersionedToolCommand {
 
-    Bcl2FastqCommand(final String workingDirectory, final String outputDirectory) {
-        super("bcl2fastq", "bcl2fastq",
+    Bcl2FastqCommand(final String workingDirectory, final String outputDirectory, final int totalCpus) {
+        super("bcl2fastq",
+                "bcl2fastq",
                 Versions.BCL2FASTQ,
                 "-R",
                 workingDirectory,
                 "-o",
                 outputDirectory,
-                "--ignore-missing-bcls",
-                "--ignore-missing-filter",
-                "--ignore-missing-positions",
-                "--ignore-missing-controls");
+                "-r",
+                String.valueOf(totalCpus / 2),
+                "-w",
+                String.valueOf(totalCpus / 2),
+                "-p",
+                String.valueOf(totalCpus));
     }
 }

--- a/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/Bcl2fastqArguments.java
+++ b/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/Bcl2fastqArguments.java
@@ -41,6 +41,8 @@ public interface Bcl2fastqArguments extends CommonArguments {
                     .inputBucket(commandLine.getOptionValue(INPUT_BUCKET))
                     .outputBucket(commandLine.getOptionValue(OUTPUT_BUCKET))
                     .sbpApiUrl(commandLine.getOptionValue(SBP_API_URL))
+                    .useLocalSsds(false)
+                    .usePreemptibleVms(false)
                     .build();
         } catch (ParseException e) {
             throw new IllegalArgumentException("Failed to parse arguments", e);

--- a/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/Bcl2fastqArguments.java
+++ b/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/Bcl2fastqArguments.java
@@ -35,7 +35,6 @@ public interface Bcl2fastqArguments extends CommonArguments {
                     .region(commandLine.getOptionValue(REGION, "europe-west4"))
                     .useLocalSsds(parseBoolean(commandLine.getOptionValue(LOCAL_SSDS, "true")))
                     .usePreemptibleVms(parseBoolean(commandLine.getOptionValue(PREEMPTIBLE_VMS, "true")))
-                    .privateKeyPath(commandLine.getOptionValue(PRIVATE_KEY_PATH))
                     .cloudSdkPath(commandLine.getOptionValue(CLOUD_SDK, System.getProperty("user.home") + "/gcloud/google-cloud-sdk/bin"))
                     .serviceAccountEmail(commandLine.getOptionValue(SERVICE_ACCOUNT_EMAIL))
                     .flowcell(commandLine.getOptionValue(FLOWCELL))

--- a/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/metadata/FastqMetadataRegistration.java
+++ b/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/metadata/FastqMetadataRegistration.java
@@ -55,7 +55,7 @@ public class FastqMetadataRegistration implements Consumer<Conversion> {
                                 .hash_r2(convertMd5ToSbpFormat(convertedFastq.md5R2()))
                                 .yld(convertedFastq.yield())
                                 .q30(Q30.of(convertedFastq))
-                                .qc_pass(QualityControl.minimumQ30(convertedFastq, sbpSample.q30_req().orElseThrow()))
+                                .qc_pass(QualityControl.minimumQ30(convertedFastq, sbpSample.q30_req().orElse(0d)))
                                 .build());
                     }
                 }

--- a/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/metadata/SbpFastqMetadataApi.java
+++ b/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/metadata/SbpFastqMetadataApi.java
@@ -55,7 +55,7 @@ public class SbpFastqMetadataApi {
                 try {
                     Response response = samples().request()
                             .post(Entity.entity(objectMapper.writeValueAsString(sample), MediaType.APPLICATION_JSON_TYPE));
-                    if (response.getStatus() == 200) {
+                    if (response.getStatus() == 201) {
                         return findOrCreate(barcode, submission);
                     } else {
                         throw new RuntimeException(String.format("Unable to post new sample [%s] api returned status [%s] and message [%s]",
@@ -97,7 +97,7 @@ public class SbpFastqMetadataApi {
                 Response response = api().path("lanes")
                         .request()
                         .post(Entity.entity(objectMapper.writeValueAsString(sbpLane), MediaType.APPLICATION_JSON_TYPE));
-                if (response.getStatus() == 200) {
+                if (response.getStatus() == 201) {
                     LOGGER.info("Posting lane for flowcell [{}] with name [{}] complete with status [{}]",
                             sbpLane.flowcell_id(),
                             sbpLane.name(),

--- a/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/metadata/SbpFastqMetadataApi.java
+++ b/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/metadata/SbpFastqMetadataApi.java
@@ -55,7 +55,7 @@ public class SbpFastqMetadataApi {
                 try {
                     Response response = samples().request()
                             .post(Entity.entity(objectMapper.writeValueAsString(sample), MediaType.APPLICATION_JSON_TYPE));
-                    if (response.getStatus() == 201) {
+                    if (isCreated(response)) {
                         return findOrCreate(barcode, submission);
                     } else {
                         throw new RuntimeException(String.format("Unable to post new sample [%s] api returned status [%s] and message [%s]",
@@ -70,6 +70,10 @@ public class SbpFastqMetadataApi {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public boolean isCreated(final Response response) {
+        return response.getStatus() == Response.Status.CREATED.getStatusCode();
     }
 
     public void create(SbpFastq fastq) {
@@ -97,7 +101,7 @@ public class SbpFastqMetadataApi {
                 Response response = api().path("lanes")
                         .request()
                         .post(Entity.entity(objectMapper.writeValueAsString(sbpLane), MediaType.APPLICATION_JSON_TYPE));
-                if (response.getStatus() == 201) {
+                if (isCreated(response)) {
                     LOGGER.info("Posting lane for flowcell [{}] with name [{}] complete with status [{}]",
                             sbpLane.flowcell_id(),
                             sbpLane.name(),

--- a/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
@@ -19,6 +19,8 @@ public interface Arguments extends CommonArguments {
 
     boolean upload();
 
+    boolean uploadFromGcp();
+
     boolean runBamMetrics();
 
     boolean runAligner();
@@ -111,6 +113,7 @@ public interface Arguments extends CommonArguments {
                     .usePreemptibleVms(true)
                     .useLocalSsds(true)
                     .upload(true)
+                    .uploadFromGcp(false)
                     .runBamMetrics(true)
                     .runAligner(true)
                     .runSnpGenotyper(true)
@@ -138,6 +141,7 @@ public interface Arguments extends CommonArguments {
                     .usePreemptibleVms(true)
                     .useLocalSsds(true)
                     .upload(true)
+                    .uploadFromGcp(false)
                     .runBamMetrics(true)
                     .runAligner(true)
                     .runSnpGenotyper(true)
@@ -172,6 +176,7 @@ public interface Arguments extends CommonArguments {
                     .usePreemptibleVms(true)
                     .useLocalSsds(true)
                     .upload(true)
+                    .uploadFromGcp(false)
                     .runBamMetrics(true)
                     .runAligner(true)
                     .runSnpGenotyper(true)

--- a/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
@@ -169,7 +169,6 @@ public interface Arguments extends CommonArguments {
                     .project(DEFAULT_DEVELOPMENT_PROJECT)
                     .version(DEFAULT_DEVELOPMENT_VERSION)
                     .sampleDirectory(DEFAULT_DOCKER_SAMPLE_DIRECTORY)
-                    .privateKeyPath(DEFAULT_DOCKER_KEY_PATH)
                     .cloudSdkPath(DEFAULT_DOCKER_CLOUD_SDK_PATH)
                     .serviceAccountEmail(DEFAULT_DEVELOPMENT_SERVICE_ACCOUNT_EMAIL)
                     .cleanup(true)

--- a/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
@@ -19,6 +19,7 @@ public class CommandLineOptions {
     private static final String VERSION_FLAG = "version";
     private static final String CLEANUP_FLAG = "cleanup";
     private static final String UPLOAD_FLAG = "upload";
+    private static final String UPLOAD_FROM_GCP_FLAG = "upload_from_gcp";
     private static final String PROJECT_FLAG = "project";
     private static final String REGION_FLAG = "region";
     private static final String PRIVATE_KEY_FLAG = "private_key_path";
@@ -80,6 +81,8 @@ public class CommandLineOptions {
                 .addOption(optionWithBooleanArg(UPLOAD_FLAG,
                         "Don't upload the sample to storage. "
                                 + "This should be used in combination with a run_id which points at an existing bucket"))
+                .addOption(optionWithBooleanArg(UPLOAD_FROM_GCP_FLAG, "Upload sample fastq from GCP instead of SBP S3. "
+                        + "Temporary feature toggle while transitioning to bcl2fastq on GCP."))
                 .addOption(project())
                 .addOption(region())
                 .addOption(sbpSampleId())
@@ -255,6 +258,7 @@ public class CommandLineOptions {
                     .usePreemptibleVms(booleanOptionWithDefault(commandLine, USE_PREEMTIBLE_VMS_FLAG, defaults.usePreemptibleVms()))
                     .useLocalSsds(booleanOptionWithDefault(commandLine, USE_LOCAL_SSDS_FLAG, defaults.useLocalSsds()))
                     .upload(booleanOptionWithDefault(commandLine, UPLOAD_FLAG, defaults.upload()))
+                    .uploadFromGcp(booleanOptionWithDefault(commandLine, UPLOAD_FROM_GCP_FLAG, defaults.uploadFromGcp()))
                     .rclonePath(commandLine.getOptionValue(RCLONE_PATH_FLAG, defaults.rclonePath()))
                     .rcloneGcpRemote(commandLine.getOptionValue(RCLONE_GCP_REMOTE_FLAG, defaults.rcloneGcpRemote()))
                     .rcloneS3RemoteDownload(commandLine.getOptionValue(RCLONE_S3_REMOTE_DOWNLOAD_FLAG, defaults.rcloneS3RemoteDownload()))

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/AlignerProvider.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/AlignerProvider.java
@@ -16,6 +16,7 @@ import com.hartwig.pipeline.execution.vm.ComputeEngine;
 import com.hartwig.pipeline.sbpapi.SbpRestApi;
 import com.hartwig.pipeline.storage.CloudCopy;
 import com.hartwig.pipeline.storage.CloudSampleUpload;
+import com.hartwig.pipeline.storage.GSFileSource;
 import com.hartwig.pipeline.storage.GSUtilCloudCopy;
 import com.hartwig.pipeline.storage.LocalFileSource;
 import com.hartwig.pipeline.storage.RCloneCloudCopy;
@@ -93,7 +94,8 @@ public abstract class AlignerProvider {
                     getArguments().rcloneGcpRemote(),
                     getArguments().rcloneS3RemoteDownload(),
                     ProcessBuilder::new);
-            SampleUpload sampleUpload = new CloudSampleUpload(new SbpS3FileSource(), cloudCopy);
+            SampleUpload sampleUpload =
+                    new CloudSampleUpload(getArguments().uploadFromGcp() ? new GSFileSource() : new SbpS3FileSource(), cloudCopy);
             return AlignerProvider.constructVmAligner(getArguments(),
                     credentials,
                     storage,

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/MachineType.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/MachineType.java
@@ -1,5 +1,7 @@
 package com.hartwig.pipeline.execution;
 
+import static java.lang.String.format;
+
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -17,7 +19,7 @@ public interface MachineType {
     int cpus();
 
     @Value.Default
-    default int diskSizeGB(){
+    default int diskSizeGB() {
         return DEFAULT_DISK_SIZE;
     }
 
@@ -39,6 +41,10 @@ public interface MachineType {
 
     static MachineType defaultMaster() {
         return ImmutableMachineType.builder().uri(GOOGLE_STANDARD_16).memoryGB(60).cpus(16).diskSizeGB(1000).build();
+    }
+
+    static MachineType custom(int memoryGB, int cores) {
+        return ImmutableMachineType.builder().uri(format("custom-%d-%d", cores, memoryGB * 1024)).cpus(cores).memoryGB(memoryGB).build();
     }
 
     static ImmutableMachineType.Builder builder() {

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
@@ -139,16 +139,6 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
                 .build();
     }
 
-    static VirtualMachineJobDefinition bcl2fastq(BashStartupScript startupScript, ResultsDirectory resultsDirectory) {
-        return ImmutableVirtualMachineJobDefinition.builder()
-                .name("bcl2fastq")
-                .imageFamily("bcl2fastq-standard")
-                .startupCommand(startupScript)
-                .performanceProfile(VirtualMachinePerformanceProfile.custom(96, 90))
-                .namespacedResults(resultsDirectory)
-                .build();
-    }
-
     static VirtualMachineJobDefinition alignment(String lane, BashStartupScript startupScript, ResultsDirectory resultsDirectory) {
         return ImmutableVirtualMachineJobDefinition.builder()
                 .name("aligner-" + lane)

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachinePerformanceProfile.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachinePerformanceProfile.java
@@ -1,24 +1,26 @@
 package com.hartwig.pipeline.execution.vm;
 
-import static java.lang.String.format;
-
 import com.hartwig.pipeline.execution.MachineType;
 import com.hartwig.pipeline.execution.PerformanceProfile;
 
 import org.immutables.value.Value;
 
 @Value.Immutable
-public interface VirtualMachinePerformanceProfile extends PerformanceProfile{
+public interface VirtualMachinePerformanceProfile extends PerformanceProfile {
 
-    String uri();
+    @Value.Default
+    default String uri() {
+        return machineType().uri();
+    }
+
+    MachineType machineType();
 
     static VirtualMachinePerformanceProfile defaultVm() {
-        return ImmutableVirtualMachinePerformanceProfile.builder().uri(MachineType.defaultVm().uri()).build();
+        return ImmutableVirtualMachinePerformanceProfile.builder().machineType(MachineType.defaultVm()).build();
     }
 
     static VirtualMachinePerformanceProfile custom(int cores, int memoryGb) {
-        return ImmutableVirtualMachinePerformanceProfile.builder()
-                .uri(format("custom-%d-%d", cores, memoryGb * 1024))
-                .build();
+
+        return ImmutableVirtualMachinePerformanceProfile.builder().machineType(MachineType.custom(memoryGb, cores)).build();
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/storage/GSFileSource.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/storage/GSFileSource.java
@@ -1,0 +1,11 @@
+package com.hartwig.pipeline.storage;
+
+import java.util.function.Function;
+
+public class GSFileSource implements Function<String, String> {
+
+    @Override
+    public String apply(final String file) {
+        return String.format("gs://%s", file);
+    }
+}

--- a/cluster/src/test/java/com/hartwig/pipeline/smoke/SmokeTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/smoke/SmokeTest.java
@@ -28,9 +28,11 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+@Ignore
 @Category(value = IntegrationTest.class)
 public class SmokeTest {
     private static final String ARCHIVE_BUCKET = "hmf-output-test";


### PR DESCRIPTION
Adds a toggle that once enabled, will upload fastq input from GCP rather than the SBP S3.
The location of the fastq is still taken from the SBP API (run->sample->fastq).

Also updated the Bcl2Fastq command thread settings to match production.