### PR TITLE
DEV-1372 Update to official HTSJDK version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <annotations.version>16.0.1</annotations.version>
         <aws-java-sdk.version>1.11.327</aws-java-sdk.version>
         <commons-lang3.version>3.9</commons-lang3.version>
-        <htsjdk.version>2.20.3</htsjdk.version>
+        <htsjdk.version>2.22.0</htsjdk.version>
         <org-reflections.version>0.9.11</org-reflections.version>
     </properties>
 
@@ -194,11 +194,6 @@
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.samtools</groupId>
-                <artifactId>htsjdk</artifactId>
-                <version>${htsjdk.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.hartwig</groupId>
                 <artifactId>cluster</artifactId>
                 <version>local-SNAPSHOT</version>
@@ -222,6 +217,12 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.github.samtools</groupId>
+                <artifactId>htsjdk</artifactId>
+                <version>${htsjdk.version}</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
This is an official version with CRAM support. Up until now we've been
using a local advance version as an official version had been delayed.

Also move this dependency to the test scope, we no longer need it in the
main app.