### PR TITLE
DEV-1106 Always use a second PD SSD when local SSDs disabled

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/ComputeEngine.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/ComputeEngine.java
@@ -211,11 +211,11 @@ public class ComputeEngine {
         AttachedDisk bootDisk = new AttachedDisk();
         bootDisk.setBoot(true);
         bootDisk.setAutoDelete(true);
-        AttachedDiskInitializeParams params = new AttachedDiskInitializeParams();
-        params.setSourceImage(sourceImage.getSelfLink());
-        params.setDiskType(pdssd(projectName, zone));
-        params.setDiskSizeGb(jobDefinition.baseImageDiskSizeGb());
-        bootDisk.setInitializeParams(params);
+        AttachedDiskInitializeParams bootDiskParams = new AttachedDiskInitializeParams();
+        bootDiskParams.setSourceImage(sourceImage.getSelfLink());
+        bootDiskParams.setDiskType(pdssd(projectName, zone));
+        bootDiskParams.setDiskSizeGb(jobDefinition.baseImageDiskSizeGb());
+        bootDisk.setInitializeParams(bootDiskParams);
         List<AttachedDisk> disks = new ArrayList<>(singletonList(bootDisk));
         if (arguments.useLocalSsds()) {
             attachLocalSsds(disks, jobDefinition.localSsdCount(), projectName, zone);

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/storage/PersistentStorageStrategy.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/storage/PersistentStorageStrategy.java
@@ -1,14 +1,14 @@
 package com.hartwig.pipeline.execution.vm.storage;
 
-import java.util.List;
-
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+
+import java.util.List;
 
 public class PersistentStorageStrategy implements StorageStrategy {
     @Override
     public List<String> initialise() {
-        String device = "/dev/whatever";
+        String device = "/dev/sdb";
         String mountPoint = "/data";
         return asList("mkdir -p " + mountPoint, "mkfs.ext4 -F " + device, format("mount %s %s", device, mountPoint));
     }

--- a/cluster/src/test/java/com/hartwig/pipeline/execution/vm/storage/PersistentStorageStrategyTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/execution/vm/storage/PersistentStorageStrategyTest.java
@@ -1,0 +1,17 @@
+package com.hartwig.pipeline.execution.vm.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.Test;
+
+public class PersistentStorageStrategyTest {
+
+    @Test
+    public void mountsSecondVolumeDeviceToData() {
+        PersistentStorageStrategy victim = new PersistentStorageStrategy();
+        List<String> results = victim.initialise();
+        assertThat(results).containsExactly("mkdir -p /data", "mkfs.ext4 -F /dev/sdb", "mount /dev/sdb /data");
+    }
+}


### PR DESCRIPTION
This solves the issue of the 2TB limit of the boot disk. The boot disk will
always be 100GB (although perhaps that can be reduced?) and workind disk size
the size of the new disk.

The disk is mounted in the startup script with the PersistentStorageStrategy.
this mounts /dev/sdb to /data.