### PR TITLE
DEV-1386 Link to datatype/sample once per file

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/PipelineState.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/PipelineState.java
@@ -1,10 +1,10 @@
 package com.hartwig.pipeline;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.Lists;
 import com.hartwig.pipeline.execution.PipelineStatus;
 
 import org.slf4j.Logger;
@@ -13,7 +13,15 @@ import org.slf4j.LoggerFactory;
 public class PipelineState {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PipelineState.class);
-    private final List<StageOutput> stageOutputs = Lists.newArrayList();
+    private final List<StageOutput> stageOutputs;
+
+    public PipelineState() {
+        this.stageOutputs = new ArrayList<>();
+    }
+
+    public PipelineState(final List<StageOutput> stageOutputs) {
+        this.stageOutputs = stageOutputs;
+    }
 
     public <T extends StageOutput> T add(final T stageOutput) {
         stageOutputs.add(stageOutput);
@@ -27,6 +35,10 @@ public class PipelineState {
             throw new IllegalArgumentException("State from one of the two pipelines was null. Did that pipeline run successfully?");
         }
         return this;
+    }
+
+    PipelineState copy() {
+        return new PipelineState(new ArrayList<>(this.stageOutputs()));
     }
 
     public List<StageOutput> stageOutputs() {

--- a/cluster/src/main/java/com/hartwig/pipeline/PipelineState.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/PipelineState.java
@@ -19,7 +19,7 @@ public class PipelineState {
         this.stageOutputs = new ArrayList<>();
     }
 
-    public PipelineState(final List<StageOutput> stageOutputs) {
+    private PipelineState(final List<StageOutput> stageOutputs) {
         this.stageOutputs = stageOutputs;
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/SingleSamplePipeline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/SingleSamplePipeline.java
@@ -39,10 +39,10 @@ public class SingleSamplePipeline {
     private final Boolean isStandalone;
     private final Arguments arguments;
 
-    SingleSamplePipeline(final SingleSampleEventListener sampleMetadataApi, final StageRunner<SingleSampleRunMetadata> stageRunner,
+    SingleSamplePipeline(final SingleSampleEventListener eventListener, final StageRunner<SingleSampleRunMetadata> stageRunner,
             final VmAligner aligner, final PipelineResults report, final ExecutorService executorService, final Boolean isStandalone,
             final Arguments arguments) {
-        this.eventListener = sampleMetadataApi;
+        this.eventListener = eventListener;
         this.stageRunner = stageRunner;
         this.aligner = aligner;
         this.report = report;

--- a/cluster/src/main/java/com/hartwig/pipeline/SingleSamplePipeline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/SingleSamplePipeline.java
@@ -40,8 +40,8 @@ public class SingleSamplePipeline {
     private final Arguments arguments;
 
     SingleSamplePipeline(final SingleSampleEventListener sampleMetadataApi, final StageRunner<SingleSampleRunMetadata> stageRunner,
-                         final VmAligner aligner, final PipelineResults report, final ExecutorService executorService, final Boolean isStandalone,
-                         final Arguments arguments) {
+            final VmAligner aligner, final PipelineResults report, final ExecutorService executorService, final Boolean isStandalone,
+            final Arguments arguments) {
         this.eventListener = sampleMetadataApi;
         this.stageRunner = stageRunner;
         this.aligner = aligner;
@@ -59,7 +59,7 @@ public class SingleSamplePipeline {
         PipelineState state = new PipelineState();
         final ResourceFiles resourceFiles = buildResourceFiles(arguments.refGenomeVersion());
         AlignmentOutput alignmentOutput = report.add(state.add(aligner.run(metadata)));
-        eventListener.alignmentComplete(state);
+        eventListener.alignmentComplete(state.copy());
         if (state.shouldProceed()) {
             report.clearOldState(arguments, metadata);
             Future<BamMetricsOutput> bamMetricsFuture =

--- a/cluster/src/main/java/com/hartwig/pipeline/transfer/SbpFileApiUpdate.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/transfer/SbpFileApiUpdate.java
@@ -3,9 +3,9 @@ package com.hartwig.pipeline.transfer;
 import static java.lang.String.format;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Base64;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import com.google.cloud.storage.Blob;
@@ -30,7 +30,7 @@ public class SbpFileApiUpdate implements Consumer<Blob> {
     private final SbpRun sbpRun;
     private final Bucket sourceBucket;
     private final SbpRestApi sbpApi;
-    private final List<ApiFileOperation> fileOperations = new ArrayList<>();
+    private final Set<ApiFileOperation> fileOperations;
 
     public SbpFileApiUpdate(final ContentTypeCorrection contentTypeCorrection, final SbpRun sbpRun, final Bucket sourceBucket,
             final SbpRestApi sbpApi, final PipelineState pipelineState) {
@@ -38,6 +38,7 @@ public class SbpFileApiUpdate implements Consumer<Blob> {
         this.sbpRun = sbpRun;
         this.sourceBucket = sourceBucket;
         this.sbpApi = sbpApi;
+        fileOperations = new HashSet<>();
         pipelineState.stageOutputs().forEach(stageOutput -> fileOperations.addAll(stageOutput.furtherOperations()));
     }
 
@@ -59,7 +60,7 @@ public class SbpFileApiUpdate implements Consumer<Blob> {
 
                 for (ApiFileOperation fileOperation : fileOperations) {
                     if (fileOperation.path().equals(blob.getName().substring(blob.getName().indexOf("/") + 1))) {
-                        LOGGER.info("Applying: {}", fileOperation);
+                        LOGGER.info("Applying [{}] for [{}]", fileOperation, blob.getName());
                         fileOperation.apply(sbpApi, fileResponse);
                     }
                 }

--- a/cluster/src/main/java/com/hartwig/pipeline/transfer/SbpFileApiUpdate.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/transfer/SbpFileApiUpdate.java
@@ -5,14 +5,12 @@ import static java.lang.String.format;
 import java.io.File;
 import java.util.Base64;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Bucket;
 import com.hartwig.pipeline.PipelineState;
-import com.hartwig.pipeline.StageOutput;
 import com.hartwig.pipeline.metadata.ApiFileOperation;
 import com.hartwig.pipeline.report.PipelineResults;
 import com.hartwig.pipeline.sbpapi.AddFileApiResponse;
@@ -32,7 +30,7 @@ public class SbpFileApiUpdate implements Consumer<Blob> {
     private final SbpRun sbpRun;
     private final Bucket sourceBucket;
     private final SbpRestApi sbpApi;
-    private final Set<ApiFileOperation> fileOperations;
+    private final Set<ApiFileOperation> fileOperations = new HashSet<>();
 
     public SbpFileApiUpdate(final ContentTypeCorrection contentTypeCorrection, final SbpRun sbpRun, final Bucket sourceBucket,
             final SbpRestApi sbpApi, final PipelineState pipelineState) {
@@ -40,8 +38,7 @@ public class SbpFileApiUpdate implements Consumer<Blob> {
         this.sbpRun = sbpRun;
         this.sourceBucket = sourceBucket;
         this.sbpApi = sbpApi;
-        fileOperations = new HashSet<>();
-        storeOperations(pipelineState.stageOutputs());
+        pipelineState.stageOutputs().forEach(stageOutput -> fileOperations.addAll(stageOutput.furtherOperations()));
     }
 
     @Override
@@ -67,18 +64,6 @@ public class SbpFileApiUpdate implements Consumer<Blob> {
                     }
                 }
             }
-        }
-    }
-
-    private void storeOperations(List<StageOutput> stageOutputs) {
-        int count = 0;
-        for (StageOutput stageOutput : stageOutputs) {
-            fileOperations.addAll(stageOutput.furtherOperations());
-            count = count + stageOutput.furtherOperations().size();
-        }
-        LOGGER.info("Stored {} operations for later", fileOperations.size());
-        if (fileOperations.size() < count) {
-            LOGGER.info("Ignored {} duplicate operations", count - fileOperations.size());
         }
     }
 

--- a/cluster/src/test/java/com/hartwig/pipeline/SingleSamplePipelineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/SingleSamplePipelineTest.java
@@ -42,6 +42,7 @@ import com.hartwig.pipeline.stages.StageRunner;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 public class SingleSamplePipelineTest {
 
@@ -248,7 +249,13 @@ public class SingleSamplePipelineTest {
     public void notifiesMetadataApiWhenAlignmentComplete() throws Exception {
         when(aligner.run(referenceRunMetadata())).thenReturn(referenceAlignmentOutput());
         PipelineState result = victim.run(referenceRunMetadata());
-        verify(eventListener, times(1)).alignmentComplete(result);
+        ArgumentCaptor<PipelineState> stateCaptor = ArgumentCaptor.forClass(PipelineState.class);
+        verify(eventListener, times(1)).alignmentComplete(stateCaptor.capture());
+        PipelineState alignmentResult = stateCaptor.getValue();
+        assertThat(alignmentResult).isNotSameAs(result);
+        assertThat(alignmentResult.status()).isEqualTo(PipelineStatus.SUCCESS);
+        assertThat(alignmentResult.stageOutputs().size()).isEqualTo(1);
+        assertThat(alignmentResult.stageOutputs().get(0).name()).isEqualTo(referenceAlignmentOutput().name());
     }
 
     @Test
@@ -260,7 +267,7 @@ public class SingleSamplePipelineTest {
                 .thenReturn(cramOutput())
                 .thenReturn(germlineCallerOutput());
         PipelineState result = victim.run(referenceRunMetadata());
-        verify(eventListener, times(1)).alignmentComplete(result);
+        verify(eventListener, times(1)).complete(result);
     }
 
     @Test


### PR DESCRIPTION
Not precisely sure yet why sometimes multiple copies of the
same operation are requested but it is not incorrect to store
and apply the operations in a set rather than a list. 

This will resolve the problem we are currently seeing 
anyway.