### PR TITLE
DEV-1134 Add output service account to the ACL of runtime bucket

### DIFF
--- a/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/Bcl2fastqArguments.java
+++ b/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/Bcl2fastqArguments.java
@@ -16,6 +16,7 @@ public interface Bcl2fastqArguments extends CommonArguments {
 
     String OUTPUT_BUCKET = "output_bucket";
     String OUTPUT_PRIVATE_KEY_PATH = "output_private_key_path";
+    String OUTPUT_SERVICE_ACCOUNT_EMAIL = "output_service_account_email";
     String OUTPUT_PROJECT = "output_project";
     String FLOWCELL = "flowcell";
     String INPUT_BUCKET = "input_bucket";
@@ -38,6 +39,7 @@ public interface Bcl2fastqArguments extends CommonArguments {
                     .sbpApiUrl(commandLine.getOptionValue(SBP_API_URL))
                     .outputBucket(commandLine.getOptionValue(OUTPUT_BUCKET))
                     .outputPrivateKeyPath(commandLine.getOptionValue(OUTPUT_PRIVATE_KEY_PATH))
+                    .outputServiceAccountEmail(commandLine.getOptionValue(OUTPUT_SERVICE_ACCOUNT_EMAIL))
                     .outputProject(commandLine.getOptionValue(OUTPUT_PROJECT))
                     .cleanup(parseBoolean(commandLine.getOptionValue(CLEANUP, "false")))
                     .useLocalSsds(false)
@@ -63,6 +65,8 @@ public interface Bcl2fastqArguments extends CommonArguments {
                 .addOption(stringOption(SBP_API_URL, "URL of the SBP metadata api"))
                 .addOption(stringOption(OUTPUT_BUCKET, "Bucket to copy to on completion"))
                 .addOption(stringOption(OUTPUT_PRIVATE_KEY_PATH, "Credentials used to copy output"))
+                .addOption(stringOption(OUTPUT_SERVICE_ACCOUNT_EMAIL, "Email of service account used to copy data from the conversion into "
+                        + "the fastq storage bucket. Will be added to the ACL of the runtime bucket."))
                 .addOption(stringOption(OUTPUT_PROJECT, "User project for output copying"));
     }
 
@@ -75,6 +79,8 @@ public interface Bcl2fastqArguments extends CommonArguments {
     String sbpApiUrl();
 
     String outputPrivateKeyPath();
+
+    String outputServiceAccountEmail();
 
     String outputProject();
 

--- a/bcl2fastq/src/test/java/com/hartwig/bcl2fastq/OutputCopierTest.java
+++ b/bcl2fastq/src/test/java/com/hartwig/bcl2fastq/OutputCopierTest.java
@@ -1,5 +1,14 @@
 package com.hartwig.bcl2fastq;
 
+import static java.lang.String.format;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.storage.Acl;
 import com.google.cloud.storage.Bucket;
 import com.google.common.collect.ImmutableList;
 import com.hartwig.bcl2fastq.conversion.Conversion;
@@ -7,25 +16,20 @@ import com.hartwig.bcl2fastq.conversion.ConvertedFastq;
 import com.hartwig.bcl2fastq.conversion.ConvertedSample;
 import com.hartwig.pipeline.storage.GsUtilFacade;
 import com.hartwig.pipeline.storage.RuntimeBucket;
+
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static java.lang.String.format;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
+import org.mockito.ArgumentCaptor;
 
 public class OutputCopierTest {
+    public static final String NA = "na";
     private Bcl2fastqArguments arguments;
     private GsUtilFacade gsUtil;
     private OutputCopier victim;
     private RuntimeBucket runtimeBucket;
     private String runtimeBucketName;
     private String runtimePath;
+    private Bucket bucket;
 
     @Before
     public void setup() {
@@ -33,6 +37,8 @@ public class OutputCopierTest {
         gsUtil = mock(GsUtilFacade.class);
         runtimeBucket = mock(RuntimeBucket.class);
         runtimePath = "results/directory";
+        bucket = mock(Bucket.class);
+        when(runtimeBucket.getUnderlyingBucket()).thenReturn(bucket);
         victim = new OutputCopier(arguments, runtimeBucket, gsUtil);
     }
 
@@ -78,6 +84,17 @@ public class OutputCopierTest {
         verifyCopy(fastqcPathR2);
     }
 
+    @Test
+    public void addsOutputServiceAccountEmailToAcl() {
+        Conversion conversion = Conversion.builder().flowcell("flow").totalReads(0).undeterminedReads(0).build();
+        victim.accept(conversion);
+        ArgumentCaptor<Acl> createdAcl = ArgumentCaptor.forClass(Acl.class);
+        verify(bucket).createAcl(createdAcl.capture());
+        Acl result = createdAcl.getValue();
+        assertThat(((Acl.User)result.getEntity()).getEmail()).isEqualTo("output@serviceaccount.com");
+        assertThat(result.getRole()).isEqualTo(Acl.Role.READER);
+    }
+
     private ConvertedFastq mockFastq(String outputPathR1, String outputPathR2) {
         ConvertedFastq fastq = mock(ConvertedFastq.class);
         when(fastq.pathR1()).thenReturn(format("%s/%s", runtimePath, outputPathR1));
@@ -93,14 +110,22 @@ public class OutputCopierTest {
     }
 
     private Bcl2fastqArguments arguments() {
-        List<String> withValues = new ArrayList<>();
-        ImmutableList.of(Bcl2fastqArguments.INPUT_BUCKET,
-                Bcl2fastqArguments.PRIVATE_KEY_PATH, Bcl2fastqArguments.SERVICE_ACCOUNT_EMAIL,
-                Bcl2fastqArguments.FLOWCELL, Bcl2fastqArguments.SBP_API_URL, Bcl2fastqArguments.OUTPUT_BUCKET,
-                Bcl2fastqArguments.OUTPUT_PRIVATE_KEY_PATH, Bcl2fastqArguments.OUTPUT_PROJECT).forEach(s -> {
-            withValues.add("-" + s);
-            withValues.add("empty");
-        });
-        return Bcl2fastqArguments.from(withValues.toArray(new String[]{}));
+        return Bcl2fastqArguments.builder()
+                .inputBucket(NA)
+                .privateKeyPath(NA)
+                .sbpApiUrl(NA)
+                .serviceAccountEmail(NA)
+                .flowcell(NA)
+                .outputServiceAccountEmail("output@serviceaccount.com")
+                .outputProject(NA)
+                .outputBucket(NA)
+                .outputPrivateKeyPath(NA)
+                .cleanup(false)
+                .project(NA)
+                .cloudSdkPath(NA)
+                .region(NA)
+                .usePreemptibleVms(false)
+                .useLocalSsds(false)
+                .build();
     }
 }

--- a/bcl2fastq/src/test/java/com/hartwig/bcl2fastq/OutputCopierTest.java
+++ b/bcl2fastq/src/test/java/com/hartwig/bcl2fastq/OutputCopierTest.java
@@ -22,7 +22,8 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 public class OutputCopierTest {
-    public static final String NA = "na";
+    private static final String NA = "na";
+    private static final String OUTPUT_SERVICE_ACCOUNT_EMAIL = "output@serviceaccount.com";
     private Bcl2fastqArguments arguments;
     private GsUtilFacade gsUtil;
     private OutputCopier victim;
@@ -91,7 +92,7 @@ public class OutputCopierTest {
         ArgumentCaptor<Acl> createdAcl = ArgumentCaptor.forClass(Acl.class);
         verify(bucket).createAcl(createdAcl.capture());
         Acl result = createdAcl.getValue();
-        assertThat(((Acl.User)result.getEntity()).getEmail()).isEqualTo("output@serviceaccount.com");
+        assertThat(((Acl.User) result.getEntity()).getEmail()).isEqualTo(OUTPUT_SERVICE_ACCOUNT_EMAIL);
         assertThat(result.getRole()).isEqualTo(Acl.Role.READER);
     }
 
@@ -116,7 +117,7 @@ public class OutputCopierTest {
                 .sbpApiUrl(NA)
                 .serviceAccountEmail(NA)
                 .flowcell(NA)
-                .outputServiceAccountEmail("output@serviceaccount.com")
+                .outputServiceAccountEmail(OUTPUT_SERVICE_ACCOUNT_EMAIL)
                 .outputProject(NA)
                 .outputBucket(NA)
                 .outputPrivateKeyPath(NA)


### PR DESCRIPTION
New argument to specify the email of the account which will do the output
transfer to hmf-database, and add this user as a READER to the bucket ACL.