### PR TITLE
Enable CMEK for BCL conversion

### DIFF
--- a/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/Bcl2fastqArguments.java
+++ b/bcl2fastq/src/main/java/com/hartwig/bcl2fastq/Bcl2fastqArguments.java
@@ -2,6 +2,8 @@ package com.hartwig.bcl2fastq;
 
 import static java.lang.Boolean.parseBoolean;
 
+import java.util.Optional;
+
 import com.hartwig.pipeline.CommonArguments;
 
 import org.apache.commons.cli.CommandLine;
@@ -22,6 +24,7 @@ public interface Bcl2fastqArguments extends CommonArguments {
     String INPUT_BUCKET = "input_bucket";
     String SBP_API_URL = "sbp_api_url";
     String CLEANUP = "cleanup";
+    String CMEK = "cmek";
 
     static Bcl2fastqArguments from(String[] args) {
         try {
@@ -42,6 +45,7 @@ public interface Bcl2fastqArguments extends CommonArguments {
                     .outputServiceAccountEmail(commandLine.getOptionValue(OUTPUT_SERVICE_ACCOUNT_EMAIL))
                     .outputProject(commandLine.getOptionValue(OUTPUT_PROJECT))
                     .cleanup(parseBoolean(commandLine.getOptionValue(CLEANUP, "false")))
+                    .cmek(commandLine.hasOption(CMEK) ? Optional.of(commandLine.getOptionValue(CMEK)) : Optional.empty())
                     .useLocalSsds(false)
                     .usePreemptibleVms(false)
                     .build();
@@ -67,7 +71,9 @@ public interface Bcl2fastqArguments extends CommonArguments {
                 .addOption(stringOption(OUTPUT_PRIVATE_KEY_PATH, "Credentials used to copy output"))
                 .addOption(stringOption(OUTPUT_SERVICE_ACCOUNT_EMAIL, "Email of service account used to copy data from the conversion into "
                         + "the fastq storage bucket. Will be added to the ACL of the runtime bucket."))
-                .addOption(stringOption(OUTPUT_PROJECT, "User project for output copying"));
+                .addOption(stringOption(OUTPUT_PROJECT, "User project for output copying"))
+                .addOption(stringOption(CMEK, "The name of the Customer Managed Encryption Key. When this flag is populated all runtime "
+                        + "buckets will use this key."));
     }
 
     String outputBucket();

--- a/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
@@ -120,7 +120,7 @@ public class CommandLineOptions {
 
     private static Option cmek() {
         return optionWithArg(CMEK_FLAG,
-                "The name of the Customer Managed Encryption Key. When this flag is populated all runtime buckets " + "will use this key.");
+                "The name of the Customer Managed Encryption Key. When this flag is populated all runtime buckets will use this key.");
     }
 
     private static Option privateNetwork() {

--- a/cluster/src/main/java/com/hartwig/pipeline/storage/RuntimeBucket.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/storage/RuntimeBucket.java
@@ -51,11 +51,7 @@ public class RuntimeBucket {
                     BucketInfo.newBuilder(runId).setStorageClass(StorageClass.REGIONAL).setLocation(arguments.region());
             arguments.cmek().ifPresent(key -> {
                 LOGGER.info("Using CMEK key [{}] to encrypt all buckets", key);
-                builder.setDefaultKmsKeyName(String.format("projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s",
-                        arguments.project(),
-                        arguments.region(),
-                        arguments.project(),
-                        key));
+                builder.setDefaultKmsKeyName(key);
             });
             bucket = storage.create(builder.build());
         }

--- a/cluster/src/test/java/com/hartwig/pipeline/storage/RuntimeBucketTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/storage/RuntimeBucketTest.java
@@ -1,7 +1,5 @@
 package com.hartwig.pipeline.storage;
 
-import static java.lang.String.format;
-
 import static com.hartwig.pipeline.testsupport.TestInputs.defaultSomaticRunMetadata;
 import static com.hartwig.pipeline.testsupport.TestInputs.referenceRunMetadata;
 
@@ -140,11 +138,7 @@ public class RuntimeBucketTest {
         String keyName = "key";
         Arguments arguments = Arguments.testDefaultsBuilder().cmek(keyName).build();
         RuntimeBucket.from(storage, NAMESPACE, referenceRunMetadata(), arguments);
-        assertThat(bucketInfo.getValue().getDefaultKmsKeyName()).isEqualTo(format("projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s",
-                arguments.project(),
-                arguments.region(),
-                arguments.project(),
-                keyName));
+        assertThat(bucketInfo.getValue().getDefaultKmsKeyName()).isEqualTo(keyName);
     }
 
     @Test


### PR DESCRIPTION
While the argument class supported it, we didn't actually have it wired in as
a CLI arg. Also removing the defaulting of the location and project of the key
to allow for use of keys in other projects.