### PR TITLE
DEV-1129 Use fastq objects to calculate total sample yld/q30

### DIFF
--- a/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/conversion/Conversion.java
+++ b/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/conversion/Conversion.java
@@ -21,7 +21,7 @@ public interface Conversion extends WithYieldAndQ30 {
 
     @Value.Derived
     default long yieldQ30() {
-        return samples().stream().mapToLong(WithYieldAndQ30::yieldQ30).sum();
+        return samples().stream().flatMap(s -> s.fastq().stream()).mapToLong(WithYieldAndQ30::yieldQ30).sum();
     }
 
     List<ConvertedSample> samples();

--- a/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/conversion/ConvertedSample.java
+++ b/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/conversion/ConvertedSample.java
@@ -15,6 +15,18 @@ public interface ConvertedSample extends WithYieldAndQ30 {
 
     List<ConvertedFastq> fastq();
 
+    @Override
+    @Value.Derived
+    default long yield() {
+        return fastq().stream().mapToLong(WithYieldAndQ30::yield).sum();
+    }
+
+    @Override
+    @Value.Derived
+    default long yieldQ30() {
+        return fastq().stream().mapToLong(WithYieldAndQ30::yieldQ30).sum();
+    }
+
     static ImmutableConvertedSample.Builder builder() {
         return ImmutableConvertedSample.builder();
     }

--- a/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/conversion/ResultAggregation.java
+++ b/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/conversion/ResultAggregation.java
@@ -43,8 +43,6 @@ public class ResultAggregation {
                     .barcode(sample.barcode())
                     .sample(sample.sample())
                     .project(sample.project())
-                    .yield(yield(sample.barcode(), stats))
-                    .yieldQ30(yieldQ30(sample.barcode(), stats))
                     .addAllFastq(listResult != null ? listResult.stream()
                             .collect(groupingBy(b -> parseLane(b.getName())))
                             .entrySet()

--- a/bcl2fastq/src/test/java/com/hartwig/bcl2fastq/conversion/ResultAggregationTest.java
+++ b/bcl2fastq/src/test/java/com/hartwig/bcl2fastq/conversion/ResultAggregationTest.java
@@ -154,12 +154,13 @@ public class ResultAggregationTest {
     }
 
     @Test
-    public void sampleYieldAndQ30CalculatedFromStats() {
+    public void sampleYieldAndQ30CalculatedFromFastq() {
+        when(bucket.list(path)).thenReturn(Lists.newArrayList(first, second));
         Conversion conversion = victim.apply(sampleSheet(), defaultStats());
 
         assertThat(conversion.samples()).hasSize(1);
         ConvertedSample sample = conversion.samples().get(0);
-        assertThat(sample.yield()).isEqualTo(2);
+        assertThat(sample.yield()).isEqualTo(3);
         assertThat(sample.yieldQ30()).isEqualTo(3);
     }
 


### PR DESCRIPTION
Queries the fastq object after creating/updating from the conversion, and does
a calculation from the whole set rather than trying to use the state of the
current sample in the API.