### PR TITLE
DEV-1124 Don't update the sample if flowcell fails QC

### DIFF
--- a/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/metadata/FastqMetadataRegistration.java
+++ b/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/metadata/FastqMetadataRegistration.java
@@ -36,7 +36,9 @@ public class FastqMetadataRegistration implements Consumer<Conversion> {
                     && QualityControl.minimumYield(conversion);
             for (ConvertedSample sample : conversion.samples()) {
                 SbpSample sbpSample = sbpApi.findOrCreate(sample.barcode(), sample.project());
-                updateSampleYieldAndStatus(sample, sbpSample);
+                if (flowcellQCPass) {
+                    updateSampleYieldAndStatus(sample, sbpSample);
+                }
                 for (ConvertedFastq convertedFastq : sample.fastq()) {
                     SbpLane sbpLane = sbpApi.findOrCreate(SbpLane.builder()
                             .flowcell_id(sbpFlowcell.id())

--- a/bcl2fastq/src/test/java/com/hartwig/bcl2fastq/metadata/FastqMetadataRegistrationTest.java
+++ b/bcl2fastq/src/test/java/com/hartwig/bcl2fastq/metadata/FastqMetadataRegistrationTest.java
@@ -2,6 +2,7 @@ package com.hartwig.bcl2fastq.metadata;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -150,6 +151,12 @@ public class FastqMetadataRegistrationTest {
         SbpSample result = sampleUpdateCaptor.getValue();
         assertThat(result.q30()).hasValue(86.66666666666667);
         assertThat(result.status()).isEqualTo(SbpSample.STATUS_READY);
+    }
+
+    @Test
+    public void sampleNotUpdatedWhenFlowcellFailsQC() {
+        victim.accept(conversion(EXISTS).undeterminedReads(7).totalReads(100).addSamples(sample().yield(1).build()).build());
+        verify(sbpApi, never()).updateSample(sampleUpdateCaptor.capture());
     }
 
     @Test


### PR DESCRIPTION
This way we won't add additional yield or improve the Q30 average if the flowcell
fails QC.