### PR TITLE
DEV-1287 Disable sage caller when shallow run

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/calling/somatic/SageV2Caller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/somatic/SageV2Caller.java
@@ -60,8 +60,7 @@ public class SageV2Caller extends TertiaryStage<SomaticCallerOutput> {
         String tumorSampleName = metadata.tumor().sampleName();
         String referenceSampleName = metadata.reference().sampleName();
 
-        SageV2Application sageV2Application = new SageV2Application(
-                resourceFiles.sageKnownHotspots(),
+        SageV2Application sageV2Application = new SageV2Application(resourceFiles.sageKnownHotspots(),
                 resourceFiles.sageActionableCodingPanel(),
                 resourceFiles.giabHighConfidenceBed(),
                 referenceGenomePath,
@@ -73,13 +72,12 @@ public class SageV2Caller extends TertiaryStage<SomaticCallerOutput> {
 
         final String refGenomeStr = resourceFiles.version() == RefGenomeVersion.HG37 ? "hg19" : "hg38";
 
-        SubStageInputOutput sageOutput = sageV2Application
-                .andThen(new SageV2PassFilter(tumorSampleName))
+        SubStageInputOutput sageOutput = sageV2Application.andThen(new SageV2PassFilter(tumorSampleName))
                 .andThen(new MappabilityAnnotation(resourceFiles.out150Mappability(), ResourceFiles.of(MAPPABILITY, "mappability.hdr")))
                 .andThen(new PonAnnotation("sage.pon", resourceFiles.sageGermlinePon(), "PON_COUNT"))
                 .andThen(new SageV2PonFilter())
                 .andThen(new SnpEff(ResourceFiles.SNPEFF_CONFIG, resourceFiles))
-                .andThen(new SageV2PostProcess( refGenomeStr))
+                .andThen(new SageV2PostProcess(refGenomeStr))
                 .andThen(FinalSubStage.of(new CosmicAnnotation(ResourceFiles.COSMIC_VCF_GZ, "ID,INFO")))
                 .apply(SubStageInputOutput.empty(tumorSampleName));
 
@@ -103,7 +101,8 @@ public class SageV2Caller extends TertiaryStage<SomaticCallerOutput> {
                         NAMESPACE,
                         Folder.from(),
                         outputFile.fileName(),
-                        OutputFile.of(metadata.tumor().sampleName(), "sage.somatic.post_processed", OutputFile.GZIPPED_VCF, false).fileName(),
+                        OutputFile.of(metadata.tumor().sampleName(), "sage.somatic.post_processed", OutputFile.GZIPPED_VCF, false)
+                                .fileName(),
                         resultsDirectory))
                 .addReportComponents(new ZippedVcfAndIndexComponent(bucket,
                         NAMESPACE,
@@ -123,6 +122,6 @@ public class SageV2Caller extends TertiaryStage<SomaticCallerOutput> {
 
     @Override
     public boolean shouldRun(final Arguments arguments) {
-        return arguments.runSageCaller();
+        return !arguments.shallow() && arguments.runSageCaller();
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/germline/GermlineCallerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/germline/GermlineCallerTest.java
@@ -1,7 +1,5 @@
 package com.hartwig.pipeline.calling.germline;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
@@ -12,7 +10,6 @@ import com.hartwig.pipeline.stages.StageTest;
 import com.hartwig.pipeline.testsupport.TestInputs;
 
 import org.junit.Before;
-import org.junit.Test;
 
 public class GermlineCallerTest extends StageTest<GermlineCallerOutput, SingleSampleRunMetadata> {
 
@@ -48,9 +45,9 @@ public class GermlineCallerTest extends StageTest<GermlineCallerOutput, SingleSa
         return Arguments.testDefaultsBuilder().runGermlineCaller(false).build();
     }
 
-    @Test
-    public void alsoDisabledWhenShallow() {
-        assertThat(victim.shouldRun(Arguments.testDefaultsBuilder().shallow(true).build())).isFalse();
+    @Override
+    protected boolean isEnabledOnShallowSeq() {
+        return false;
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/somatic/SageV2CallerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/somatic/SageV2CallerTest.java
@@ -44,6 +44,11 @@ public class SageV2CallerTest extends TertiaryStageTest<SomaticCallerOutput> {
     }
 
     @Override
+    protected boolean isEnabledOnShallowSeq() {
+        return false;
+    }
+
+    @Override
     public void returnsExpectedOutput() {
         // ignored for now.
     }

--- a/cluster/src/test/java/com/hartwig/pipeline/stages/StageTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/stages/StageTest.java
@@ -1,5 +1,13 @@
 package com.hartwig.pipeline.stages;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.CopyWriter;
 import com.google.cloud.storage.Storage;
@@ -11,16 +19,9 @@ import com.hartwig.pipeline.execution.vm.BashCommand;
 import com.hartwig.pipeline.execution.vm.VmDirectories;
 import com.hartwig.pipeline.metadata.RunMetadata;
 import com.hartwig.pipeline.storage.RuntimeBucket;
+
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public abstract class StageTest<S extends StageOutput, M extends RunMetadata> {
 
@@ -65,6 +66,11 @@ public abstract class StageTest<S extends StageOutput, M extends RunMetadata> {
     }
 
     @Test
+    public void enabledOnShallowSeq() {
+        assertThat(victim.shouldRun(Arguments.builder().from(defaultArguments()).shallow(true).build())).isEqualTo(isEnabledOnShallowSeq());
+    }
+
+    @Test
     public void returnsExpectedOutput() {
         S output = victim.output(input(), PipelineStatus.SUCCESS, runtimeBucket, ResultsDirectory.defaultDirectory());
         assertThat(output.status()).isEqualTo(PipelineStatus.SUCCESS);
@@ -96,5 +102,9 @@ public abstract class StageTest<S extends StageOutput, M extends RunMetadata> {
 
     private List<String> commands(List<String> commands) {
         return commands.stream().map(command -> command.replace("$TOOLS_DIR", VmDirectories.TOOLS)).collect(Collectors.toList());
+    }
+
+    protected boolean isEnabledOnShallowSeq() {
+        return true;
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/bachelor/BachelorTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/bachelor/BachelorTest.java
@@ -46,9 +46,9 @@ public class BachelorTest extends TertiaryStageTest<BachelorOutput> {
                 + "/opt/resources/reference_genome/hg37/Homo_sapiens.GRCh37.GATK.illumina.fasta -output_dir /data/output -log_debug");
     }
 
-    @Test
-    public void doesntRunWhenShallowEnabled() {
-        assertThat(victim.shouldRun(Arguments.testDefaultsBuilder().shallow(true).runTertiary(true).build())).isFalse();
+    @Override
+    protected boolean isEnabledOnShallowSeq() {
+        return false;
     }
 
     @Test

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/chord/ChordTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/chord/ChordTest.java
@@ -1,18 +1,13 @@
 package com.hartwig.pipeline.tertiary.chord;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Collections;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
-import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.tertiary.TertiaryStageTest;
 import com.hartwig.pipeline.testsupport.TestInputs;
-
-import org.junit.Test;
 
 public class ChordTest extends TertiaryStageTest<ChordOutput> {
 
@@ -33,9 +28,9 @@ public class ChordTest extends TertiaryStageTest<ChordOutput> {
                 + "/data/input/tumor.purple.somatic.vcf.gz /data/input/tumor.purple.sv.vcf.gz");
     }
 
-    @Test
-    public void doesntRunWhenShallowEnabled() {
-        assertThat(victim.shouldRun(Arguments.testDefaultsBuilder().shallow(true).runTertiary(true).build())).isFalse();
+    @Override
+    protected boolean isEnabledOnShallowSeq() {
+        return false;
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/healthcheck/HealthCheckerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/healthcheck/HealthCheckerTest.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 import com.google.cloud.storage.Blob;
 import com.google.common.collect.ImmutableList;
-import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.ResultsDirectory;
 import com.hartwig.pipeline.execution.PipelineStatus;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
@@ -75,9 +74,9 @@ public class HealthCheckerTest extends TertiaryStageTest<HealthCheckOutput> {
                 PipelineStatus.FAILED);
     }
 
-    @Test
-    public void doesntRunWhenShallowEnabled() {
-        assertThat(victim.shouldRun(Arguments.testDefaultsBuilder().shallow(true).runTertiary(true).build())).isFalse();
+    @Override
+    protected boolean isEnabledOnShallowSeq() {
+        return false;
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/linx/LinxTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/linx/LinxTest.java
@@ -1,18 +1,14 @@
 package com.hartwig.pipeline.tertiary.linx;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Collections;
 import java.util.List;
 
-import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.tertiary.TertiaryStageTest;
 import com.hartwig.pipeline.testsupport.TestInputs;
 
 import org.junit.Before;
-import org.junit.Test;
 
 public class LinxTest extends TertiaryStageTest<LinxOutput> {
 
@@ -46,9 +42,9 @@ public class LinxTest extends TertiaryStageTest<LinxOutput> {
                 + "/opt/resources/knowledgebases/output/knownPromiscuousThree.csv -chaining_sv_limit 0 -check_drivers -write_vis_data");
     }
 
-    @Test
-    public void doesntRunWhenShallowEnabled() {
-        assertThat(victim.shouldRun(Arguments.testDefaultsBuilder().shallow(true).runTertiary(true).build())).isFalse();
+    @Override
+    protected boolean isEnabledOnShallowSeq() {
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Currently the output is not used in the shallow run and it doesn't provide anything interesting to use later. Disable the caller when the shallow flag is true.