### PR TITLE
DEV-1250 Register CRAMs with API

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
@@ -46,7 +46,8 @@ public class PipelineMain {
                     Executors.newCachedThreadPool(),
                     referenceEventListener,
                     tumorEventListener,
-                    somaticMetadataApi.get()).run();
+                    somaticMetadataApi,
+                    CleanupProvider.from(arguments, storage).get()).run();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -68,7 +69,6 @@ public class PipelineMain {
                         metadata -> RuntimeBucket.from(storage, GermlineCaller.NAMESPACE, metadata, arguments)), somaticMetadataApi,
                 PipelineResultsProvider.from(storage, arguments, Versions.pipelineVersion()).get(),
                 new FullSomaticResults(storage, arguments),
-                CleanupProvider.from(arguments, storage).get(),
                 Executors.newCachedThreadPool());
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/PipelineState.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/PipelineState.java
@@ -29,7 +29,7 @@ public class PipelineState {
         return this;
     }
 
-    List<StageOutput> stageOutputs() {
+    public List<StageOutput> stageOutputs() {
         return stageOutputs;
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/SomaticPipeline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/SomaticPipeline.java
@@ -144,7 +144,7 @@ public class SomaticPipeline {
             }
         }
         fullSomaticResults.compose(metadata);
-        setMetadataApi.complete(state.status(), metadata);
+        setMetadataApi.complete(state.status(), metadata, state);
         if (state.shouldProceed()) {
             cleanup.run(metadata);
         }

--- a/cluster/src/main/java/com/hartwig/pipeline/SomaticPipeline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/SomaticPipeline.java
@@ -17,7 +17,6 @@ import com.hartwig.pipeline.calling.somatic.SomaticCaller;
 import com.hartwig.pipeline.calling.somatic.SomaticCallerOutput;
 import com.hartwig.pipeline.calling.structural.StructuralCaller;
 import com.hartwig.pipeline.calling.structural.StructuralCallerOutput;
-import com.hartwig.pipeline.cleanup.Cleanup;
 import com.hartwig.pipeline.metadata.SingleSampleRunMetadata;
 import com.hartwig.pipeline.metadata.SomaticMetadataApi;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
@@ -59,15 +58,14 @@ public class SomaticPipeline {
     private final SomaticMetadataApi setMetadataApi;
     private final PipelineResults pipelineResults;
     private final FullSomaticResults fullSomaticResults;
-    private final Cleanup cleanup;
     private final ExecutorService executorService;
 
     SomaticPipeline(final Arguments arguments, final StageRunner<SomaticRunMetadata> stageRunner,
             final AlignmentOutputStorage alignmentOutputStorage,
             final OutputStorage<BamMetricsOutput, SingleSampleRunMetadata> bamMetricsOutputStorage,
             final OutputStorage<GermlineCallerOutput, SingleSampleRunMetadata> germlineCallerOutputStorage,
-            final SomaticMetadataApi setMetadataApi, final PipelineResults pipelineResults,
-            final FullSomaticResults fullSomaticResults, final Cleanup cleanup, final ExecutorService executorService) {
+            final SomaticMetadataApi setMetadataApi, final PipelineResults pipelineResults, final FullSomaticResults fullSomaticResults,
+            final ExecutorService executorService) {
         this.arguments = arguments;
         this.stageRunner = stageRunner;
         this.alignmentOutputStorage = alignmentOutputStorage;
@@ -76,7 +74,6 @@ public class SomaticPipeline {
         this.setMetadataApi = setMetadataApi;
         this.pipelineResults = pipelineResults;
         this.fullSomaticResults = fullSomaticResults;
-        this.cleanup = cleanup;
         this.executorService = executorService;
     }
 
@@ -144,10 +141,6 @@ public class SomaticPipeline {
             }
         }
         fullSomaticResults.compose(metadata);
-        setMetadataApi.complete(state.status(), metadata, state);
-        if (state.shouldProceed()) {
-            cleanup.run(metadata);
-        }
         return state;
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/StageOutput.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/StageOutput.java
@@ -3,6 +3,7 @@ package com.hartwig.pipeline;
 import java.util.List;
 
 import com.hartwig.pipeline.execution.PipelineStatus;
+import com.hartwig.pipeline.metadata.ApiFileOperation;
 import com.hartwig.pipeline.report.ReportComponent;
 
 public interface StageOutput {
@@ -12,4 +13,6 @@ public interface StageOutput {
     PipelineStatus status();
 
     List<ReportComponent> reportComponents();
+
+    List<ApiFileOperation> furtherOperations();
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/cram/CramConversion.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/cram/CramConversion.java
@@ -18,7 +18,6 @@ import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
 import com.hartwig.pipeline.execution.vm.VirtualMachinePerformanceProfile;
 import com.hartwig.pipeline.execution.vm.VmDirectories;
 import com.hartwig.pipeline.metadata.AddDatatypeToFile;
-import com.hartwig.pipeline.metadata.AdditionalApiCalls;
 import com.hartwig.pipeline.metadata.LinkFileToSample;
 import com.hartwig.pipeline.metadata.SingleSampleRunMetadata;
 import com.hartwig.pipeline.report.Folder;
@@ -75,17 +74,16 @@ public class CramConversion implements Stage<CramOutput, SingleSampleRunMetadata
         String fullCram = format("%s%s/%s", folder.name(), NAMESPACE, cram);
         String fullCrai = format("%s%s/%s", folder.name(), NAMESPACE, crai);
 
-        AdditionalApiCalls.instance().register(fullCram, new LinkFileToSample(metadata.entityId()));
-        AdditionalApiCalls.instance().register(fullCrai, new LinkFileToSample(metadata.entityId()));
-        AdditionalApiCalls.instance().register(fullCram, new AddDatatypeToFile("reads"));
-        AdditionalApiCalls.instance().register(fullCrai, new AddDatatypeToFile("reads"));
-
         return CramOutput.builder()
                 .status(jobStatus)
                 .addReportComponents(new RunLogComponent(bucket, NAMESPACE, folder, resultsDirectory),
                         new StartupScriptComponent(bucket, NAMESPACE, folder),
                         new SingleFileComponent(bucket, NAMESPACE, folder, cram, cram, resultsDirectory),
                         new SingleFileComponent(bucket, NAMESPACE, folder, crai, crai, resultsDirectory))
+                .addFurtherOperations(new LinkFileToSample(fullCram, metadata.entityId()),
+                        new LinkFileToSample(fullCrai, metadata.entityId()),
+                        new AddDatatypeToFile(fullCram, "reads"),
+                        new AddDatatypeToFile(fullCrai, "reads"))
                 .build();
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/cram/CramConversion.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/cram/CramConversion.java
@@ -75,8 +75,8 @@ public class CramConversion implements Stage<CramOutput, SingleSampleRunMetadata
         String fullCram = format("%s%s/%s", folder.name(), NAMESPACE, cram);
         String fullCrai = format("%s%s/%s", folder.name(), NAMESPACE, crai);
 
-        AdditionalApiCalls.instance().register(fullCram, new LinkFileToSample(metadata.sampleId()));
-        AdditionalApiCalls.instance().register(fullCrai, new LinkFileToSample(metadata.sampleId()));
+        AdditionalApiCalls.instance().register(fullCram, new LinkFileToSample(metadata.entityId()));
+        AdditionalApiCalls.instance().register(fullCrai, new LinkFileToSample(metadata.entityId()));
         AdditionalApiCalls.instance().register(fullCram, new AddDatatypeToFile("reads"));
         AdditionalApiCalls.instance().register(fullCrai, new AddDatatypeToFile("reads"));
 

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/AddDatatypeToFile.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/AddDatatypeToFile.java
@@ -1,17 +1,24 @@
 package com.hartwig.pipeline.metadata;
 
-import com.hartwig.pipeline.sbpapi.FileResponse;
+import com.hartwig.pipeline.sbpapi.AddFileApiResponse;
 import com.hartwig.pipeline.sbpapi.SbpRestApi;
 
 public class AddDatatypeToFile implements ApiFileOperation {
+    private String path;
     private final String datatype;
 
-    public AddDatatypeToFile(String datatype) {
+    public AddDatatypeToFile(String path, String datatype) {
+        this.path = path;
         this.datatype = datatype;
     }
 
     @Override
-    public void apply(final SbpRestApi api, final FileResponse file) {
-        api.patchFile(file.id, "datatype", datatype);
+    public void apply(final SbpRestApi api, final AddFileApiResponse file) {
+        api.patchFile(file.id(), "datatype", datatype);
+    }
+
+    @Override
+    public String path() {
+        return path;
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/AddDatatypeToFile.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/AddDatatypeToFile.java
@@ -1,0 +1,17 @@
+package com.hartwig.pipeline.metadata;
+
+import com.hartwig.pipeline.sbpapi.FileResponse;
+import com.hartwig.pipeline.sbpapi.SbpRestApi;
+
+public class AddDatatypeToFile implements ApiFileOperation {
+    private final String datatype;
+
+    public AddDatatypeToFile(String datatype) {
+        this.datatype = datatype;
+    }
+
+    @Override
+    public void apply(final SbpRestApi api, final FileResponse file) {
+        api.patchFile(file.id, "datatype", datatype);
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/AdditionalApiCalls.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/AdditionalApiCalls.java
@@ -1,0 +1,47 @@
+package com.hartwig.pipeline.metadata;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.hartwig.pipeline.sbpapi.FileResponse;
+import com.hartwig.pipeline.sbpapi.SbpRestApi;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AdditionalApiCalls {
+    private static final AdditionalApiCalls INSTANCE = new AdditionalApiCalls();
+    private static final Logger LOGGER = LoggerFactory.getLogger(AdditionalApiCalls.class);
+    private Map<String, List<ApiFileOperation>> metadata;
+
+    private AdditionalApiCalls() {
+        metadata = new HashMap<>();
+        //String name = RunTag.apply(arguments, metadata.sampleId());
+    }
+
+    public static AdditionalApiCalls instance() {
+        return INSTANCE;
+    }
+
+    public synchronized void register(String filePath, ApiFileOperation extraOperation) {
+        metadata.putIfAbsent(filePath, new ArrayList<>());
+        metadata.get(filePath).add(extraOperation);
+        LOGGER.info("Registered [{}] to file path [{}]", extraOperation, filePath);
+    }
+
+    public void apply(final SbpRestApi sbpApi, String filePath, FileResponse fileResponse) {
+        LOGGER.info("Applying additional operations for path [{}]", filePath);
+
+        // Replace this with passing in the name to the constructor?
+        String prefixRemoved = filePath.substring(filePath.indexOf("/") + 1);
+        List<ApiFileOperation> extraOps = metadata.get(prefixRemoved);
+        if (extraOps != null) {
+            extraOps.forEach(o -> {
+                LOGGER.info("Found operation [{}] to apply", o);
+                o.apply(sbpApi, fileResponse);
+            });
+        }
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/AdditionalApiCalls.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/AdditionalApiCalls.java
@@ -5,7 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.hartwig.pipeline.sbpapi.FileResponse;
+import com.hartwig.pipeline.sbpapi.AddFileApiResponse;
 import com.hartwig.pipeline.sbpapi.SbpRestApi;
 
 import org.slf4j.Logger;
@@ -31,7 +31,7 @@ public class AdditionalApiCalls {
         LOGGER.info("Registered [{}] to file path [{}]", extraOperation, filePath);
     }
 
-    public void apply(final SbpRestApi sbpApi, String filePath, FileResponse fileResponse) {
+    public void apply(final SbpRestApi sbpApi, String filePath, AddFileApiResponse fileResponse) {
         LOGGER.info("Applying additional operations for path [{}]", filePath);
 
         // Replace this with passing in the name to the constructor?

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/ApiFileOperation.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/ApiFileOperation.java
@@ -1,8 +1,10 @@
 package com.hartwig.pipeline.metadata;
 
-import com.hartwig.pipeline.sbpapi.FileResponse;
+import com.hartwig.pipeline.sbpapi.AddFileApiResponse;
 import com.hartwig.pipeline.sbpapi.SbpRestApi;
 
 public interface ApiFileOperation {
-    void apply(SbpRestApi api, FileResponse file);
+    void apply(SbpRestApi api, AddFileApiResponse file);
+
+    String path();
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/ApiFileOperation.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/ApiFileOperation.java
@@ -1,0 +1,8 @@
+package com.hartwig.pipeline.metadata;
+
+import com.hartwig.pipeline.sbpapi.FileResponse;
+import com.hartwig.pipeline.sbpapi.SbpRestApi;
+
+public interface ApiFileOperation {
+    void apply(SbpRestApi api, FileResponse file);
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/LinkFileToSample.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/LinkFileToSample.java
@@ -4,9 +4,9 @@ import com.hartwig.pipeline.sbpapi.FileResponse;
 import com.hartwig.pipeline.sbpapi.SbpRestApi;
 
 public class LinkFileToSample implements ApiFileOperation {
-    private final String sampleId;
+    private final int sampleId;
 
-    public LinkFileToSample(String sampleId) {
+    public LinkFileToSample(int sampleId) {
         this.sampleId = sampleId;
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/LinkFileToSample.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/LinkFileToSample.java
@@ -1,17 +1,24 @@
 package com.hartwig.pipeline.metadata;
 
-import com.hartwig.pipeline.sbpapi.FileResponse;
+import com.hartwig.pipeline.sbpapi.AddFileApiResponse;
 import com.hartwig.pipeline.sbpapi.SbpRestApi;
 
 public class LinkFileToSample implements ApiFileOperation {
+    private String path;
     private final int sampleId;
 
-    public LinkFileToSample(int sampleId) {
+    public LinkFileToSample(String path, int sampleId) {
+        this.path = path;
         this.sampleId = sampleId;
     }
 
     @Override
-    public void apply(final SbpRestApi api, final FileResponse fileResponse) {
-        api.linkFileToSample(fileResponse.id, sampleId);
+    public void apply(final SbpRestApi api, final AddFileApiResponse fileResponse) {
+        api.linkFileToSample(fileResponse.id(), sampleId);
+    }
+
+    @Override
+    public String path() {
+        return path;
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/LinkFileToSample.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/LinkFileToSample.java
@@ -1,0 +1,17 @@
+package com.hartwig.pipeline.metadata;
+
+import com.hartwig.pipeline.sbpapi.FileResponse;
+import com.hartwig.pipeline.sbpapi.SbpRestApi;
+
+public class LinkFileToSample implements ApiFileOperation {
+    private final String sampleId;
+
+    public LinkFileToSample(String sampleId) {
+        this.sampleId = sampleId;
+    }
+
+    @Override
+    public void apply(final SbpRestApi api, final FileResponse fileResponse) {
+        api.linkFileToSample(fileResponse.id, sampleId);
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/LocalSomaticMetadataApi.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/LocalSomaticMetadataApi.java
@@ -1,6 +1,7 @@
 package com.hartwig.pipeline.metadata;
 
 import com.hartwig.pipeline.Arguments;
+import com.hartwig.pipeline.PipelineState;
 import com.hartwig.pipeline.RunTag;
 import com.hartwig.pipeline.execution.PipelineStatus;
 
@@ -32,7 +33,7 @@ public class LocalSomaticMetadataApi implements SomaticMetadataApi {
     }
 
     @Override
-    public void complete(final PipelineStatus status, SomaticRunMetadata metadata) {
+    public void complete(final PipelineStatus status, SomaticRunMetadata metadata, PipelineState state) {
         // do nothing
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/LocalSomaticMetadataApi.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/LocalSomaticMetadataApi.java
@@ -3,7 +3,6 @@ package com.hartwig.pipeline.metadata;
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.PipelineState;
 import com.hartwig.pipeline.RunTag;
-import com.hartwig.pipeline.execution.PipelineStatus;
 
 public class LocalSomaticMetadataApi implements SomaticMetadataApi {
 
@@ -33,7 +32,7 @@ public class LocalSomaticMetadataApi implements SomaticMetadataApi {
     }
 
     @Override
-    public void complete(final PipelineStatus status, SomaticRunMetadata metadata, PipelineState state) {
+    public void complete(final PipelineState state, SomaticRunMetadata metadata) {
         // do nothing
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/SbpSomaticMetadataApi.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/SbpSomaticMetadataApi.java
@@ -126,6 +126,7 @@ public class SbpSomaticMetadataApi implements SomaticMetadataApi {
                 sbpRestApi.updateRunStatus(runIdAsString, UPLOADING, arguments.archiveBucket());
                 googleArchiver.transfer(metadata);
                 OutputIterator.from(new SbpFileApiUpdate(ContentTypeCorrection.get(),
+                        AdditionalApiCalls.instance(),
                         sbpRun,
                         sourceBucket,
                         sbpRestApi).andThen(new BlobCleanup()), sourceBucket).iterate(metadata);

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/SbpSomaticMetadataApi.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/SbpSomaticMetadataApi.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.cloud.storage.Bucket;
 import com.hartwig.pipeline.Arguments;
+import com.hartwig.pipeline.PipelineState;
 import com.hartwig.pipeline.execution.PipelineStatus;
 import com.hartwig.pipeline.jackson.ObjectMappers;
 import com.hartwig.pipeline.sbpapi.SbpIni;
@@ -116,7 +117,7 @@ public class SbpSomaticMetadataApi implements SomaticMetadataApi {
     }
 
     @Override
-    public void complete(final PipelineStatus status, SomaticRunMetadata metadata) {
+    public void complete(final PipelineStatus status, SomaticRunMetadata metadata, PipelineState pipelineState) {
         String runIdAsString = String.valueOf(sbpRunId);
         SbpRun sbpRun = getSbpRun();
         String sbpBucket = sbpRun.bucket();
@@ -129,7 +130,8 @@ public class SbpSomaticMetadataApi implements SomaticMetadataApi {
                         AdditionalApiCalls.instance(),
                         sbpRun,
                         sourceBucket,
-                        sbpRestApi).andThen(new BlobCleanup()), sourceBucket).iterate(metadata);
+                        sbpRestApi,
+                        pipelineState).andThen(new BlobCleanup()), sourceBucket).iterate(metadata);
                 sbpRestApi.updateRunStatus(runIdAsString,
                         status == PipelineStatus.SUCCESS ? successStatus() : FAILED,
                         arguments.archiveBucket());

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/SomaticMetadataApi.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/SomaticMetadataApi.java
@@ -1,11 +1,10 @@
 package com.hartwig.pipeline.metadata;
 
 import com.hartwig.pipeline.PipelineState;
-import com.hartwig.pipeline.execution.PipelineStatus;
 
 public interface SomaticMetadataApi {
 
     SomaticRunMetadata get();
 
-    void complete(PipelineStatus status, SomaticRunMetadata metadata, PipelineState state);
+    void complete(PipelineState state, SomaticRunMetadata metadata);
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/SomaticMetadataApi.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/SomaticMetadataApi.java
@@ -1,10 +1,11 @@
 package com.hartwig.pipeline.metadata;
 
+import com.hartwig.pipeline.PipelineState;
 import com.hartwig.pipeline.execution.PipelineStatus;
 
 public interface SomaticMetadataApi {
 
     SomaticRunMetadata get();
 
-    void complete(PipelineStatus status, SomaticRunMetadata metadata);
+    void complete(PipelineStatus status, SomaticRunMetadata metadata, PipelineState state);
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/sbpapi/AddFileApiResponse.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/sbpapi/AddFileApiResponse.java
@@ -1,0 +1,11 @@
+package com.hartwig.pipeline.sbpapi;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(as = ImmutableAddFileApiResponse.class)
+public interface AddFileApiResponse {
+    int id();
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/sbpapi/FileResponse.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/sbpapi/FileResponse.java
@@ -1,0 +1,8 @@
+package com.hartwig.pipeline.sbpapi;
+
+public class FileResponse {
+    public int id;
+
+    public FileResponse() {
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/sbpapi/FileResponse.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/sbpapi/FileResponse.java
@@ -1,8 +1,0 @@
-package com.hartwig.pipeline.sbpapi;
-
-public class FileResponse {
-    public int id;
-
-    public FileResponse() {
-    }
-}

--- a/cluster/src/main/java/com/hartwig/pipeline/sbpapi/SbpRestApi.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/sbpapi/SbpRestApi.java
@@ -99,11 +99,11 @@ public class SbpRestApi {
         }
     }
 
-    public FileResponse postFile(final SbpFileMetadata metaData) {
+    public AddFileApiResponse postFile(final SbpFileMetadata metaData) {
         try {
             return ObjectMappers.get()
                     .readValue(post(api().path(FILES), OBJECT_MAPPER.writeValueAsString(metaData)).readEntity(String.class),
-                            FileResponse.class);
+                            AddFileApiResponse.class);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/cluster/src/main/java/com/hartwig/pipeline/sbpapi/SbpRestApi.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/sbpapi/SbpRestApi.java
@@ -109,16 +109,16 @@ public class SbpRestApi {
         }
     }
 
-    public void linkFileToSample(final int id, final String sampleId) {
-        Map<String, String> request = new HashMap<>();
-        request.put("id", sampleId);
+    public void linkFileToSample(final int id, final int sampleId) {
+        Map<String, Integer> request = new HashMap<>();
+        request.put("sample_id", sampleId);
         submitJson(POST, api().path(format("%s/%d/sample", FILES, id)), request, Response.Status.CREATED);
     }
 
     public void patchFile(final int id, final String key, final String value) {
         Map<String, String> request = new HashMap<>();
         request.put(key, value);
-        submitJson(PATCH, api().path(format("%s/%d", FILES, id)), request, Response.Status.CREATED);
+        submitJson(PATCH, api().path(format("%s/%d", FILES, id)), request, Response.Status.OK);
     }
 
     private Response post(final WebTarget path, final String json) {
@@ -142,7 +142,11 @@ public class SbpRestApi {
                 LOGGER.info("{} complete with status [{}]", method, response.getStatus());
                 return response;
             } else {
-                LOGGER.error("{} to [{}] returned {}", method, path, response.getStatus());
+                LOGGER.error("{} to [{}] unexpectedly returned {}:\n{}",
+                        method,
+                        path,
+                        response.getStatus(),
+                        response.readEntity(String.class));
                 throw error(response);
             }
         } catch (JsonProcessingException e) {

--- a/cluster/src/main/java/com/hartwig/pipeline/transfer/SbpFileApiUpdate.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/transfer/SbpFileApiUpdate.java
@@ -3,14 +3,18 @@ package com.hartwig.pipeline.transfer;
 import static java.lang.String.format;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.List;
 import java.util.function.Consumer;
 
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Bucket;
+import com.hartwig.pipeline.PipelineState;
 import com.hartwig.pipeline.metadata.AdditionalApiCalls;
+import com.hartwig.pipeline.metadata.ApiFileOperation;
 import com.hartwig.pipeline.report.PipelineResults;
-import com.hartwig.pipeline.sbpapi.FileResponse;
+import com.hartwig.pipeline.sbpapi.AddFileApiResponse;
 import com.hartwig.pipeline.sbpapi.SbpFileMetadata;
 import com.hartwig.pipeline.sbpapi.SbpRestApi;
 import com.hartwig.pipeline.sbpapi.SbpRun;
@@ -28,14 +32,16 @@ public class SbpFileApiUpdate implements Consumer<Blob> {
     private final SbpRun sbpRun;
     private final Bucket sourceBucket;
     private final SbpRestApi sbpApi;
+    private final List<ApiFileOperation> fileOperations = new ArrayList<>();
 
     public SbpFileApiUpdate(final ContentTypeCorrection contentTypeCorrection, final AdditionalApiCalls additionalApiCalls,
-            final SbpRun sbpRun, final Bucket sourceBucket, final SbpRestApi sbpApi) {
+            final SbpRun sbpRun, final Bucket sourceBucket, final SbpRestApi sbpApi, final PipelineState pipelineState) {
         this.contentTypeCorrection = contentTypeCorrection;
         this.additionalApiCalls = additionalApiCalls;
         this.sbpRun = sbpRun;
         this.sourceBucket = sourceBucket;
         this.sbpApi = sbpApi;
+        pipelineState.stageOutputs().forEach(stageOutput -> fileOperations.addAll(stageOutput.furtherOperations()));
     }
 
     @Override
@@ -52,8 +58,14 @@ public class SbpFileApiUpdate implements Consumer<Blob> {
                         .filesize(blob.getSize())
                         .hash(convertMd5ToSbpFormat(blob.getMd5()))
                         .build();
-                FileResponse response = sbpApi.postFile(metaData);
-                additionalApiCalls.apply(sbpApi, blob.getName(), response);
+                AddFileApiResponse fileResponse = sbpApi.postFile(metaData);
+
+                for (ApiFileOperation fileOperation : fileOperations) {
+                    if (fileOperation.path().equals(blob.getName().substring(blob.getName().indexOf("/") + 1))) {
+                        LOGGER.info("Found operation [{}] to apply", fileOperation);
+                        fileOperation.apply(sbpApi, fileResponse);
+                    }
+                }
             }
         }
     }

--- a/cluster/src/test/java/com/hartwig/pipeline/FullPipelineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/FullPipelineTest.java
@@ -1,42 +1,62 @@
 package com.hartwig.pipeline;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.concurrent.Executors;
 
+import com.hartwig.pipeline.cleanup.Cleanup;
 import com.hartwig.pipeline.execution.PipelineStatus;
 import com.hartwig.pipeline.metadata.SingleSampleEventListener;
+import com.hartwig.pipeline.metadata.SomaticMetadataApi;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.metrics.BamMetricsOutput;
 import com.hartwig.pipeline.testsupport.TestInputs;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
 
 public class FullPipelineTest {
 
     private static final SomaticRunMetadata METADATA = TestInputs.defaultSomaticRunMetadata();
+    private SomaticMetadataApi api;
     private SingleSamplePipeline reference;
     private SingleSamplePipeline tumor;
     private SomaticPipeline somatic;
     private FullPipeline victim;
     private SingleSampleEventListener referenceListener;
     private SingleSampleEventListener tumorListener;
+    private Cleanup cleanup;
 
     @Before
     public void setUp() throws Exception {
         reference = mock(SingleSamplePipeline.class);
         tumor = mock(SingleSamplePipeline.class);
         somatic = mock(SomaticPipeline.class);
+        cleanup = mock(Cleanup.class);
+
+        api = mock(SomaticMetadataApi.class);
+        when(api.get()).thenReturn(METADATA);
 
         referenceListener = new SingleSampleEventListener();
         tumorListener = new SingleSampleEventListener();
-        victim = new FullPipeline(reference, tumor, somatic, Executors.newCachedThreadPool(), referenceListener, tumorListener, METADATA);
+        victim = new FullPipeline(reference,
+                tumor,
+                somatic,
+                Executors.newCachedThreadPool(),
+                referenceListener,
+                tumorListener,
+                api,
+                cleanup);
     }
 
     @Test
@@ -92,16 +112,82 @@ public class FullPipelineTest {
 
     @Test
     public void supportsSingleSampleIni() throws Exception {
+        SomaticRunMetadata metadata = TestInputs.defaultSingleSampleRunMetadata();
+        when(api.get()).thenReturn(metadata);
         victim = new FullPipeline(reference,
                 tumor,
                 somatic,
                 Executors.newCachedThreadPool(),
                 referenceListener,
                 tumorListener,
-                TestInputs.defaultSingleSampleRunMetadata());
-        when(reference.run(METADATA.reference())).then(callHandlers(referenceListener, succeeded(), succeeded()));
+                api,
+                cleanup);
+        when(reference.run(metadata.reference())).then(callHandlers(referenceListener, succeeded(), succeeded()));
         when(somatic.run()).thenReturn(succeeded());
         assertThat(victim.run().status()).isEqualTo(PipelineStatus.SUCCESS);
+    }
+
+    @Test
+    public void notifiesSetMetadataApiOnSuccessfulSomaticRun() throws Exception {
+        when(reference.run(METADATA.reference())).then(callHandlers(referenceListener, succeeded(), succeeded()));
+        when(tumor.run(METADATA.tumor())).then(callHandlers(tumorListener, succeeded(), succeeded()));
+        when(somatic.run()).thenReturn(succeeded());
+
+        victim.run();
+
+        ArgumentCaptor<PipelineState> stateCaptor = ArgumentCaptor.forClass(PipelineState.class);
+        verify(api, times(1)).complete(stateCaptor.capture(), eq(METADATA));
+        assertThat(stateCaptor.getValue().status()).isEqualTo(PipelineStatus.SUCCESS);
+    }
+
+    @Test
+    public void notifiesSetMetadataApiOnFailedSomaticRun() throws Exception {
+        when(reference.run(METADATA.reference())).then(callHandlers(referenceListener, succeeded(), succeeded()));
+        when(tumor.run(METADATA.tumor())).then(callHandlers(tumorListener, succeeded(), succeeded()));
+        when(somatic.run()).thenReturn(failed());
+
+        victim.run();
+
+        ArgumentCaptor<PipelineState> stateCaptor = ArgumentCaptor.forClass(PipelineState.class);
+        verify(api, times(1)).complete(stateCaptor.capture(), eq(METADATA));
+        assertThat(stateCaptor.getValue().status()).isEqualTo(PipelineStatus.FAILED);
+    }
+
+    @Test
+    public void runsCleanupOnSuccessfulSomaticRun() throws Exception {
+        when(reference.run(METADATA.reference())).then(callHandlers(referenceListener, succeeded(), succeeded()));
+        when(tumor.run(METADATA.tumor())).then(callHandlers(tumorListener, succeeded(), succeeded()));
+        when(somatic.run()).thenReturn(succeeded());
+
+        victim.run();
+
+        verify(cleanup, times(1)).run(METADATA);
+    }
+
+    @Test
+    public void doesNotRunCleanupOnFailedSomaticRun() throws Exception {
+        when(reference.run(METADATA.reference())).then(callHandlers(referenceListener, succeeded(), succeeded()));
+        when(tumor.run(METADATA.tumor())).then(callHandlers(tumorListener, succeeded(), succeeded()));
+        when(somatic.run()).thenReturn(failed());
+
+        victim.run();
+
+        verify(cleanup, never()).run(METADATA);
+    }
+
+    @Test
+    public void doesNotRunCleanupOnFailedTransfer() throws Exception {
+        when(reference.run(METADATA.reference())).then(callHandlers(referenceListener, succeeded(), succeeded()));
+        when(tumor.run(METADATA.tumor())).then(callHandlers(tumorListener, succeeded(), succeeded()));
+        when(somatic.run()).thenReturn(succeeded());
+        doThrow(new NullPointerException()).when(api).complete(any(PipelineState.class), any(SomaticRunMetadata.class));
+
+        try {
+            victim.run();
+        } catch (Exception e) {
+            // continue
+        }
+        verify(cleanup, never()).run(any());
     }
 
     private static PipelineState succeeded() {

--- a/cluster/src/test/java/com/hartwig/pipeline/PipelineStateTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/PipelineStateTest.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 
 import com.hartwig.pipeline.execution.PipelineStatus;
+import com.hartwig.pipeline.metadata.ApiFileOperation;
 import com.hartwig.pipeline.report.ReportComponent;
 
 import org.jetbrains.annotations.NotNull;
@@ -57,6 +58,11 @@ public class PipelineStateTest {
 
             @Override
             public List<ReportComponent> reportComponents() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public List<ApiFileOperation> furtherOperations() {
                 return Collections.emptyList();
             }
         };

--- a/cluster/src/test/java/com/hartwig/pipeline/SomaticPipelineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/SomaticPipelineTest.java
@@ -21,12 +21,8 @@ import static com.hartwig.pipeline.testsupport.TestInputs.tumorRunMetadata;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
@@ -40,7 +36,6 @@ import com.hartwig.pipeline.calling.germline.GermlineCallerOutput;
 import com.hartwig.pipeline.calling.somatic.SomaticCaller;
 import com.hartwig.pipeline.calling.somatic.SomaticCallerOutput;
 import com.hartwig.pipeline.calling.structural.StructuralCaller;
-import com.hartwig.pipeline.cleanup.Cleanup;
 import com.hartwig.pipeline.execution.PipelineStatus;
 import com.hartwig.pipeline.metadata.SingleSampleRunMetadata;
 import com.hartwig.pipeline.metadata.SomaticMetadataApi;
@@ -64,7 +59,6 @@ public class SomaticPipelineTest {
     private SomaticPipeline victim;
     private StructuralCaller structuralCaller;
     private SomaticMetadataApi setMetadataApi;
-    private Cleanup cleanup;
     private StageRunner<SomaticRunMetadata> stageRunner;
     private OutputStorage<GermlineCallerOutput, SingleSampleRunMetadata> germlineCallerOutputStorage;
 
@@ -81,7 +75,6 @@ public class SomaticPipelineTest {
         when(storage.get(ARGUMENTS.patientReportBucket())).thenReturn(reportBucket);
         final PipelineResults pipelineResults = PipelineResultsProvider.from(storage, ARGUMENTS, "test").get();
         final FullSomaticResults fullSomaticResults = mock(FullSomaticResults.class);
-        cleanup = mock(Cleanup.class);
         stageRunner = mock(StageRunner.class);
         germlineCallerOutputStorage = mock(OutputStorage.class);
         victim = new SomaticPipeline(ARGUMENTS,
@@ -92,7 +85,6 @@ public class SomaticPipelineTest {
                 setMetadataApi,
                 pipelineResults,
                 fullSomaticResults,
-                cleanup,
                 Executors.newSingleThreadExecutor());
     }
 
@@ -164,58 +156,6 @@ public class SomaticPipelineTest {
     }
 
     @Test
-    public void notifiesSetMetadataApiOnSuccessfulRun() {
-        successfulRun();
-        victim.run();
-        verify(setMetadataApi, times(1)).complete(eq(PipelineStatus.SUCCESS), eq(defaultSomaticRunMetadata()), any(PipelineState.class));
-    }
-
-    @Test
-    public void notifiesSetMetadataApiOnFailedRun() {
-        failedRun();
-        victim.run();
-        verify(setMetadataApi, times(1)).complete(eq(PipelineStatus.FAILED), eq(defaultSomaticRunMetadata()), any(PipelineState.class));
-    }
-
-    @Test
-    public void runsCleanupOnSuccessfulRun() {
-        successfulRun();
-        victim.run();
-        verify(cleanup, times(1)).run(defaultSomaticRunMetadata());
-    }
-
-    @Test
-    public void doesNotRunCleanupOnFailedRun() {
-        failedRun();
-        victim.run();
-        verify(cleanup, never()).run(defaultSomaticRunMetadata());
-    }
-
-    @Test
-    public void doesNotRunCleanupOnFailedTransfer() {
-        successfulRun();
-        doThrow(new NullPointerException()).when(setMetadataApi)
-                .complete(eq(PipelineStatus.SUCCESS), eq(defaultSomaticRunMetadata()), any(PipelineState.class));
-        try {
-            victim.run();
-        } catch (Exception e) {
-            // continue
-        }
-        verify(cleanup, never()).run(defaultSomaticRunMetadata());
-    }
-
-    @Test
-    public void onlyDoesTransferAndCleanupIfSingleSampleRun() {
-        when(alignmentOutputStorage.get(referenceRunMetadata())).thenReturn(Optional.of(referenceAlignmentOutput()));
-        when(setMetadataApi.get()).thenReturn(SomaticRunMetadata.builder()
-                .from(defaultSomaticRunMetadata())
-                .maybeTumor(Optional.empty())
-                .build());
-        victim.run();
-        verifyZeroInteractions(stageRunner, structuralCaller);
-    }
-
-    @Test
     public void failsRunOnQcFailure() {
         bothAlignmentsAvailable();
         bothMetricsAvailable();
@@ -232,6 +172,17 @@ public class SomaticPipelineTest {
                 .thenReturn(chordOutput());
         PipelineState state = victim.run();
         assertThat(state.status()).isEqualTo(PipelineStatus.QC_FAILED);
+    }
+
+    @Test
+    public void skipsStructuralCallerIfSingleSampleRun() {
+        when(alignmentOutputStorage.get(referenceRunMetadata())).thenReturn(Optional.of(referenceAlignmentOutput()));
+        when(setMetadataApi.get()).thenReturn(SomaticRunMetadata.builder()
+                .from(defaultSomaticRunMetadata())
+                .maybeTumor(Optional.empty())
+                .build());
+        victim.run();
+        verifyZeroInteractions(stageRunner, structuralCaller);
     }
 
     private void successfulRun() {

--- a/cluster/src/test/java/com/hartwig/pipeline/SomaticPipelineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/SomaticPipelineTest.java
@@ -167,14 +167,14 @@ public class SomaticPipelineTest {
     public void notifiesSetMetadataApiOnSuccessfulRun() {
         successfulRun();
         victim.run();
-        verify(setMetadataApi, times(1)).complete(PipelineStatus.SUCCESS, defaultSomaticRunMetadata());
+        verify(setMetadataApi, times(1)).complete(eq(PipelineStatus.SUCCESS), eq(defaultSomaticRunMetadata()), any(PipelineState.class));
     }
 
     @Test
     public void notifiesSetMetadataApiOnFailedRun() {
         failedRun();
         victim.run();
-        verify(setMetadataApi, times(1)).complete(PipelineStatus.FAILED, defaultSomaticRunMetadata());
+        verify(setMetadataApi, times(1)).complete(eq(PipelineStatus.FAILED), eq(defaultSomaticRunMetadata()), any(PipelineState.class));
     }
 
     @Test
@@ -194,7 +194,8 @@ public class SomaticPipelineTest {
     @Test
     public void doesNotRunCleanupOnFailedTransfer() {
         successfulRun();
-        doThrow(new NullPointerException()).when(setMetadataApi).complete(PipelineStatus.SUCCESS, defaultSomaticRunMetadata());
+        doThrow(new NullPointerException()).when(setMetadataApi)
+                .complete(eq(PipelineStatus.SUCCESS), eq(defaultSomaticRunMetadata()), any(PipelineState.class));
         try {
             victim.run();
         } catch (Exception e) {

--- a/cluster/src/test/java/com/hartwig/pipeline/metadata/SbpSomaticMetadataApiTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/metadata/SbpSomaticMetadataApiTest.java
@@ -55,6 +55,7 @@ public class SbpSomaticMetadataApiTest {
         entityId = ArgumentCaptor.forClass(String.class);
         status = ArgumentCaptor.forClass(String.class);
         pipelineState = mock(PipelineState.class);
+        when(pipelineState.status()).thenReturn(PipelineStatus.SUCCESS);
         victim = new SbpSomaticMetadataApi(Arguments.testDefaults(), SET_ID, sbpRestApi, sourceBucket, googleArchiver);
     }
 
@@ -73,7 +74,7 @@ public class SbpSomaticMetadataApiTest {
 
     @Test
     public void mapsSuccessStatusToSnpCheck() {
-        victim.complete(PipelineStatus.SUCCESS, somaticRunMetadata, pipelineState);
+        victim.complete(pipelineState, somaticRunMetadata);
         verify(sbpRestApi, times(2)).updateRunStatus(entityId.capture(), status.capture(), any());
         assertThat(entityId.getValue()).isEqualTo(String.valueOf(SET_ID));
         assertThat(status.getValue()).isEqualTo(SbpSomaticMetadataApi.SNP_CHECK);
@@ -86,7 +87,7 @@ public class SbpSomaticMetadataApiTest {
                 sbpRestApi,
                 sourceBucket,
                 googleArchiver);
-        victim.complete(PipelineStatus.SUCCESS, somaticRunMetadata, pipelineState);
+        victim.complete(pipelineState, somaticRunMetadata);
         verify(sbpRestApi, times(2)).updateRunStatus(entityId.capture(), status.capture(), any());
         assertThat(entityId.getValue()).isEqualTo(String.valueOf(SET_ID));
         assertThat(status.getValue()).isEqualTo(SbpSomaticMetadataApi.SUCCESS);
@@ -94,7 +95,8 @@ public class SbpSomaticMetadataApiTest {
 
     @Test
     public void mapsFailedStatusToPipeline5Finished() {
-        victim.complete(PipelineStatus.FAILED, somaticRunMetadata, pipelineState);
+        when(pipelineState.status()).thenReturn(PipelineStatus.FAILED);
+        victim.complete(pipelineState, somaticRunMetadata);
         verify(sbpRestApi, times(2)).updateRunStatus(entityId.capture(), status.capture(), any());
         assertThat(entityId.getValue()).isEqualTo(String.valueOf(SET_ID));
         assertThat(status.getAllValues().get(1)).isEqualTo(SbpSomaticMetadataApi.FAILED);
@@ -119,13 +121,14 @@ public class SbpSomaticMetadataApiTest {
 
     @Test(expected = IllegalStateException.class)
     public void throwsIllegalStateIfNoBucketInRun() {
+        when(pipelineState.status()).thenReturn(PipelineStatus.FAILED);
         when(sbpRestApi.getRun(SET_ID)).thenReturn(TestJson.get("get_run_no_bucket"));
-        victim.complete(PipelineStatus.FAILED, somaticRunMetadata, pipelineState);
+        victim.complete(pipelineState, somaticRunMetadata);
     }
 
     @Test
     public void shouldIterateThroughOutputObjects() {
-        victim.complete(PipelineStatus.SUCCESS, somaticRunMetadata, pipelineState);
+        victim.complete(pipelineState, somaticRunMetadata);
         verify(sourceBucket).list(PREFIX);
     }
 
@@ -133,7 +136,7 @@ public class SbpSomaticMetadataApiTest {
     public void setsRunToFailedAndRethrowsIfSbpTransferFails() {
         doThrow(new RuntimeException()).when(sourceBucket).list(PREFIX);
         try {
-            victim.complete(PipelineStatus.SUCCESS, somaticRunMetadata, pipelineState);
+            victim.complete(pipelineState, somaticRunMetadata);
             fail("An exception should have been thrown");
         } catch (RuntimeException e) {
             verify(sbpRestApi).updateRunStatus(any(), eq(SbpSomaticMetadataApi.FAILED), any());
@@ -142,7 +145,7 @@ public class SbpSomaticMetadataApiTest {
 
     @Test
     public void shouldTransferToArchive() {
-        victim.complete(PipelineStatus.SUCCESS, somaticRunMetadata, pipelineState);
+        victim.complete(pipelineState, somaticRunMetadata);
         verify(googleArchiver).transfer(somaticRunMetadata);
     }
 
@@ -150,7 +153,7 @@ public class SbpSomaticMetadataApiTest {
     public void setsRunToFailedAndRethrowsIfArchiveFails() {
         doThrow(new RuntimeException()).when(googleArchiver).transfer(any());
         try {
-            victim.complete(PipelineStatus.SUCCESS, somaticRunMetadata, pipelineState);
+            victim.complete(pipelineState, somaticRunMetadata);
             fail("An exception should have been thrown");
         } catch (RuntimeException e) {
             verify(sbpRestApi).updateRunStatus(any(), eq(SbpSomaticMetadataApi.FAILED), any());

--- a/cluster/src/test/java/com/hartwig/pipeline/report/PipelineResultsTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/report/PipelineResultsTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import com.google.cloud.storage.Bucket;
@@ -17,6 +18,7 @@ import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.PipelineState;
 import com.hartwig.pipeline.StageOutput;
 import com.hartwig.pipeline.execution.PipelineStatus;
+import com.hartwig.pipeline.metadata.ApiFileOperation;
 import com.hartwig.pipeline.metrics.BamMetricsOutput;
 import com.hartwig.pipeline.testsupport.TestInputs;
 
@@ -119,6 +121,11 @@ public class PipelineResultsTest {
             @Override
             public List<ReportComponent> reportComponents() {
                 return components;
+            }
+
+            @Override
+            public List<ApiFileOperation> furtherOperations() {
+                return Collections.emptyList();
             }
         };
     }

--- a/cluster/src/test/java/com/hartwig/pipeline/transfer/SbpFileApiUpdateTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/transfer/SbpFileApiUpdateTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Bucket;
+import com.hartwig.pipeline.metadata.AdditionalApiCalls;
 import com.hartwig.pipeline.sbpapi.SbpFileMetadata;
 import com.hartwig.pipeline.sbpapi.SbpRestApi;
 import com.hartwig.pipeline.sbpapi.SbpRun;
@@ -25,6 +26,7 @@ public class SbpFileApiUpdateTest {
     private SbpFileApiUpdate victim;
     private Blob blob;
     private ContentTypeCorrection correction;
+    private AdditionalApiCalls metadata;
 
     @Before
     public void setUp() throws Exception {
@@ -34,7 +36,8 @@ public class SbpFileApiUpdateTest {
         sbpRestApi = mock(SbpRestApi.class);
         blob = TestBlobs.blob("report/run/blob");
         correction = mock(ContentTypeCorrection.class);
-        victim = new SbpFileApiUpdate(correction, run, sourceBucket, sbpRestApi);
+        metadata = mock(AdditionalApiCalls.class);
+        victim = new SbpFileApiUpdate(correction, metadata, run, sourceBucket, sbpRestApi);
     }
 
     @Test

--- a/cluster/src/test/java/com/hartwig/pipeline/transfer/SbpFileApiUpdateTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/transfer/SbpFileApiUpdateTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Bucket;
+import com.hartwig.pipeline.PipelineState;
 import com.hartwig.pipeline.metadata.AdditionalApiCalls;
 import com.hartwig.pipeline.sbpapi.SbpFileMetadata;
 import com.hartwig.pipeline.sbpapi.SbpRestApi;
@@ -27,6 +28,7 @@ public class SbpFileApiUpdateTest {
     private Blob blob;
     private ContentTypeCorrection correction;
     private AdditionalApiCalls metadata;
+    private PipelineState pipelineState;
 
     @Before
     public void setUp() throws Exception {
@@ -37,7 +39,8 @@ public class SbpFileApiUpdateTest {
         blob = TestBlobs.blob("report/run/blob");
         correction = mock(ContentTypeCorrection.class);
         metadata = mock(AdditionalApiCalls.class);
-        victim = new SbpFileApiUpdate(correction, metadata, run, sourceBucket, sbpRestApi);
+        pipelineState = mock(PipelineState.class);
+        victim = new SbpFileApiUpdate(correction, metadata, run, sourceBucket, sbpRestApi, pipelineState);
     }
 
     @Test


### PR DESCRIPTION
Allow calling of arbitrary API endpoints after files have been created
so that we can add additional metadata for certain files from the run.