### PR TITLE
DEV-1289 Use fastq file directly rather than lane parsing for RG

### DIFF
--- a/cluster/src/main/java/com/hartwig/patient/Lane.java
+++ b/cluster/src/main/java/com/hartwig/patient/Lane.java
@@ -17,29 +17,8 @@ public interface Lane {
     String secondOfPairPath();
 
     @Value.Default
-    default String name() {
-        return "lane_" + laneNumber();
-    }
-
-    @Value.Default
     default String flowCellId() {
         return NOT_APPLICABLE;
-    }
-
-    @Value.Default
-    default String index() {
-        return NOT_APPLICABLE;
-    }
-
-    @Value.Default
-    default String suffix() {
-        return NOT_APPLICABLE;
-    }
-
-    default String recordGroupId() {
-        // Assumption is that name follows "sample_lane" format.
-        String[] split = name().split("_");
-        return String.format("%s_%s_%s_%s_%s", split[0], flowCellId(), index(), split[1], suffix());
     }
 
     static ImmutableLane.Builder builder() {

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/sample/FastqFiles.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/sample/FastqFiles.java
@@ -20,13 +20,8 @@ class FastqFiles {
             String[] tokens = filename.split("_");
             String laneNumber = tokens[3];
             String flowCellId = tokens[1];
-            ImmutableLane.Builder builder = builders.computeIfAbsent(laneNumber + flowCellId,
-                    s -> Lane.builder()
-                            .laneNumber(laneNumber)
-                            .name(sampleName + "_" + laneNumber)
-                            .flowCellId(flowCellId)
-                            .index(tokens[2])
-                            .suffix(tokens[5].substring(0, tokens[5].indexOf('.'))));
+            ImmutableLane.Builder builder =
+                    builders.computeIfAbsent(laneNumber + flowCellId, s -> Lane.builder().laneNumber(laneNumber).flowCellId(flowCellId));
             if (tokens[4].equals("R1")) {
                 builder.firstOfPairPath(filename);
             } else if (tokens[4].equals("R2")) {

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/sample/SbpSampleReader.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/sample/SbpSampleReader.java
@@ -99,13 +99,10 @@ public class SbpSampleReader {
         String laneNumber = tokens[3];
         String flowCellId = tokens[1];
         return Lane.builder()
-                .name(tokens[0] + "_" + laneNumber)
                 .laneNumber(laneNumber)
                 .firstOfPairPath(s3Path(sbpFastQ, sbpFastQ.name_r1()))
                 .secondOfPairPath(s3Path(sbpFastQ, sbpFastQ.name_r2()))
-                .suffix("")
                 .flowCellId(flowCellId)
-                .index(tokens[2])
                 .build();
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/vm/LaneAlignment.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/vm/LaneAlignment.java
@@ -29,7 +29,7 @@ public class LaneAlignment extends SubStage {
 
     @Override
     public List<BashCommand> bash(final OutputFile input, final OutputFile output) {
-        return Collections.singletonList(new PipeCommands(new BwaMemCommand(lane.recordGroupId(),
+        return Collections.singletonList(new PipeCommands(new BwaMemCommand(RecordGroupId.from(firstFastqPath),
                 sampleName,
                 lane.flowCellId(),
                 referenceGenomePath,

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/vm/LaneAlignment.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/vm/LaneAlignment.java
@@ -11,15 +11,17 @@ import com.hartwig.pipeline.execution.vm.unix.PipeCommands;
 
 public class LaneAlignment extends SubStage {
 
+    private final boolean strictFastqNaming;
     private final String referenceGenomePath;
     private final String firstFastqPath;
     private final String secondFastqPath;
     private final String sampleName;
     private final Lane lane;
 
-    LaneAlignment(final String referenceGenomePath, final String firstFastqPath, final String secondFastqPath, final String sampleName,
+    LaneAlignment(final boolean strictFastqNaming, final String referenceGenomePath, final String firstFastqPath, final String secondFastqPath, final String sampleName,
             final Lane lane) {
         super("sorted." + VmAligner.laneId(lane), OutputFile.BAM);
+        this.strictFastqNaming = strictFastqNaming;
         this.referenceGenomePath = referenceGenomePath;
         this.firstFastqPath = firstFastqPath;
         this.secondFastqPath = secondFastqPath;
@@ -29,7 +31,7 @@ public class LaneAlignment extends SubStage {
 
     @Override
     public List<BashCommand> bash(final OutputFile input, final OutputFile output) {
-        return Collections.singletonList(new PipeCommands(new BwaMemCommand(RecordGroupId.from(firstFastqPath),
+        return Collections.singletonList(new PipeCommands(new BwaMemCommand(RecordGroupId.from(strictFastqNaming, firstFastqPath),
                 sampleName,
                 lane.flowCellId(),
                 referenceGenomePath,

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/vm/RecordGroupId.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/vm/RecordGroupId.java
@@ -1,10 +1,25 @@
 package com.hartwig.pipeline.alignment.vm;
 
-import java.io.File;
+import static org.apache.commons.io.FilenameUtils.getName;
+import static org.apache.commons.io.FilenameUtils.removeExtension;
 
-public class RecordGroupId {
+import java.util.regex.Pattern;
 
-    static String from(String fastq) {
-        return new File(fastq).getName().replace("_R1", "").replace("_R2", "").replace(".fastq", "").replace(".gz", "");
+public interface RecordGroupId {
+
+    static String from(boolean strict, String fastq) {
+        String fastqNoExtension = removeFastqAndGz(getName(fastq));
+        if (strict) {
+            if (!Pattern.compile("^.*_.*_.*_L[0-9]{3}_R[1,2]_[0-9]{3}$").matcher(fastqNoExtension).matches()) {
+                throw new IllegalArgumentException(String.format("Fastq file [%s] did not match the expected pattern of "
+                        + "SAMPLENAME_FLOWCELLID_INDEX_LANE_PAIR_001.fastq.gz. Failing this run as this will cause issues later in the reads "
+                        + "RG field", fastq));
+            }
+        }
+        return fastqNoExtension.replace("_R1", "").replace("_R2", "");
+    }
+
+    static String removeFastqAndGz(final String name) {
+        return removeExtension(removeExtension(name));
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/vm/RecordGroupId.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/vm/RecordGroupId.java
@@ -1,0 +1,10 @@
+package com.hartwig.pipeline.alignment.vm;
+
+import java.io.File;
+
+public class RecordGroupId {
+
+    static String from(String fastq) {
+        return new File(fastq).getName().replace("_R1", "").replace("_R2", "").replace(".fastq", "").replace(".gz", "");
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/vm/VmAligner.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/vm/VmAligner.java
@@ -98,7 +98,8 @@ public class VmAligner {
 
             bash.addCommand(first).addCommand(second);
 
-            SubStageInputOutput alignment = new LaneAlignment(resourceFiles.refGenomeFile(),
+            SubStageInputOutput alignment = new LaneAlignment(arguments.sbpApiRunId().isPresent(),
+                    resourceFiles.refGenomeFile(),
                     first.getLocalTargetPath(),
                     second.getLocalTargetPath(),
                     sample.name(),

--- a/cluster/src/test/java/com/hartwig/pipeline/alignment/sample/SbpSampleReaderTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/alignment/sample/SbpSampleReaderTest.java
@@ -4,8 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
-
 import com.hartwig.patient.Sample;
 import com.hartwig.pipeline.metadata.TestJson;
 import com.hartwig.pipeline.sbpapi.SbpRestApi;
@@ -42,7 +40,7 @@ public class SbpSampleReaderTest {
     }
 
     @Test
-    public void addsAllLanesToSample() throws Exception {
+    public void addsAllLanesToSample() {
         returnJson(FASTQ_JSON);
         Sample sample = victim.read(EXISTS);
         assertThat(sample).isNotNull();
@@ -50,29 +48,28 @@ public class SbpSampleReaderTest {
     }
 
     @Test
-    public void parsesPatientNameFromReadsFile() throws Exception {
+    public void parsesPatientNameFromReadsFile() {
         returnJson(FASTQ_JSON);
         Sample sample = victim.read(EXISTS);
         assertThat(sample.name()).isEqualTo(SAMPLE_NAME);
     }
 
     @Test
-    public void getsBarcodeFromAPi() throws Exception {
+    public void getsBarcodeFromAPi() {
         returnJson(FASTQ_JSON);
         Sample sample = victim.read(EXISTS);
         assertThat(sample.barcode()).isEqualTo("FR13257296");
     }
 
     @Test
-    public void getsFlowcellAndIndexFromFileName()  throws Exception {
+    public void getsFlowcellFromFileName()  {
         returnJson(FASTQ_JSON);
         Sample sample = victim.read(EXISTS);
         assertThat(sample.lanes().get(0).flowCellId()).isEqualTo("HJKLMALXX");
-        assertThat(sample.lanes().get(0).index()).isEqualTo("S6");
     }
 
     @Test
-    public void filtersLanesWhichHaveNotPassedQC() throws Exception {
+    public void filtersLanesWhichHaveNotPassedQC(){
         returnJson(FASTQ_JSON_SINGLE_QC_FAILED);
         Sample sample = victim.read(EXISTS);
         assertThat(sample.lanes()).hasSize(1);
@@ -80,7 +77,7 @@ public class SbpSampleReaderTest {
     }
 
     @Test
-    public void handlesSubdirectories() throws Exception {
+    public void handlesSubdirectories() {
         returnJson(FASTQ_JSON_SUBDIRECTORIES);
         Sample sample = victim.read(EXISTS);
         assertThat(sample.lanes()).hasSize(2);
@@ -88,18 +85,18 @@ public class SbpSampleReaderTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void throwsIllegalArgumentWhenAllLanesFilteredQc() throws Exception {
+    public void throwsIllegalArgumentWhenAllLanesFilteredQc() {
         returnJson(FASTQ_JSON_ALL_QC_FAILED);
         victim.read(EXISTS);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void throwsIllegalArgumentWhenFastqNameIncorrect() throws Exception {
+    public void throwsIllegalArgumentWhenFastqNameIncorrect() {
         returnJson(BAD_FASTQ_NAME);
         victim.read(EXISTS);
     }
 
-    private void returnJson(final String sampleJsonLocation) throws IOException {
+    private void returnJson(final String sampleJsonLocation) {
         when(sbpRestApi.getFastQ(EXISTS)).thenReturn(TestJson.get(sampleJsonLocation));
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/alignment/vm/LaneAlignmentTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/alignment/vm/LaneAlignmentTest.java
@@ -13,7 +13,8 @@ public class LaneAlignmentTest extends SubStageTest {
 
     @Override
     public SubStage createVictim() {
-        return new LaneAlignment("reference.fasta",
+        return new LaneAlignment(false,
+                "reference.fasta",
                 "COLO829v003R_AHHKYHDSXX_S13_L001_R1_001.fastq.gz",
                 "COLO829v003R_AHHKYHDSXX_S13_L001_R2_001.fastq.gz",
                 "tumor",

--- a/cluster/src/test/java/com/hartwig/pipeline/alignment/vm/LaneAlignmentTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/alignment/vm/LaneAlignmentTest.java
@@ -14,10 +14,10 @@ public class LaneAlignmentTest extends SubStageTest {
     @Override
     public SubStage createVictim() {
         return new LaneAlignment("reference.fasta",
-                "R1.fastq",
-                "R2.fastq",
+                "COLO829v003R_AHHKYHDSXX_S13_L001_R1_001.fastq.gz",
+                "COLO829v003R_AHHKYHDSXX_S13_L001_R2_001.fastq.gz",
                 "tumor",
-                emptyBuilder().name("tumor_L001").laneNumber("L001").flowCellId("flowCell").build());
+                emptyBuilder().laneNumber("L001").flowCellId("flowCell").build());
 
     }
 
@@ -29,8 +29,9 @@ public class LaneAlignmentTest extends SubStageTest {
     @Test
     public void alignsBamsAndSortsEachLaneFastqPair() {
         assertThat(bash()).contains("(/opt/tools/bwa/0.7.17/bwa mem -R "
-                + "\"@RG\\tID:tumor_flowCell__L001_\\tLB:tumor\\tPL:ILLUMINA\\tPU:flowCell\\tSM:tumor\" -Y -t $(grep -c '^processor' /proc/cpuinfo) "
-                + "reference.fasta R1.fastq R2.fastq | /opt/tools/sambamba/0.6.8/sambamba view -f bam -S -l0 /dev/stdin | "
-                + "/opt/tools/sambamba/0.6.8/sambamba sort -o /data/output/tumor.sorted.flowCell-L001.bam /dev/stdin)");
+                + "\"@RG\\tID:COLO829v003R_AHHKYHDSXX_S13_L001_001\\tLB:tumor\\tPL:ILLUMINA\\tPU:flowCell\\tSM:tumor\" "
+                + "-Y -t $(grep -c '^processor' /proc/cpuinfo) reference.fasta COLO829v003R_AHHKYHDSXX_S13_L001_R1_001.fastq.gz "
+                + "COLO829v003R_AHHKYHDSXX_S13_L001_R2_001.fastq.gz | /opt/tools/sambamba/0.6.8/sambamba view -f bam -S -l0 /dev/stdin "
+                + "| /opt/tools/sambamba/0.6.8/sambamba sort -o /data/output/tumor.sorted.flowCell-L001.bam /dev/stdin)");
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/alignment/vm/Lanes.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/alignment/vm/Lanes.java
@@ -6,6 +6,6 @@ import com.hartwig.patient.Lane;
 class Lanes {
 
     static ImmutableLane.Builder emptyBuilder() {
-        return Lane.builder().name("").firstOfPairPath("").secondOfPairPath("").flowCellId("").index("").suffix("");
+        return Lane.builder().firstOfPairPath("").secondOfPairPath("").flowCellId("");
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/alignment/vm/RecordGroupIdTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/alignment/vm/RecordGroupIdTest.java
@@ -1,0 +1,23 @@
+package com.hartwig.pipeline.alignment.vm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class RecordGroupIdTest {
+
+    @Test
+    public void removesR1FromFastqName() {
+        assertThat(RecordGroupId.from("COLO829v003R_AHHKYHDSXX_S13_L001_R1_001.fastq.gz")).isEqualTo("COLO829v003R_AHHKYHDSXX_S13_L001_001");
+    }
+
+    @Test
+    public void removesR2FromFastqName() {
+        assertThat(RecordGroupId.from("COLO829v003R_AHHKYHDSXX_S13_L001_R2_001.fastq.gz")).isEqualTo("COLO829v003R_AHHKYHDSXX_S13_L001_001");
+    }
+
+    @Test
+    public void removesFastqExtension() {
+        assertThat(RecordGroupId.from("COLO829v003R_AHHKYHDSXX_S13_L001_R2_001.fastq")).isEqualTo("COLO829v003R_AHHKYHDSXX_S13_L001_001");
+    }
+}

--- a/cluster/src/test/java/com/hartwig/pipeline/alignment/vm/RecordGroupIdTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/alignment/vm/RecordGroupIdTest.java
@@ -8,16 +8,40 @@ public class RecordGroupIdTest {
 
     @Test
     public void removesR1FromFastqName() {
-        assertThat(RecordGroupId.from("COLO829v003R_AHHKYHDSXX_S13_L001_R1_001.fastq.gz")).isEqualTo("COLO829v003R_AHHKYHDSXX_S13_L001_001");
+        assertThat(RecordGroupId.from(false, "COLO829v003R_AHHKYHDSXX_S13_L001_R1_001.fastq.gz")).isEqualTo(
+                "COLO829v003R_AHHKYHDSXX_S13_L001_001");
     }
 
     @Test
     public void removesR2FromFastqName() {
-        assertThat(RecordGroupId.from("COLO829v003R_AHHKYHDSXX_S13_L001_R2_001.fastq.gz")).isEqualTo("COLO829v003R_AHHKYHDSXX_S13_L001_001");
+        assertThat(RecordGroupId.from(false, "COLO829v003R_AHHKYHDSXX_S13_L001_R2_001.fastq.gz")).isEqualTo(
+                "COLO829v003R_AHHKYHDSXX_S13_L001_001");
     }
 
     @Test
     public void removesFastqExtension() {
-        assertThat(RecordGroupId.from("COLO829v003R_AHHKYHDSXX_S13_L001_R2_001.fastq")).isEqualTo("COLO829v003R_AHHKYHDSXX_S13_L001_001");
+        assertThat(RecordGroupId.from(false, "COLO829v003R_AHHKYHDSXX_S13_L001_R2_001.fastq")).isEqualTo(
+                "COLO829v003R_AHHKYHDSXX_S13_L001_001");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void strictNamingMissingFields() {
+        RecordGroupId.from(true, "COLO829v003R_S13_L001_R2_001.fastq");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void strictNamingLaneNotCorrectFormat() {
+        RecordGroupId.from(true, "COLO829v003R_AHHKYHDSXX_S13_L0A1_R2_001.fastq");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void strictNamingPositionInPairIncorrectFormat() {
+        RecordGroupId.from(true, "COLO829v003R_AHHKYHDSXX_S13_L0A1_P2_001.fastq");
+    }
+
+    @Test
+    public void strictNamingPasses() {
+        assertThat(RecordGroupId.from(true, "COLO829v003R_AHHKYHDSXX_S13_L001_R1_001.fastq.gz")).isEqualTo(
+                "COLO829v003R_AHHKYHDSXX_S13_L001_001");
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/alignment/vm/VmAlignerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/alignment/vm/VmAlignerTest.java
@@ -143,7 +143,6 @@ public class VmAlignerTest {
 
     private static ImmutableLane lane(int index) {
         return Lanes.emptyBuilder()
-                .name(String.format("%s_L00%s", METADATA.sampleName(), index))
                 .flowCellId("flowcell")
                 .laneNumber(String.format("L00%s", index))
                 .build();

--- a/cluster/src/test/java/com/hartwig/pipeline/storage/CloudSampleUploadTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/storage/CloudSampleUploadTest.java
@@ -26,9 +26,6 @@ public class CloudSampleUploadTest {
             .firstOfPairPath(FASTQ_DIR + "reads1.fastq.gz")
             .secondOfPairPath(FASTQ_DIR + "mates1.fastq.gz")
             .laneNumber("")
-            .index("")
-            .suffix("")
-            .name("")
             .flowCellId("")
             .build();
     private static final Sample SAMPLE_ONE_LANE = Sample.builder(SAMPLE_NAME).addLanes(LANE_1).build();


### PR DESCRIPTION
Simplifies the record group id parsing by using the fastq file path as input, rather than
the lane which is parsed from the API or json. This also results in the removal of a couple
of those ill defined field in the lane, suffix, index and name.