### PR TITLE
DEV-1555 Print failure logs at the end of pipeline

### DIFF
--- a/batch/src/main/java/com/hartwig/batch/BatchDispatcher.java
+++ b/batch/src/main/java/com/hartwig/batch/BatchDispatcher.java
@@ -86,7 +86,8 @@ public class BatchDispatcher {
             final String label = format(paddingFormat, i + 1);
             RuntimeFiles executionFlags = RuntimeFiles.of(label);
             RuntimeBucket outputBucket = RuntimeBucket.from(storage, arguments.outputBucket(), label, arguments);
-            BashStartupScript startupScript = BashStartupScript.of(outputBucket.name(), executionFlags);
+            BashStartupScript startupScript =
+                    BashStartupScript.of(outputBucket.name(), executionFlags);
             Future<PipelineStatus> future = executorService.submit(() -> computeEngine.submit(outputBucket,
                     instanceFactory.get().execute(operationInputs, outputBucket, startupScript, executionFlags),
                     label));

--- a/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
@@ -21,6 +21,7 @@ import com.hartwig.pipeline.metadata.SomaticMetadataApiProvider;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.metrics.BamMetricsOutput;
 import com.hartwig.pipeline.pubsub.PublisherProvider;
+import com.hartwig.pipeline.report.FailureSummary;
 import com.hartwig.pipeline.report.FullSomaticResults;
 import com.hartwig.pipeline.report.PipelineResultsProvider;
 import com.hartwig.pipeline.reruns.ApiPersistedDataset;
@@ -111,6 +112,7 @@ public class PipelineMain {
                     new FullSomaticResults(storage, arguments),
                     CleanupProvider.from(arguments, storage).get()).run();
             completedEvent(eventSubjects, publisher, state.status().toString(), arguments.publishToTurquoise());
+            FailureSummary.of(storage, state);
             return state;
 
         } catch (Exception e) {

--- a/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
@@ -21,9 +21,9 @@ import com.hartwig.pipeline.metadata.SomaticMetadataApiProvider;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.metrics.BamMetricsOutput;
 import com.hartwig.pipeline.pubsub.PublisherProvider;
-import com.hartwig.pipeline.report.FailureSummary;
 import com.hartwig.pipeline.report.FullSomaticResults;
 import com.hartwig.pipeline.report.PipelineResultsProvider;
+import com.hartwig.pipeline.report.VmExecutionLogSummary;
 import com.hartwig.pipeline.reruns.ApiPersistedDataset;
 import com.hartwig.pipeline.reruns.NoopPersistedDataset;
 import com.hartwig.pipeline.reruns.PersistedDataset;
@@ -112,7 +112,7 @@ public class PipelineMain {
                     new FullSomaticResults(storage, arguments),
                     CleanupProvider.from(arguments, storage).get()).run();
             completedEvent(eventSubjects, publisher, state.status().toString(), arguments.publishToTurquoise());
-            FailureSummary.of(storage, state);
+            VmExecutionLogSummary.ofFailedStages(storage, state);
             return state;
 
         } catch (Exception e) {

--- a/cluster/src/main/java/com/hartwig/pipeline/StageOutput.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/StageOutput.java
@@ -2,6 +2,7 @@ package com.hartwig.pipeline;
 
 import java.util.List;
 
+import com.google.cloud.storage.Blob;
 import com.hartwig.pipeline.execution.PipelineStatus;
 import com.hartwig.pipeline.metadata.ApiFileOperation;
 import com.hartwig.pipeline.report.ReportComponent;
@@ -15,4 +16,6 @@ public interface StageOutput {
     List<ReportComponent> reportComponents();
 
     List<ApiFileOperation> furtherOperations();
+
+    List<Blob> logs();
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/StageOutput.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/StageOutput.java
@@ -2,10 +2,10 @@ package com.hartwig.pipeline;
 
 import java.util.List;
 
-import com.google.cloud.storage.Blob;
 import com.hartwig.pipeline.execution.PipelineStatus;
 import com.hartwig.pipeline.metadata.ApiFileOperation;
 import com.hartwig.pipeline.report.ReportComponent;
+import com.hartwig.pipeline.storage.GoogleStorageLocation;
 
 public interface StageOutput {
 
@@ -17,5 +17,5 @@ public interface StageOutput {
 
     List<ApiFileOperation> furtherOperations();
 
-    List<Blob> logs();
+    List<GoogleStorageLocation> failedLogLocations();
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/bwa/BwaAligner.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/bwa/BwaAligner.java
@@ -14,7 +14,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
-import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Storage;
 import com.hartwig.patient.Lane;
 import com.hartwig.patient.Sample;
@@ -94,7 +93,7 @@ public class BwaAligner implements Aligner {
         List<Future<PipelineStatus>> futures = new ArrayList<>();
         List<GoogleStorageLocation> perLaneBams = new ArrayList<>();
         List<ReportComponent> laneLogComponents = new ArrayList<>();
-        List<Blob> logs = new ArrayList<>();
+        List<GoogleStorageLocation> laneFailedLogs = new ArrayList<>();
         for (Lane lane : sample.lanes()) {
 
             RuntimeBucket laneBucket = RuntimeBucket.from(storage, laneNamespace(lane), metadata, arguments);
@@ -123,7 +122,7 @@ public class BwaAligner implements Aligner {
                     laneBucket,
                     VirtualMachineJobDefinition.alignment(laneId(lane).toLowerCase(), bash, resultsDirectory))));
             laneLogComponents.add(new RunLogComponent(laneBucket, laneNamespace(lane), Folder.from(metadata), resultsDirectory));
-            logs.add(laneBucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)));
+            laneFailedLogs.add(GoogleStorageLocation.of(laneBucket.name(), RunLogComponent.LOG_FILE));
         }
 
         AlignmentOutput output;
@@ -155,8 +154,8 @@ public class BwaAligner implements Aligner {
                     .maybeFinalBaiLocation(GoogleStorageLocation.of(rootBucket.name(),
                             resultsDirectory.path(bai(merged.outputFile().fileName()))))
                     .addAllReportComponents(laneLogComponents)
-                    .addAllLogs(logs)
-                    .addLogs(rootBucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
+                    .addAllFailedLogLocations(laneFailedLogs)
+                    .addFailedLogLocations(GoogleStorageLocation.of(rootBucket.name(), RunLogComponent.LOG_FILE))
                     .addReportComponents(new RunLogComponent(rootBucket, Aligner.NAMESPACE, Folder.from(metadata), resultsDirectory));
             if (!arguments.outputCram()) {
                 outputBuilder.addReportComponents(new SingleFileComponent(rootBucket,

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/germline/GermlineCaller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/germline/GermlineCaller.java
@@ -125,6 +125,7 @@ public class GermlineCaller implements Stage<GermlineCallerOutput, SingleSampleR
             final ResultsDirectory resultsDirectory) {
         return GermlineCallerOutput.builder()
                 .status(status)
+                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
                 .maybeGermlineVcfLocation(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(outputFile.fileName())))
                 .maybeGermlineVcfIndexLocation(GoogleStorageLocation.of(bucket.name(),
                         resultsDirectory.path(FileTypes.tabixIndex(outputFile.fileName()))))

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/germline/GermlineCaller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/germline/GermlineCaller.java
@@ -125,7 +125,7 @@ public class GermlineCaller implements Stage<GermlineCallerOutput, SingleSampleR
             final ResultsDirectory resultsDirectory) {
         return GermlineCallerOutput.builder()
                 .status(status)
-                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
+                .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .maybeGermlineVcfLocation(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(outputFile.fileName())))
                 .maybeGermlineVcfIndexLocation(GoogleStorageLocation.of(bucket.name(),
                         resultsDirectory.path(FileTypes.tabixIndex(outputFile.fileName()))))

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/somatic/SageCaller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/somatic/SageCaller.java
@@ -86,6 +86,7 @@ public class SageCaller extends TertiaryStage<SomaticCallerOutput> {
             final ResultsDirectory resultsDirectory) {
         return SomaticCallerOutput.builder(NAMESPACE)
                 .status(jobStatus)
+                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
                 .maybeFinalSomaticVcf(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(filteredOutputFile.fileName())))
                 .addReportComponents(bqrComponent(metadata.tumor(), "png", bucket, resultsDirectory))
                 .addReportComponents(bqrComponent(metadata.tumor(), "tsv", bucket, resultsDirectory))

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/somatic/SageCaller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/somatic/SageCaller.java
@@ -86,7 +86,7 @@ public class SageCaller extends TertiaryStage<SomaticCallerOutput> {
             final ResultsDirectory resultsDirectory) {
         return SomaticCallerOutput.builder(NAMESPACE)
                 .status(jobStatus)
-                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
+                .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .maybeFinalSomaticVcf(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(filteredOutputFile.fileName())))
                 .addReportComponents(bqrComponent(metadata.tumor(), "png", bucket, resultsDirectory))
                 .addReportComponents(bqrComponent(metadata.tumor(), "tsv", bucket, resultsDirectory))

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/structural/StructuralCaller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/structural/StructuralCaller.java
@@ -99,6 +99,7 @@ public class StructuralCaller implements Stage<StructuralCallerOutput, SomaticRu
             final ResultsDirectory resultsDirectory) {
         return StructuralCallerOutput.builder()
                 .status(jobStatus)
+                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
                 .maybeUnfilteredVcf(resultLocation(bucket, resultsDirectory, unfilteredVcf))
                 .maybeUnfilteredVcfIndex(resultLocation(bucket, resultsDirectory, unfilteredVcf + ".tbi"))
                 .addReportComponents(new ZippedVcfAndIndexComponent(bucket,

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/structural/StructuralCaller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/structural/StructuralCaller.java
@@ -99,7 +99,7 @@ public class StructuralCaller implements Stage<StructuralCallerOutput, SomaticRu
             final ResultsDirectory resultsDirectory) {
         return StructuralCallerOutput.builder()
                 .status(jobStatus)
-                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
+                .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .maybeUnfilteredVcf(resultLocation(bucket, resultsDirectory, unfilteredVcf))
                 .maybeUnfilteredVcfIndex(resultLocation(bucket, resultsDirectory, unfilteredVcf + ".tbi"))
                 .addReportComponents(new ZippedVcfAndIndexComponent(bucket,

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/structural/StructuralCallerPostProcess.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/structural/StructuralCallerPostProcess.java
@@ -93,7 +93,7 @@ public class StructuralCallerPostProcess implements Stage<StructuralCallerPostPr
                         FileTypes.tabixIndex(resultsDirectory.path(basename(somaticFilteredVcf)))))
                 .maybeFullVcf(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(basename(somaticVcf))))
                 .maybeFullVcfIndex(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(basename(somaticVcf + ".tbi"))))
-                .addLogs(bucket.get(RunLogComponent.LOG_FILE))
+                .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .addReportComponents(new ZippedVcfAndIndexComponent(bucket,
                         NAMESPACE,
                         Folder.root(),

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/structural/StructuralCallerPostProcess.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/structural/StructuralCallerPostProcess.java
@@ -93,6 +93,7 @@ public class StructuralCallerPostProcess implements Stage<StructuralCallerPostPr
                         FileTypes.tabixIndex(resultsDirectory.path(basename(somaticFilteredVcf)))))
                 .maybeFullVcf(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(basename(somaticVcf))))
                 .maybeFullVcfIndex(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(basename(somaticVcf + ".tbi"))))
+                .addLogs(bucket.get(RunLogComponent.LOG_FILE))
                 .addReportComponents(new ZippedVcfAndIndexComponent(bucket,
                         NAMESPACE,
                         Folder.root(),

--- a/cluster/src/main/java/com/hartwig/pipeline/cram/CramConversion.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/cram/CramConversion.java
@@ -76,6 +76,7 @@ public class CramConversion implements Stage<CramOutput, SingleSampleRunMetadata
 
         return CramOutput.builder()
                 .status(jobStatus)
+                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
                 .addReportComponents(new RunLogComponent(bucket, NAMESPACE, folder, resultsDirectory),
                         new StartupScriptComponent(bucket, NAMESPACE, folder),
                         new SingleFileComponent(bucket, NAMESPACE, folder, cram, cram, resultsDirectory),

--- a/cluster/src/main/java/com/hartwig/pipeline/cram/CramConversion.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/cram/CramConversion.java
@@ -25,6 +25,7 @@ import com.hartwig.pipeline.report.SingleFileComponent;
 import com.hartwig.pipeline.report.StartupScriptComponent;
 import com.hartwig.pipeline.resource.ResourceFiles;
 import com.hartwig.pipeline.stages.Stage;
+import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 
 public class CramConversion implements Stage<CramOutput, SingleSampleRunMetadata> {
@@ -76,7 +77,7 @@ public class CramConversion implements Stage<CramOutput, SingleSampleRunMetadata
 
         return CramOutput.builder()
                 .status(jobStatus)
-                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
+                .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .addReportComponents(new RunLogComponent(bucket, NAMESPACE, folder, resultsDirectory),
                         new StartupScriptComponent(bucket, NAMESPACE, folder),
                         new SingleFileComponent(bucket, NAMESPACE, folder, cram, cram, resultsDirectory),

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/BashStartupScript.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/BashStartupScript.java
@@ -36,7 +36,8 @@ public class BashStartupScript {
     }
 
     String asUnixString() {
-        return asUnixString(new StorageStrategy() {});
+        return asUnixString(new StorageStrategy() {
+        });
     }
 
     String asUnixString(StorageStrategy storageStrategy) {
@@ -44,22 +45,21 @@ public class BashStartupScript {
         String commandSuffix = format(" >>%s 2>&1 || die", localLogFile);
         String jobFailedFlag = "/tmp/" + runtimeFiles.failure();
 
-        List<String> preamble = new ArrayList<>(asList(
-                "#!/bin/bash -x\n",
+        List<String> preamble = new ArrayList<>(asList("#!/bin/bash -x\n",
                 "set -o pipefail\n",
                 "function die() {",
                 "  exit_code=$?",
                 "  echo \"Unknown failure: called command returned $exit_code\"",
-                format("  gsutil -m cp %s gs://%s/results/", localLogFile, runtimeBucketName),
+                format("  gsutil -m cp %s gs://%s", localLogFile, runtimeBucketName),
                 format("  echo $exit_code > %s", jobFailedFlag),
                 format("  gsutil -m cp %s gs://%s", jobFailedFlag, runtimeBucketName),
                 "  exit $exit_code\n" + "}\n"));
         preamble.addAll(storageStrategy.initialise());
         preamble.add("ulimit -n 102400");
         addCompletionCommands();
-        return String.join("\n", preamble) + "\n" +
-                commands.stream().collect(joining(format("%s\n", commandSuffix))) +
-                (commands.isEmpty() ? "" : commandSuffix);
+        return String.join("\n", preamble) + "\n" + commands.stream().collect(joining(format("%s\n", commandSuffix))) + (commands.isEmpty()
+                ? ""
+                : commandSuffix);
     }
 
     BashStartupScript addLine(String lineOne) {

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/BashStartupScript.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/BashStartupScript.java
@@ -50,7 +50,7 @@ public class BashStartupScript {
                 "function die() {",
                 "  exit_code=$?",
                 "  echo \"Unknown failure: called command returned $exit_code\"",
-                format("  gsutil -m cp %s gs://%s", localLogFile, runtimeBucketName),
+                format("  gsutil -m cp %s gs://%s/results/", localLogFile, runtimeBucketName),
                 format("  echo $exit_code > %s", jobFailedFlag),
                 format("  gsutil -m cp %s gs://%s", jobFailedFlag, runtimeBucketName),
                 "  exit $exit_code\n" + "}\n"));

--- a/cluster/src/main/java/com/hartwig/pipeline/flagstat/Flagstat.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/flagstat/Flagstat.java
@@ -58,6 +58,7 @@ public class Flagstat implements Stage<FlagstatOutput, SingleSampleRunMetadata> 
         String outputFile = FlagstatOutput.outputFile(metadata.sampleName());
         return FlagstatOutput.builder()
                 .status(status)
+                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
                 .addReportComponents(new RunLogComponent(bucket, Flagstat.NAMESPACE, Folder.from(metadata), resultsDirectory))
                 .addReportComponents(new StartupScriptComponent(bucket, NAMESPACE, Folder.from(metadata)))
                 .addReportComponents(new SingleFileComponent(bucket,

--- a/cluster/src/main/java/com/hartwig/pipeline/flagstat/Flagstat.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/flagstat/Flagstat.java
@@ -19,6 +19,7 @@ import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.report.SingleFileComponent;
 import com.hartwig.pipeline.report.StartupScriptComponent;
 import com.hartwig.pipeline.stages.Stage;
+import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 
 public class Flagstat implements Stage<FlagstatOutput, SingleSampleRunMetadata> {
@@ -58,7 +59,7 @@ public class Flagstat implements Stage<FlagstatOutput, SingleSampleRunMetadata> 
         String outputFile = FlagstatOutput.outputFile(metadata.sampleName());
         return FlagstatOutput.builder()
                 .status(status)
-                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
+                .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .addReportComponents(new RunLogComponent(bucket, Flagstat.NAMESPACE, Folder.from(metadata), resultsDirectory))
                 .addReportComponents(new StartupScriptComponent(bucket, NAMESPACE, Folder.from(metadata)))
                 .addReportComponents(new SingleFileComponent(bucket,

--- a/cluster/src/main/java/com/hartwig/pipeline/metrics/BamMetrics.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metrics/BamMetrics.java
@@ -74,6 +74,7 @@ public class BamMetrics implements Stage<BamMetricsOutput, SingleSampleRunMetada
         return BamMetricsOutput.builder()
                 .status(jobStatus)
                 .sample(metadata.sampleName())
+                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
                 .maybeMetricsOutputFile(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(outputFile)))
                 .addReportComponents(new RunLogComponent(bucket, namespace(), Folder.from(metadata), resultsDirectory))
                 .addReportComponents(new StartupScriptComponent(bucket, namespace(), Folder.from(metadata)))

--- a/cluster/src/main/java/com/hartwig/pipeline/metrics/BamMetrics.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metrics/BamMetrics.java
@@ -74,7 +74,7 @@ public class BamMetrics implements Stage<BamMetricsOutput, SingleSampleRunMetada
         return BamMetricsOutput.builder()
                 .status(jobStatus)
                 .sample(metadata.sampleName())
-                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
+                .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .maybeMetricsOutputFile(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(outputFile)))
                 .addReportComponents(new RunLogComponent(bucket, namespace(), Folder.from(metadata), resultsDirectory))
                 .addReportComponents(new StartupScriptComponent(bucket, namespace(), Folder.from(metadata)))

--- a/cluster/src/main/java/com/hartwig/pipeline/report/FailureSummary.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/report/FailureSummary.java
@@ -1,0 +1,38 @@
+package com.hartwig.pipeline.report;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Storage;
+import com.hartwig.pipeline.PipelineState;
+import com.hartwig.pipeline.StageOutput;
+import com.hartwig.pipeline.execution.PipelineStatus;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FailureSummary {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FailureSummary.class);
+
+    public static void of(final Storage storage, final PipelineState state) {
+        List<StageOutput> failures = state.stageOutputs()
+                .stream()
+                .filter(stageOutput -> stageOutput.status().equals(PipelineStatus.FAILED))
+                .collect(Collectors.toList());
+        if (!failures.isEmpty()) {
+            LOGGER.error("Failures in pipeline stages. Printing each failures full run.log here");
+            for (StageOutput failure : failures) {
+                for (Blob log : failure.logs()) {
+                    LOGGER.error("========================================== start {} ==========================================",
+                            log.getName());
+                    LOGGER.error(new String(log.getContent()));
+                    LOGGER.error("========================================== end {} ==========================================",
+                            log.getName());
+                    ;
+                }
+            }
+        }
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/report/RunLogComponent.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/report/RunLogComponent.java
@@ -5,7 +5,7 @@ import com.hartwig.pipeline.storage.RuntimeBucket;
 
 public class RunLogComponent extends SingleFileComponent {
 
-    private static final String LOG_FILE = "run.log";
+    public static final String LOG_FILE = "run.log";
 
     public RunLogComponent(final RuntimeBucket runtimeBucket, final String namespace, final Folder folder,
             final ResultsDirectory resultsDirectory) {

--- a/cluster/src/main/java/com/hartwig/pipeline/resource/OverriddenReferenceGenome.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/resource/OverriddenReferenceGenome.java
@@ -53,7 +53,7 @@ public class OverriddenReferenceGenome implements ResourceFiles {
 
     @Override
     public String gridssBreakpointPon() {
-        return decorated.gridssBreakendPon();
+        return decorated.gridssBreakpointPon();
     }
 
     @Override

--- a/cluster/src/main/java/com/hartwig/pipeline/resource/OverriddenReferenceGenome.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/resource/OverriddenReferenceGenome.java
@@ -53,7 +53,7 @@ public class OverriddenReferenceGenome implements ResourceFiles {
 
     @Override
     public String gridssBreakpointPon() {
-        return decorated.gridssBreakpointPon();
+        return decorated.gridssBreakendPon();
     }
 
     @Override

--- a/cluster/src/main/java/com/hartwig/pipeline/snpgenotype/SnpGenotype.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/snpgenotype/SnpGenotype.java
@@ -74,6 +74,7 @@ public class SnpGenotype implements Stage<SnpGenotypeOutput, SingleSampleRunMeta
             final ResultsDirectory resultsDirectory) {
         return SnpGenotypeOutput.builder()
                 .status(status)
+                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
                 .addReportComponents(new RunLogComponent(bucket, NAMESPACE, Folder.from(metadata), resultsDirectory))
                 .addReportComponents(new StartupScriptComponent(bucket, NAMESPACE, Folder.from(metadata)))
                 .addReportComponents(new SingleFileComponent(bucket,

--- a/cluster/src/main/java/com/hartwig/pipeline/snpgenotype/SnpGenotype.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/snpgenotype/SnpGenotype.java
@@ -23,6 +23,7 @@ import com.hartwig.pipeline.report.StartupScriptComponent;
 import com.hartwig.pipeline.resource.RefGenomeVersion;
 import com.hartwig.pipeline.resource.ResourceFiles;
 import com.hartwig.pipeline.stages.Stage;
+import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 
 public class SnpGenotype implements Stage<SnpGenotypeOutput, SingleSampleRunMetadata> {
@@ -74,7 +75,7 @@ public class SnpGenotype implements Stage<SnpGenotypeOutput, SingleSampleRunMeta
             final ResultsDirectory resultsDirectory) {
         return SnpGenotypeOutput.builder()
                 .status(status)
-                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
+                .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .addReportComponents(new RunLogComponent(bucket, NAMESPACE, Folder.from(metadata), resultsDirectory))
                 .addReportComponents(new StartupScriptComponent(bucket, NAMESPACE, Folder.from(metadata)))
                 .addReportComponents(new SingleFileComponent(bucket,

--- a/cluster/src/main/java/com/hartwig/pipeline/storage/GoogleStorageLocation.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/storage/GoogleStorageLocation.java
@@ -1,5 +1,7 @@
 package com.hartwig.pipeline.storage;
 
+import com.google.cloud.storage.BlobId;
+
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -17,9 +19,11 @@ public interface GoogleStorageLocation {
         return false;
     }
 
-    default GoogleStorageLocation parent() {
-        String[] split = path().split("/");
-        return GoogleStorageLocation.of(bucket(), split[split.length - 1], true);
+    default BlobId asBlobId() {
+        String[] splitBucket = bucket().split("/");
+        String bucketNoNamespace = splitBucket[0];
+        String namespace = splitBucket.length == 2 ? splitBucket[1] : "";
+        return BlobId.of(bucketNoNamespace, namespace + "/" + path());
     }
 
     static GoogleStorageLocation of(String bucket, String path) {

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/amber/Amber.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/amber/Amber.java
@@ -61,7 +61,7 @@ public class Amber extends TertiaryStage<AmberOutput> {
             final ResultsDirectory resultsDirectory) {
         return AmberOutput.builder()
                 .status(jobStatus)
-                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
+                .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .maybeOutputDirectory(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(), true))
                 .addReportComponents(new EntireOutputComponent(bucket, Folder.root(), NAMESPACE, resultsDirectory))
                 .addFurtherOperations(new AddDatatypeToFile(DataType.B_ALLELE_FREQUENCY,

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/amber/Amber.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/amber/Amber.java
@@ -15,6 +15,7 @@ import com.hartwig.pipeline.metadata.AddDatatypeToFile;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.EntireOutputComponent;
 import com.hartwig.pipeline.report.Folder;
+import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.reruns.PersistedLocations;
 import com.hartwig.pipeline.resource.ResourceFiles;
@@ -60,6 +61,7 @@ public class Amber extends TertiaryStage<AmberOutput> {
             final ResultsDirectory resultsDirectory) {
         return AmberOutput.builder()
                 .status(jobStatus)
+                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
                 .maybeOutputDirectory(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(), true))
                 .addReportComponents(new EntireOutputComponent(bucket, Folder.root(), NAMESPACE, resultsDirectory))
                 .addFurtherOperations(new AddDatatypeToFile(DataType.B_ALLELE_FREQUENCY,

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/bachelor/Bachelor.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/bachelor/Bachelor.java
@@ -20,6 +20,7 @@ import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.resource.ResourceFiles;
 import com.hartwig.pipeline.stages.Stage;
+import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 import com.hartwig.pipeline.tertiary.purple.PurpleOutput;
 
@@ -75,7 +76,7 @@ public class Bachelor implements Stage<BachelorOutput, SomaticRunMetadata> {
             final ResultsDirectory resultsDirectory) {
         return BachelorOutput.builder()
                 .status(jobStatus)
-                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
+                .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .addReportComponents(new EntireOutputComponent(bucket, Folder.root(), NAMESPACE, resultsDirectory))
                 .build();
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/bachelor/Bachelor.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/bachelor/Bachelor.java
@@ -17,6 +17,7 @@ import com.hartwig.pipeline.execution.vm.VmDirectories;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.EntireOutputComponent;
 import com.hartwig.pipeline.report.Folder;
+import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.resource.ResourceFiles;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.storage.RuntimeBucket;
@@ -74,6 +75,7 @@ public class Bachelor implements Stage<BachelorOutput, SomaticRunMetadata> {
             final ResultsDirectory resultsDirectory) {
         return BachelorOutput.builder()
                 .status(jobStatus)
+                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
                 .addReportComponents(new EntireOutputComponent(bucket, Folder.root(), NAMESPACE, resultsDirectory))
                 .build();
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/chord/Chord.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/chord/Chord.java
@@ -14,6 +14,7 @@ import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.EntireOutputComponent;
 import com.hartwig.pipeline.report.Folder;
+import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.resource.RefGenomeVersion;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.storage.RuntimeBucket;
@@ -60,6 +61,7 @@ public class Chord implements Stage<ChordOutput, SomaticRunMetadata> {
             final ResultsDirectory resultsDirectory) {
         return ChordOutput.builder()
                 .status(jobStatus)
+                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
                 .addReportComponents(new EntireOutputComponent(bucket, Folder.root(), Chord.NAMESPACE, resultsDirectory))
                 .build();
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/chord/Chord.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/chord/Chord.java
@@ -17,6 +17,7 @@ import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.resource.RefGenomeVersion;
 import com.hartwig.pipeline.stages.Stage;
+import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 import com.hartwig.pipeline.tertiary.purple.PurpleOutput;
 
@@ -61,7 +62,7 @@ public class Chord implements Stage<ChordOutput, SomaticRunMetadata> {
             final ResultsDirectory resultsDirectory) {
         return ChordOutput.builder()
                 .status(jobStatus)
-                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
+                .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .addReportComponents(new EntireOutputComponent(bucket, Folder.root(), Chord.NAMESPACE, resultsDirectory))
                 .build();
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/cobalt/Cobalt.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/cobalt/Cobalt.java
@@ -60,7 +60,7 @@ public class Cobalt extends TertiaryStage<CobaltOutput> {
         return CobaltOutput.builder()
                 .status(jobStatus)
                 .maybeOutputDirectory(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(), true))
-                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
+                .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .addReportComponents(new EntireOutputComponent(bucket, Folder.root(), NAMESPACE, resultsDirectory))
                 .addFurtherOperations(new AddDatatypeToFile(DataType.TUMOR_READ_DEPTH_RATIO,
                         Folder.root(),

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/cobalt/Cobalt.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/cobalt/Cobalt.java
@@ -14,6 +14,7 @@ import com.hartwig.pipeline.metadata.AddDatatypeToFile;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.EntireOutputComponent;
 import com.hartwig.pipeline.report.Folder;
+import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.reruns.PersistedLocations;
 import com.hartwig.pipeline.resource.ResourceFiles;
@@ -59,6 +60,7 @@ public class Cobalt extends TertiaryStage<CobaltOutput> {
         return CobaltOutput.builder()
                 .status(jobStatus)
                 .maybeOutputDirectory(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(), true))
+                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
                 .addReportComponents(new EntireOutputComponent(bucket, Folder.root(), NAMESPACE, resultsDirectory))
                 .addFurtherOperations(new AddDatatypeToFile(DataType.TUMOR_READ_DEPTH_RATIO,
                         Folder.root(),

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/healthcheck/HealthChecker.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/healthcheck/HealthChecker.java
@@ -85,7 +85,7 @@ public class HealthChecker implements Stage<HealthCheckOutput, SomaticRunMetadat
 
         return HealthCheckOutput.builder()
                 .status(checkHealthCheckerOutput(metadata.tumor().sampleName(), bucket, jobStatus, resultsDirectory))
-                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
+                .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .maybeOutputDirectory(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path()))
                 .addReportComponents(new EntireOutputComponent(bucket, Folder.root(), NAMESPACE, resultsDirectory))
                 .build();

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/healthcheck/HealthChecker.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/healthcheck/HealthChecker.java
@@ -17,6 +17,7 @@ import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.metrics.BamMetricsOutput;
 import com.hartwig.pipeline.report.EntireOutputComponent;
 import com.hartwig.pipeline.report.Folder;
+import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
@@ -84,6 +85,7 @@ public class HealthChecker implements Stage<HealthCheckOutput, SomaticRunMetadat
 
         return HealthCheckOutput.builder()
                 .status(checkHealthCheckerOutput(metadata.tumor().sampleName(), bucket, jobStatus, resultsDirectory))
+                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
                 .maybeOutputDirectory(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path()))
                 .addReportComponents(new EntireOutputComponent(bucket, Folder.root(), NAMESPACE, resultsDirectory))
                 .build();

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/Linx.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/Linx.java
@@ -17,6 +17,7 @@ import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.resource.ResourceFiles;
 import com.hartwig.pipeline.stages.Stage;
+import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 import com.hartwig.pipeline.tertiary.purple.PurpleOutput;
 
@@ -72,7 +73,7 @@ public class Linx implements Stage<LinxOutput, SomaticRunMetadata> {
             final ResultsDirectory resultsDirectory) {
         return LinxOutput.builder()
                 .status(jobStatus)
-                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
+                .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .addReportComponents(new EntireOutputComponent(bucket, Folder.root(), NAMESPACE, resultsDirectory))
                 .build();
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/Linx.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/Linx.java
@@ -14,6 +14,7 @@ import com.hartwig.pipeline.execution.vm.VmDirectories;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.EntireOutputComponent;
 import com.hartwig.pipeline.report.Folder;
+import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.resource.ResourceFiles;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.storage.RuntimeBucket;
@@ -71,6 +72,7 @@ public class Linx implements Stage<LinxOutput, SomaticRunMetadata> {
             final ResultsDirectory resultsDirectory) {
         return LinxOutput.builder()
                 .status(jobStatus)
+                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
                 .addReportComponents(new EntireOutputComponent(bucket, Folder.root(), NAMESPACE, resultsDirectory))
                 .build();
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/purple/Purple.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/purple/Purple.java
@@ -19,6 +19,7 @@ import com.hartwig.pipeline.metadata.AddDatatypeToFile;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.EntireOutputComponent;
 import com.hartwig.pipeline.report.Folder;
+import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.reruns.PersistedLocations;
 import com.hartwig.pipeline.resource.ResourceFiles;
@@ -106,6 +107,7 @@ public class Purple implements Stage<PurpleOutput, SomaticRunMetadata> {
             final ResultsDirectory resultsDirectory) {
         return PurpleOutput.builder()
                 .status(jobStatus)
+                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
                 .maybeOutputDirectory(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(), true))
                 .maybeSomaticVcf(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(somaticVcf(metadata))))
                 .maybeStructuralVcf(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(svVcf(metadata))))

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/purple/Purple.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/purple/Purple.java
@@ -107,7 +107,7 @@ public class Purple implements Stage<PurpleOutput, SomaticRunMetadata> {
             final ResultsDirectory resultsDirectory) {
         return PurpleOutput.builder()
                 .status(jobStatus)
-                .addLogs(bucket.get(resultsDirectory.path(RunLogComponent.LOG_FILE)))
+                .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .maybeOutputDirectory(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(), true))
                 .maybeSomaticVcf(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(somaticVcf(metadata))))
                 .maybeStructuralVcf(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(svVcf(metadata))))

--- a/cluster/src/test/java/com/hartwig/pipeline/PipelineStateTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/PipelineStateTest.java
@@ -5,10 +5,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Collections;
 import java.util.List;
 
-import com.google.cloud.storage.Blob;
 import com.hartwig.pipeline.execution.PipelineStatus;
 import com.hartwig.pipeline.metadata.ApiFileOperation;
 import com.hartwig.pipeline.report.ReportComponent;
+import com.hartwig.pipeline.storage.GoogleStorageLocation;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
@@ -68,7 +68,7 @@ public class PipelineStateTest {
             }
 
             @Override
-            public List<Blob> logs() {
+            public List<GoogleStorageLocation> failedLogLocations() {
                 return Collections.emptyList();
             }
         };

--- a/cluster/src/test/java/com/hartwig/pipeline/PipelineStateTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/PipelineStateTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Collections;
 import java.util.List;
 
+import com.google.cloud.storage.Blob;
 import com.hartwig.pipeline.execution.PipelineStatus;
 import com.hartwig.pipeline.metadata.ApiFileOperation;
 import com.hartwig.pipeline.report.ReportComponent;
@@ -63,6 +64,11 @@ public class PipelineStateTest {
 
             @Override
             public List<ApiFileOperation> furtherOperations() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public List<Blob> logs() {
                 return Collections.emptyList();
             }
         };

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/germline/GermlineCallerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/germline/GermlineCallerTest.java
@@ -58,7 +58,12 @@ public class GermlineCallerTest extends StageTest<GermlineCallerOutput, SingleSa
 
     @Override
     public void returnsExpectedOutput() {
-        // not supported yet.
+        // not supported currently
+    }
+
+    @Override
+    public void addsLogs() {
+        // not supported currently
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/somatic/SageCallerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/somatic/SageCallerTest.java
@@ -46,12 +46,17 @@ public class SageCallerTest extends TertiaryStageTest<SomaticCallerOutput> {
 
     @Override
     public void returnsExpectedOutput() {
-        // ignored for now.
+        // not supported currently
     }
 
     @Override
     protected void validateOutput(final SomaticCallerOutput output) {
-        // ignored for now.
+        // not supported currently
+    }
+
+    @Override
+    public void addsLogs() {
+        // not supported currently
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/structural/StructuralCallerPostProcessTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/structural/StructuralCallerPostProcessTest.java
@@ -1,7 +1,5 @@
 package com.hartwig.pipeline.calling.structural;
 
-import static java.lang.String.format;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
@@ -46,10 +44,6 @@ public class StructuralCallerPostProcessTest extends StageTest<StructuralCallerP
                         "tumor.gridss.unfiltered.vcf.gz.tbi"));
     }
 
-    private String inputDownload(String bucket, String basename) {
-        return input(format("%s/aligner/results/%s", bucket, basename), basename);
-    }
-
     @Override
     protected String expectedRuntimeBucketName() {
         return TestInputs.SOMATIC_BUCKET;
@@ -76,6 +70,11 @@ public class StructuralCallerPostProcessTest extends StageTest<StructuralCallerP
 
     @Override
     public void returnsExpectedOutput() {
+        // not supported currently
+    }
+
+    @Override
+    public void addsLogs() {
         // not supported currently
     }
 

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/structural/StructuralCallerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/structural/StructuralCallerTest.java
@@ -83,6 +83,11 @@ public class StructuralCallerTest extends StageTest<StructuralCallerOutput, Soma
     }
 
     @Override
+    public void addsLogs() {
+        // not supported currently
+    }
+
+    @Override
     protected void validatePersistedOutput(final StructuralCallerOutput output) {
         assertThat(output.unfilteredVcf()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
                 "set/gridss/" + TUMOR_GRIDSS_UNFILTERED_VCF_GZ));

--- a/cluster/src/test/java/com/hartwig/pipeline/execution/vm/QuotaConstrainedComputeEngineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/execution/vm/QuotaConstrainedComputeEngineTest.java
@@ -52,8 +52,7 @@ public class QuotaConstrainedComputeEngineTest {
         ArgumentCaptor<VirtualMachineJobDefinition> constrained = ArgumentCaptor.forClass(VirtualMachineJobDefinition.class);
         when(decorated.submit(any(), constrained.capture(), any())).thenReturn(PipelineStatus.SUCCESS);
 
-        QuotaConstrainedComputeEngine victim = new QuotaConstrainedComputeEngine(decorated, serviceUsage, REGION, PROJECT,
-                0.6);
+        QuotaConstrainedComputeEngine victim = new QuotaConstrainedComputeEngine(decorated, serviceUsage, REGION, PROJECT, 0.6);
         PipelineStatus result = victim.submit(MockRuntimeBucket.test().getRuntimeBucket(), jobDefinition);
         assertThat(result).isEqualTo(PipelineStatus.SUCCESS);
         MachineType machineType = constrained.getValue().performanceProfile().machineType();

--- a/cluster/src/test/java/com/hartwig/pipeline/report/PipelineResultsTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/report/PipelineResultsTest.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.common.collect.Lists;
@@ -21,6 +20,7 @@ import com.hartwig.pipeline.StageOutput;
 import com.hartwig.pipeline.execution.PipelineStatus;
 import com.hartwig.pipeline.metadata.ApiFileOperation;
 import com.hartwig.pipeline.metrics.BamMetricsOutput;
+import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.testsupport.TestInputs;
 
 import org.jetbrains.annotations.NotNull;
@@ -137,7 +137,7 @@ public class PipelineResultsTest {
             }
 
             @Override
-            public List<Blob> logs() {
+            public List<GoogleStorageLocation> failedLogLocations() {
                 return Collections.emptyList();
             }
         };

--- a/cluster/src/test/java/com/hartwig/pipeline/report/PipelineResultsTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/report/PipelineResultsTest.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.common.collect.Lists;
@@ -132,6 +133,11 @@ public class PipelineResultsTest {
 
             @Override
             public List<ApiFileOperation> furtherOperations() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public List<Blob> logs() {
                 return Collections.emptyList();
             }
         };

--- a/cluster/src/test/java/com/hartwig/pipeline/stages/StageTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/stages/StageTest.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.CopyWriter;
 import com.google.cloud.storage.Storage;
@@ -53,6 +54,7 @@ public abstract class StageTest<S extends StageOutput, M extends RunMetadata> {
         storage = mock(Storage.class);
         runtimeBucket = mock(RuntimeBucket.class);
         when(runtimeBucket.name()).thenReturn(runtimeBucketName);
+        when(runtimeBucket.get(any())).thenReturn(mock(Blob.class));
     }
 
     @Test
@@ -114,6 +116,11 @@ public abstract class StageTest<S extends StageOutput, M extends RunMetadata> {
     public void returnsExpectedFurtherOperations() {
         assertThat(victim.output(input(), PipelineStatus.SUCCESS, runtimeBucket, ResultsDirectory.defaultDirectory())
                 .furtherOperations()).isEqualTo(expectedFurtherOperations());
+    }
+
+    @Test
+    public void addsLogs() {
+        assertThat(victim.output(input(), PipelineStatus.SUCCESS, runtimeBucket, ResultsDirectory.defaultDirectory()).logs()).isNotEmpty();
     }
 
     protected List<ApiFileOperation> expectedFurtherOperations() {

--- a/cluster/src/test/java/com/hartwig/pipeline/stages/StageTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/stages/StageTest.java
@@ -120,7 +120,7 @@ public abstract class StageTest<S extends StageOutput, M extends RunMetadata> {
 
     @Test
     public void addsLogs() {
-        assertThat(victim.output(input(), PipelineStatus.SUCCESS, runtimeBucket, ResultsDirectory.defaultDirectory()).logs()).isNotEmpty();
+        assertThat(victim.output(input(), PipelineStatus.SUCCESS, runtimeBucket, ResultsDirectory.defaultDirectory()).failedLogLocations()).isNotEmpty();
     }
 
     protected List<ApiFileOperation> expectedFurtherOperations() {

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/bachelor/BachelorTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/bachelor/BachelorTest.java
@@ -60,4 +60,9 @@ public class BachelorTest extends TertiaryStageTest<BachelorOutput> {
     protected void validateOutput(final BachelorOutput output) {
         // no additional validation
     }
+
+    @Override
+    public void addsLogs() {
+        // not supported currently
+    }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/linx/LinxTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/linx/LinxTest.java
@@ -51,4 +51,9 @@ public class LinxTest extends TertiaryStageTest<LinxOutput> {
     protected void validateOutput(final LinxOutput output) {
         // no additional validation
     }
+
+    @Override
+    public void addsLogs() {
+        // not supported currently
+    }
 }


### PR DESCRIPTION
Adds a field to the stage outputs to cache a reference to the log blob in case of failure.

Little awkward as we need to explicitly add the log everywhere, but can't find another solution
with the current state of the StageOutputs. The lanes in the BwaAligner also make it a bit
tricky to make a really general solution.