### PR TITLE
DEV-1279 Copy all single-pipeline files on rerun

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/SingleSamplePipeline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/SingleSamplePipeline.java
@@ -61,7 +61,7 @@ public class SingleSamplePipeline {
         AlignmentOutput alignmentOutput = report.add(state.add(aligner.run(metadata)));
         eventListener.alignmentComplete(state);
         if (state.shouldProceed()) {
-            report.initialise(arguments, metadata);
+            report.clearOldState(arguments, metadata);
             Future<BamMetricsOutput> bamMetricsFuture =
                     executorService.submit(() -> stageRunner.run(metadata, new BamMetrics(resourceFiles, alignmentOutput)));
             Future<SnpGenotypeOutput> unifiedGenotyperFuture =

--- a/cluster/src/main/java/com/hartwig/pipeline/SingleSamplePipeline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/SingleSamplePipeline.java
@@ -2,6 +2,10 @@ package com.hartwig.pipeline;
 
 import static com.hartwig.pipeline.resource.ResourceFilesFactory.buildResourceFiles;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
 import com.hartwig.pipeline.alignment.AlignmentOutput;
 import com.hartwig.pipeline.alignment.vm.VmAligner;
 import com.hartwig.pipeline.calling.germline.GermlineCaller;
@@ -19,12 +23,9 @@ import com.hartwig.pipeline.resource.ResourceFiles;
 import com.hartwig.pipeline.snpgenotype.SnpGenotype;
 import com.hartwig.pipeline.snpgenotype.SnpGenotypeOutput;
 import com.hartwig.pipeline.stages.StageRunner;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 
 public class SingleSamplePipeline {
 
@@ -60,7 +61,7 @@ public class SingleSamplePipeline {
         AlignmentOutput alignmentOutput = report.add(state.add(aligner.run(metadata)));
         eventListener.alignmentComplete(state);
         if (state.shouldProceed()) {
-
+            report.initialise(arguments, metadata);
             Future<BamMetricsOutput> bamMetricsFuture =
                     executorService.submit(() -> stageRunner.run(metadata, new BamMetrics(resourceFiles, alignmentOutput)));
             Future<SnpGenotypeOutput> unifiedGenotyperFuture =

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/AddDatatypeToFile.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/AddDatatypeToFile.java
@@ -1,5 +1,7 @@
 package com.hartwig.pipeline.metadata;
 
+import static java.lang.String.format;
+
 import com.hartwig.pipeline.sbpapi.AddFileApiResponse;
 import com.hartwig.pipeline.sbpapi.SbpRestApi;
 
@@ -20,5 +22,10 @@ public class AddDatatypeToFile implements ApiFileOperation {
     @Override
     public String path() {
         return path;
+    }
+
+    @Override
+    public String toString() {
+        return format("add datatype [%s] to [%s]", datatype, path);
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/LinkFileToSample.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/LinkFileToSample.java
@@ -1,5 +1,7 @@
 package com.hartwig.pipeline.metadata;
 
+import static java.lang.String.format;
+
 import com.hartwig.pipeline.sbpapi.AddFileApiResponse;
 import com.hartwig.pipeline.sbpapi.SbpRestApi;
 
@@ -20,5 +22,10 @@ public class LinkFileToSample implements ApiFileOperation {
     @Override
     public String path() {
         return path;
+    }
+
+    @Override
+    public String toString() {
+        return format("link [%s] to sample [%d]", path, sampleId);
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/report/PipelineResults.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/report/PipelineResults.java
@@ -97,4 +97,12 @@ public class PipelineResults {
     private String path(final String name, final Folder folder, final String fileName) {
         return String.format("%s/%s%s", name, folder.name(), fileName);
     }
+
+    public void initialise(final Arguments arguments, final SingleSampleRunMetadata metadata) {
+        String name = RunTag.apply(arguments, metadata.sampleId());
+        boolean deleted = storage.delete(reportBucket.getName(), format("%s/%s", name, STAGING_COMPLETE));
+        if (deleted) {
+            LOGGER.info("Deleted existing staging complete flag");
+        }
+    }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/report/PipelineResults.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/report/PipelineResults.java
@@ -98,7 +98,7 @@ public class PipelineResults {
         return String.format("%s/%s%s", name, folder.name(), fileName);
     }
 
-    public void initialise(final Arguments arguments, final SingleSampleRunMetadata metadata) {
+    public void clearOldState(final Arguments arguments, final SingleSampleRunMetadata metadata) {
         String name = RunTag.apply(arguments, metadata.sampleId());
         boolean deleted = storage.delete(reportBucket.getName(), format("%s/%s", name, STAGING_COMPLETE));
         if (deleted) {

--- a/cluster/src/main/java/com/hartwig/pipeline/transfer/SbpFileApiUpdate.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/transfer/SbpFileApiUpdate.java
@@ -59,7 +59,7 @@ public class SbpFileApiUpdate implements Consumer<Blob> {
 
                 for (ApiFileOperation fileOperation : fileOperations) {
                     if (fileOperation.path().equals(blob.getName().substring(blob.getName().indexOf("/") + 1))) {
-                        LOGGER.info("Found operation [{}] to apply", fileOperation);
+                        LOGGER.info("Applying: {}", fileOperation);
                         fileOperation.apply(sbpApi, fileResponse);
                     }
                 }

--- a/cluster/src/test/java/com/hartwig/pipeline/SingleSamplePipelineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/SingleSamplePipelineTest.java
@@ -299,7 +299,7 @@ public class SingleSamplePipelineTest {
         when(aligner.run(referenceRunMetadata())).thenReturn(referenceAlignmentOutput());
         initialiseVictim(false);
         victim.run(referenceRunMetadata());
-        verify(pipelineResults).initialise(any(Arguments.class), eq(referenceRunMetadata()));
+        verify(pipelineResults).clearOldState(any(Arguments.class), eq(referenceRunMetadata()));
     }
 
     private void assertFailed(final PipelineState runOutput) {

--- a/cluster/src/test/java/com/hartwig/pipeline/SingleSamplePipelineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/SingleSamplePipelineTest.java
@@ -1,5 +1,28 @@
 package com.hartwig.pipeline;
 
+import static com.hartwig.pipeline.testsupport.TestInputs.cramOutput;
+import static com.hartwig.pipeline.testsupport.TestInputs.flagstatOutput;
+import static com.hartwig.pipeline.testsupport.TestInputs.germlineCallerOutput;
+import static com.hartwig.pipeline.testsupport.TestInputs.referenceAlignmentOutput;
+import static com.hartwig.pipeline.testsupport.TestInputs.referenceMetricsOutput;
+import static com.hartwig.pipeline.testsupport.TestInputs.referenceRunMetadata;
+import static com.hartwig.pipeline.testsupport.TestInputs.referenceSample;
+import static com.hartwig.pipeline.testsupport.TestInputs.snpGenotypeOutput;
+import static com.hartwig.pipeline.testsupport.TestInputs.tumorAlignmentOutput;
+import static com.hartwig.pipeline.testsupport.TestInputs.tumorMetricsOutput;
+import static com.hartwig.pipeline.testsupport.TestInputs.tumorRunMetadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.Executors;
+
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.hartwig.pipeline.alignment.AlignmentOutput;
@@ -16,30 +39,9 @@ import com.hartwig.pipeline.report.PipelineResultsProvider;
 import com.hartwig.pipeline.report.ReportComponent;
 import com.hartwig.pipeline.snpgenotype.SnpGenotypeOutput;
 import com.hartwig.pipeline.stages.StageRunner;
+
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.concurrent.Executors;
-
-import static com.hartwig.pipeline.testsupport.TestInputs.cramOutput;
-import static com.hartwig.pipeline.testsupport.TestInputs.flagstatOutput;
-import static com.hartwig.pipeline.testsupport.TestInputs.germlineCallerOutput;
-import static com.hartwig.pipeline.testsupport.TestInputs.referenceAlignmentOutput;
-import static com.hartwig.pipeline.testsupport.TestInputs.referenceMetricsOutput;
-import static com.hartwig.pipeline.testsupport.TestInputs.referenceRunMetadata;
-import static com.hartwig.pipeline.testsupport.TestInputs.referenceSample;
-import static com.hartwig.pipeline.testsupport.TestInputs.snpGenotypeOutput;
-import static com.hartwig.pipeline.testsupport.TestInputs.tumorAlignmentOutput;
-import static com.hartwig.pipeline.testsupport.TestInputs.tumorMetricsOutput;
-import static com.hartwig.pipeline.testsupport.TestInputs.tumorRunMetadata;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class SingleSamplePipelineTest {
 
@@ -282,12 +284,22 @@ public class SingleSamplePipelineTest {
     }
 
     @Test
-    public void doesnotComposeReportIfStatusIsFailed() throws Exception {
+    public void doesNotComposeReportIfStatusIsFailed() throws Exception {
         pipelineResults = mock(PipelineResults.class);
         AlignmentOutput alignmentOutput = AlignmentOutput.builder().status(PipelineStatus.FAILED).sample(referenceSample()).build();
         when(aligner.run(referenceRunMetadata())).thenReturn(alignmentOutput);
         victim.run(referenceRunMetadata());
         verify(pipelineResults, never()).compose(any(), eq(true), any());
+    }
+
+    @Test
+    public void clearsOutExistingStagingFlag() throws Exception {
+        pipelineResults = mock(PipelineResults.class);
+        when(pipelineResults.add(any())).thenAnswer(i -> i.getArguments()[0]);
+        when(aligner.run(referenceRunMetadata())).thenReturn(referenceAlignmentOutput());
+        initialiseVictim(false);
+        victim.run(referenceRunMetadata());
+        verify(pipelineResults).initialise(any(Arguments.class), eq(referenceRunMetadata()));
     }
 
     private void assertFailed(final PipelineState runOutput) {

--- a/cluster/src/test/java/com/hartwig/pipeline/report/PipelineResultsTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/report/PipelineResultsTest.java
@@ -103,7 +103,7 @@ public class PipelineResultsTest {
 
     @Test
     public void initialisationClearsOutStagedFlag() {
-        victim.initialise(Arguments.testDefaults(), TestInputs.referenceRunMetadata());
+        victim.clearOldState(Arguments.testDefaults(), TestInputs.referenceRunMetadata());
         verify(storage).delete(outputBucket.getName(), "reference-test/STAGED");
     }
 

--- a/cluster/src/test/java/com/hartwig/pipeline/report/PipelineResultsTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/report/PipelineResultsTest.java
@@ -34,10 +34,11 @@ public class PipelineResultsTest {
     private boolean secondComponentRan;
     private PipelineResults victim;
     private Bucket outputBucket;
+    private Storage storage;
 
     @Before
     public void setUp() throws Exception {
-        final Storage storage = mock(Storage.class);
+        storage = mock(Storage.class);
         outputBucket = mock(Bucket.class);
         when(outputBucket.getName()).thenReturn(PIPELINE_OUTPUT);
         victim = new PipelineResults("test", storage, outputBucket, Arguments.testDefaultsBuilder().runId("tag").build());
@@ -98,6 +99,12 @@ public class PipelineResultsTest {
         victim.compose(TestInputs.referenceRunMetadata(), false, state);
         verify(outputBucket, times(1)).create(createBlobCaptor.capture(), (byte[]) any());
         assertThat(createBlobCaptor.getAllValues().get(0)).isEqualTo("reference-tag/STAGED");
+    }
+
+    @Test
+    public void initialisationClearsOutStagedFlag() {
+        victim.initialise(Arguments.testDefaults(), TestInputs.referenceRunMetadata());
+        verify(storage).delete(outputBucket.getName(), "reference-test/STAGED");
     }
 
     @NotNull


### PR DESCRIPTION
We encountered a failure in production in which a failure in the CRAM
stage resulted in a rerun of the pipeline, but after the rerun succeeded
the output directory did not contain the files from the sample that had
failed the first time (none of them; the subdirectory for the sample
itself wasn't even present).

Looks like the reason for this was that the flag file which tells the
pipeline that the staging directory has been populated was left-over
from the first run, which meant that upon re-run the pipeline didn't
wait for the files to be copied from the staging bucket into the final
archive bucket.

Also improve logging output for post-applied operations to make
debugging this problem easier.