### PR TITLE
DEV-1142 Include undetermined yield in Q30 calculations

### DIFF
--- a/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/conversion/Conversion.java
+++ b/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/conversion/Conversion.java
@@ -1,6 +1,7 @@
 package com.hartwig.bcl2fastq.conversion;
 
 import java.util.List;
+import java.util.function.ToLongFunction;
 
 import org.immutables.value.Value;
 
@@ -9,24 +10,26 @@ public interface Conversion extends WithYieldAndQ30 {
 
     String flowcell();
 
-    long undeterminedReads();
-
-    long totalReads();
-
     @Value.Derived
     @Override
     default long yield() {
-        return totalReads();
+        return sumDeterminedAndUndetermined(WithYieldAndQ30::yield);
     }
 
     @Value.Derived
     default long yieldQ30() {
-        return samples().stream().flatMap(s -> s.fastq().stream()).mapToLong(WithYieldAndQ30::yieldQ30).sum();
+        return sumDeterminedAndUndetermined(WithYieldAndQ30::yieldQ30);
     }
+
+    ConvertedUndetermined undetermined();
 
     List<ConvertedSample> samples();
 
     static ImmutableConversion.Builder builder() {
         return ImmutableConversion.builder();
+    }
+
+    private long sumDeterminedAndUndetermined(final ToLongFunction<WithYieldAndQ30> mapToLong) {
+        return samples().stream().flatMap(s -> s.fastq().stream()).mapToLong(mapToLong).sum() + mapToLong.applyAsLong(undetermined());
     }
 }

--- a/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/conversion/ConvertedUndetermined.java
+++ b/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/conversion/ConvertedUndetermined.java
@@ -1,0 +1,11 @@
+package com.hartwig.bcl2fastq.conversion;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface ConvertedUndetermined extends WithYieldAndQ30 {
+
+    static ImmutableConvertedUndetermined.Builder builder() {
+        return ImmutableConvertedUndetermined.builder();
+    }
+}

--- a/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/stats/UndeterminedStats.java
+++ b/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/stats/UndeterminedStats.java
@@ -1,12 +1,17 @@
 package com.hartwig.bcl2fastq.stats;
 
+import java.util.List;
+
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(as = ImmutableUndeterminedStats.class)
+@Value.Style(jdkOnly=true)
 public interface UndeterminedStats {
 
     long yield();
+
+    List<ReadMetrics> readMetrics();
 }

--- a/bcl2fastq/src/test/java/com/hartwig/bcl2fastq/OutputCopierTest.java
+++ b/bcl2fastq/src/test/java/com/hartwig/bcl2fastq/OutputCopierTest.java
@@ -47,7 +47,7 @@ public class OutputCopierTest {
 
     @Test
     public void shouldDoNothingOnEmptyConversion() {
-        Conversion conversion = Conversion.builder().flowcell("flow").totalReads(0).undeterminedReads(0).build();
+        Conversion conversion = Conversion.builder().flowcell("flow").build();
         victim.accept(conversion);
         verifyZeroInteractions(gsUtil);
     }
@@ -108,7 +108,7 @@ public class OutputCopierTest {
 
     @Test
     public void addsOutputServiceAccountEmailToAcl() {
-        Conversion conversion = Conversion.builder().flowcell("flow").totalReads(0).undeterminedReads(0).build();
+        Conversion conversion = Conversion.builder().flowcell("flow").build();
         victim.accept(conversion);
         ArgumentCaptor<Acl> createdAcl = ArgumentCaptor.forClass(Acl.class);
         verify(bucket).createAcl(createdAcl.capture());

--- a/bcl2fastq/src/test/java/com/hartwig/bcl2fastq/OutputCopierTest.java
+++ b/bcl2fastq/src/test/java/com/hartwig/bcl2fastq/OutputCopierTest.java
@@ -15,10 +15,13 @@ import com.google.common.collect.ImmutableList;
 import com.hartwig.bcl2fastq.conversion.Conversion;
 import com.hartwig.bcl2fastq.conversion.ConvertedFastq;
 import com.hartwig.bcl2fastq.conversion.ConvertedSample;
+import com.hartwig.bcl2fastq.conversion.ConvertedUndetermined;
+import com.hartwig.bcl2fastq.conversion.ImmutableConvertedUndetermined;
 import com.hartwig.pipeline.storage.GsUtilFacade;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 import com.hartwig.pipeline.testsupport.TestBlobs;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -47,7 +50,7 @@ public class OutputCopierTest {
 
     @Test
     public void shouldDoNothingOnEmptyConversion() {
-        Conversion conversion = Conversion.builder().flowcell("flow").build();
+        Conversion conversion = Conversion.builder().flowcell("flow").undetermined(emptyUndetermined()).build();
         victim.accept(conversion);
         verifyZeroInteractions(gsUtil);
     }
@@ -108,12 +111,17 @@ public class OutputCopierTest {
 
     @Test
     public void addsOutputServiceAccountEmailToAcl() {
-        Conversion conversion = Conversion.builder().flowcell("flow").build();
+        Conversion conversion = Conversion.builder().flowcell("flow").undetermined(emptyUndetermined()).build();
         victim.accept(conversion);
         ArgumentCaptor<Acl> createdAcl = ArgumentCaptor.forClass(Acl.class);
         verify(bucket).createAcl(createdAcl.capture());
         Acl result = createdAcl.getValue();
         verifyAcl(result);
+    }
+
+    @NotNull
+    public ImmutableConvertedUndetermined emptyUndetermined() {
+        return ConvertedUndetermined.builder().yieldQ30(0).yield(0).build();
     }
 
     public void verifyAcl(final Acl result) {

--- a/bcl2fastq/src/test/java/com/hartwig/bcl2fastq/conversion/ResultAggregationTest.java
+++ b/bcl2fastq/src/test/java/com/hartwig/bcl2fastq/conversion/ResultAggregationTest.java
@@ -147,10 +147,11 @@ public class ResultAggregationTest {
 
     @Test
     public void totalUndeterminedAndReadsCalculatedFromStats() {
+        when(bucket.list(path)).thenReturn(Lists.newArrayList(first, second));
         Conversion conversion = victim.apply(sampleSheet(), defaultStats());
 
-        assertThat(conversion.undeterminedReads()).isEqualTo(1);
-        assertThat(conversion.totalReads()).isEqualTo(4);
+        assertThat(conversion.undetermined().yield()).isEqualTo(1);
+        assertThat(conversion.yield()).isEqualTo(4);
     }
 
     @Test


### PR DESCRIPTION
A bit of a refactor to make things more consistent. We create an object in our Conversion datamodel to hold
the undetermined stats. This is populated from read metrics now deserialized in the UndeterminedStats

All stats in Conversion are now derived, to ensure the numbers are always consistent across the datamodel.