### PR TITLE
DEV-1530 Make tumor optional in JSON

### DIFF
--- a/cluster/src/main/java/com/hartwig/patient/ReferenceTumorPair.java
+++ b/cluster/src/main/java/com/hartwig/patient/ReferenceTumorPair.java
@@ -1,5 +1,7 @@
 package com.hartwig.patient;
 
+import java.util.Optional;
+
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import org.immutables.value.Value;
@@ -10,5 +12,5 @@ public interface ReferenceTumorPair {
 
     Sample reference();
 
-    Sample tumor();
+    Optional<Sample> tumor();
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/sample/JsonSampleSource.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/sample/JsonSampleSource.java
@@ -2,6 +2,7 @@ package com.hartwig.pipeline.alignment.sample;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Optional;
 
 import com.hartwig.patient.ReferenceTumorPair;
 import com.hartwig.patient.Sample;
@@ -23,13 +24,13 @@ public class JsonSampleSource implements SampleSource {
 
     @Override
     public Sample sample(final SingleSampleRunMetadata metadata) {
-        return sample(metadata.type());
+        return sample(metadata.type()).orElseThrow();
     }
 
-    public Sample sample(final SampleType sampleType) {
+    public Optional<Sample> sample(final SampleType sampleType) {
         try {
             if (sampleType.equals(SingleSampleRunMetadata.SampleType.REFERENCE)) {
-                return pair.reference();
+                return Optional.of(pair.reference());
             } else {
                 return pair.tumor();
             }

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/LocalSomaticMetadata.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/LocalSomaticMetadata.java
@@ -1,5 +1,7 @@
 package com.hartwig.pipeline.metadata;
 
+import java.util.Optional;
+
 import com.hartwig.patient.Sample;
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.PipelineState;
@@ -20,21 +22,21 @@ public class LocalSomaticMetadata implements SomaticMetadataApi {
     @Override
     public SomaticRunMetadata get() {
         String setId = RunTag.apply(arguments, arguments.setId());
-        Sample reference = jsonSampleSource.sample(SampleType.REFERENCE);
-        Sample tumor = jsonSampleSource.sample(SampleType.TUMOR);
+        Sample reference = jsonSampleSource.sample(SampleType.REFERENCE).orElseThrow();
+        Optional<Sample> tumor = jsonSampleSource.sample(SampleType.TUMOR);
 
         return SomaticRunMetadata.builder()
                 .set(setId)
                 .id(setId)
                 .bucket(arguments.outputBucket())
-                .maybeTumor(SingleSampleRunMetadata.builder()
+                .maybeTumor(tumor.map(t -> SingleSampleRunMetadata.builder()
                         .id(setId)
                         .bucket(arguments.outputBucket())
                         .set(setId)
                         .type(SingleSampleRunMetadata.SampleType.TUMOR)
-                        .barcode(tumor.name())
-                        .sampleName(tumor.name())
-                        .build())
+                        .barcode(t.name())
+                        .sampleName(t.name())
+                        .build()))
                 .reference(SingleSampleRunMetadata.builder()
                         .id(setId)
                         .bucket(arguments.outputBucket())

--- a/sample_json/cancerPanelSingleSample.json
+++ b/sample_json/cancerPanelSingleSample.json
@@ -1,0 +1,33 @@
+{
+  "reference": {
+    "type": "REFERENCE",
+    "name": "CPCT12345678R",
+    "lanes": [
+      {
+        "laneNumber": "1",
+        "firstOfPairPath": "hmf-verification-data-fastq/cancerPanel/CPCT12345678R_HJJLGCCXX_S1_L001_R1_001.fastq.gz",
+        "secondOfPairPath": "hmf-verification-data-fastq/cancerPanel/CPCT12345678R_HJJLGCCXX_S1_L001_R2_001.fastq.gz"
+      },
+      {
+        "laneNumber": "2",
+        "firstOfPairPath": "hmf-verification-data-fastq/cancerPanel/CPCT12345678R_AHHKYHDSXX_S13_L001_R1_001.fastq.gz",
+        "secondOfPairPath": "hmf-verification-data-fastq/cancerPanel/CPCT12345678R_AHHKYHDSXX_S13_L001_R1_001.fastq.gz"
+      },
+      {
+        "laneNumber": "3",
+        "firstOfPairPath": "hmf-verification-data-fastq/cancerPanel/CPCT12345678R_AHHKYHDSXX_S13_L002_R1_001.fastq.gz",
+        "secondOfPairPath": "hmf-verification-data-fastq/cancerPanel/CPCT12345678R_AHHKYHDSXX_S13_L002_R1_001.fastq.gz"
+      },
+      {
+        "laneNumber": "4",
+        "firstOfPairPath": "hmf-verification-data-fastq/cancerPanel/CPCT12345678R_AHHKYHDSXX_S13_L003_R1_001.fastq.gz",
+        "secondOfPairPath": "hmf-verification-data-fastq/cancerPanel/CPCT12345678R_AHHKYHDSXX_S13_L003_R1_001.fastq.gz"
+      },
+      {
+        "laneNumber": "5",
+        "firstOfPairPath": "hmf-verification-data-fastq/cancerPanel/CPCT12345678R_AHHKYHDSXX_S13_L004_R1_001.fastq.gz",
+        "secondOfPairPath": "hmf-verification-data-fastq/cancerPanel/CPCT12345678R_AHHKYHDSXX_S13_L004_R1_001.fastq.gz"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
By making it optional, we can carry that forward to the metadata construction and leverage the
existing logic to kick into single sample mode.