### PR TITLE
DEV-1140 Make all the R2 fields optional

### DIFF
--- a/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/OutputCopier.java
+++ b/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/OutputCopier.java
@@ -36,9 +36,11 @@ public class OutputCopier implements Consumer<Conversion> {
             for (ConvertedSample sample : conversion.samples()) {
                 for (ConvertedFastq fastq : sample.fastq()) {
                     runtimeBucket.getUnderlyingBucket().get(fastq.pathR1()).createAcl(reader);
-                    runtimeBucket.getUnderlyingBucket().get(fastq.pathR2()).createAcl(reader);
                     copy(fastq.pathR1(), fastq.outputPathR1());
-                    copy(fastq.pathR2(), fastq.outputPathR2());
+                    if (fastq.pathR2().isPresent() && fastq.outputPathR2().isPresent()) {
+                        runtimeBucket.getUnderlyingBucket().get(fastq.pathR2().get()).createAcl(reader);
+                        copy(fastq.pathR2().get(), fastq.outputPathR2().get());
+                    }
                 }
             }
         } catch (Exception e) {

--- a/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/conversion/ConvertedFastq.java
+++ b/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/conversion/ConvertedFastq.java
@@ -1,5 +1,7 @@
 package com.hartwig.bcl2fastq.conversion;
 
+import java.util.Optional;
+
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -9,19 +11,19 @@ public interface ConvertedFastq extends WithYieldAndQ30{
 
     String pathR1();
 
-    String pathR2();
+    Optional<String> pathR2();
 
     String outputPathR1();
 
-    String outputPathR2();
+    Optional<String> outputPathR2();
 
     long sizeR1();
 
-    long sizeR2();
+    Optional<Long> sizeR2();
 
     String md5R1();
 
-    String md5R2();
+    Optional<String> md5R2();
 
     static ImmutableConvertedFastq.Builder builder() {
         return ImmutableConvertedFastq.builder();

--- a/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/conversion/ResultAggregation.java
+++ b/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/conversion/ResultAggregation.java
@@ -72,25 +72,24 @@ public class ResultAggregation {
                 lane.getValue().stream().collect(toMap(b -> ResultAggregation.parseNumInPair(b.getName()), Function.identity()));
         Blob blobR1 = pair.get("R1");
         Blob blobR2 = pair.get("R2");
-        if (blobR1 == null || blobR2 == null) {
-            throw new IllegalArgumentException(String.format("Missing one or both ends of pair in lane [%s] paths [%s]",
+        if (blobR1 == null) {
+            throw new IllegalArgumentException(String.format("Missing first end of pair in lane [%s] paths [%s]",
                     lane.getKey(),
                     lane.getValue().stream().map(Blob::getName).collect(Collectors.joining(","))));
         }
         FastqId id = FastqId.of(parseLaneIndex(blobR1.getName()), sample.barcode());
-        return ImmutableConvertedFastq.builder()
+        ImmutableConvertedFastq.Builder builder = ImmutableConvertedFastq.builder()
                 .id(id)
                 .pathR1(blobR1.getName())
-                .pathR2(blobR2.getName())
                 .outputPathR1(outputPath(stats, blobR1))
-                .outputPathR2(outputPath(stats, blobR2))
                 .sizeR1(blobR1.getSize())
-                .sizeR2(blobR2.getSize())
                 .md5R1(blobR1.getMd5())
-                .md5R2(blobR2.getMd5())
                 .yield(yield(id, stats))
-                .yieldQ30(yieldQ30(id, stats))
-                .build();
+                .yieldQ30(yieldQ30(id, stats));
+        if (blobR2 != null) {
+            builder.pathR2(blobR2.getName()).outputPathR2(outputPath(stats, blobR2)).sizeR2(blobR2.getSize()).md5R2(blobR2.getMd5());
+        }
+        return builder.build();
     }
 
     private static String outputPath(final Stats stats, final Blob blobR1) {

--- a/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/metadata/FastqMetadataRegistration.java
+++ b/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/metadata/FastqMetadataRegistration.java
@@ -52,9 +52,9 @@ public class FastqMetadataRegistration implements Consumer<Conversion> {
                             .name_r1(convertedFastq.outputPathR1())
                             .size_r1(convertedFastq.sizeR1())
                             .hash_r1(convertMd5ToSbpFormat(convertedFastq.md5R1()))
-                            .name_r2(convertedFastq.outputPathR2())
+                            .name_r2(convertedFastq.outputPathR2().orElse(""))
                             .size_r2(convertedFastq.sizeR2())
-                            .hash_r2(convertMd5ToSbpFormat(convertedFastq.md5R2()))
+                            .hash_r2(convertMd5ToSbpFormat(convertedFastq.md5R2().orElse("")))
                             .yld(convertedFastq.yield())
                             .q30(Q30.of(convertedFastq))
                             .qc_pass(flowcellQCPass && QualityControl.minimumQ30(convertedFastq, sbpSample.q30_req().orElse(0d)))
@@ -94,7 +94,7 @@ public class FastqMetadataRegistration implements Consumer<Conversion> {
     private void updateSampleYieldAndStatus(final ConvertedSample sample, final SbpSample sbpSample, final List<SbpFastq> validFastq) {
         long totalSampleYield = validFastq.stream().filter(SbpFastq::qc_pass).mapToLong(f -> f.yld().orElse(0L)).sum();
         long totalSampleYieldQ30 =
-                validFastq.stream().filter(SbpFastq::qc_pass).mapToLong(f -> (long) (f.q30().orElse(0d)/100 * f.yld().orElse(0L))).sum();
+                validFastq.stream().filter(SbpFastq::qc_pass).mapToLong(f -> (long) (f.q30().orElse(0d) / 100 * f.yld().orElse(0L))).sum();
         double sampleQ30 = Q30.of(new WithYieldAndQ30() {
             @Override
             public long yield() {

--- a/bcl2fastq/src/test/java/com/hartwig/bcl2fastq/OutputCopierTest.java
+++ b/bcl2fastq/src/test/java/com/hartwig/bcl2fastq/OutputCopierTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+
 import com.google.cloud.storage.Acl;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Bucket;
@@ -125,8 +127,8 @@ public class OutputCopierTest {
         ConvertedFastq fastq = mock(ConvertedFastq.class);
         when(fastq.pathR1()).thenReturn(format("%s/%s", runtimePath, outputPathR1));
         when(fastq.outputPathR1()).thenReturn(outputPathR1);
-        when(fastq.pathR2()).thenReturn(format("%s/%s", runtimePath, outputPathR2));
-        when(fastq.outputPathR2()).thenReturn(outputPathR2);
+        when(fastq.pathR2()).thenReturn(Optional.of(format("%s/%s", runtimePath, outputPathR2)));
+        when(fastq.outputPathR2()).thenReturn(Optional.of(outputPathR2));
         return fastq;
     }
 

--- a/bcl2fastq/src/test/java/com/hartwig/bcl2fastq/conversion/ResultAggregationTest.java
+++ b/bcl2fastq/src/test/java/com/hartwig/bcl2fastq/conversion/ResultAggregationTest.java
@@ -8,7 +8,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
 import java.util.List;
 
 import com.google.cloud.storage.Blob;
@@ -95,11 +94,11 @@ public class ResultAggregationTest {
         ConvertedFastq firstFastq = fastq.get(0);
         assertThat(firstFastq.id()).isEqualTo(FastqId.of(1, BARCODE));
         assertThat(firstFastq.pathR1()).isEqualTo(first.getName());
-        assertThat(firstFastq.pathR2()).isEqualTo(second.getName());
+        assertThat(firstFastq.pathR2()).hasValue(second.getName());
         ConvertedFastq secondFastq = fastq.get(1);
         assertThat(secondFastq.id()).isEqualTo(FastqId.of(2, BARCODE));
         assertThat(secondFastq.pathR1()).isEqualTo(third.getName());
-        assertThat(secondFastq.pathR2()).isEqualTo(fourth.getName());
+        assertThat(secondFastq.pathR2()).hasValue(fourth.getName());
     }
 
     @Test(expected = IllegalStateException.class)
@@ -134,15 +133,9 @@ public class ResultAggregationTest {
         List<ConvertedFastq> fastq = conversion.samples().get(0).fastq();
         ConvertedFastq firstFastq = fastq.get(0);
         assertThat(firstFastq.sizeR1()).isEqualTo(SIZE_R1);
-        assertThat(firstFastq.sizeR2()).isEqualTo(SIZE_R2);
+        assertThat(firstFastq.sizeR2()).hasValue(SIZE_R2);
         assertThat(firstFastq.md5R1()).isEqualTo(MD5_R1);
-        assertThat(firstFastq.md5R2()).isEqualTo(MD5_R2);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void failsWhenUnpairedReadsEncountered() {
-        when(bucket.list(path)).thenReturn(Collections.singletonList(first));
-        victim.apply(sampleSheet(), defaultStats());
+        assertThat(firstFastq.md5R2()).hasValue(MD5_R2);
     }
 
     @Test
@@ -171,7 +164,7 @@ public class ResultAggregationTest {
         List<ConvertedFastq> fastq = conversion.samples().get(0).fastq();
         ConvertedFastq firstFastq = fastq.get(0);
         assertThat(firstFastq.outputPathR1()).isEqualTo("GIAB12878_flowcell_S1_L001_R1_001.fastq.gz");
-        assertThat(firstFastq.outputPathR2()).isEqualTo("GIAB12878_flowcell_S1_L001_R2_001.fastq.gz");
+        assertThat(firstFastq.outputPathR2()).hasValue("GIAB12878_flowcell_S1_L001_R2_001.fastq.gz");
     }
 
     private static ImmutableStats defaultStats() {


### PR DESCRIPTION
In production trials we've seen conversions with only the R1 values. By making
the R2 optional we can support this permutation of input.