### PR TITLE
DEV-1575 Add command line options for subnet and network tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 branches:
   only:
-    - master
+    - DEV-1575
 sudo: required
 language: java
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 branches:
   only:
-    - DEV-1575
+    - master
 sudo: required
 language: java
 jdk:

--- a/cluster/src/main/java/com/hartwig/pipeline/CommonArguments.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/CommonArguments.java
@@ -1,5 +1,6 @@
 package com.hartwig.pipeline;
 
+import java.util.List;
 import java.util.Optional;
 
 import com.hartwig.pipeline.resource.RefGenomeVersion;
@@ -46,6 +47,10 @@ public interface CommonArguments {
     boolean useLocalSsds();
 
     String network();
+
+    Optional<String> subnet();
+
+    List<String> tags();
 
     Integer pollInterval();
 

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngine.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngine.java
@@ -212,13 +212,19 @@ public class GoogleComputeEngine implements ComputeEngine {
 
     private void addNetworkInterface(Instance instance, String projectName) {
         NetworkInterface network = new NetworkInterface();
-        network.setNetwork(format("%s/global/networks/%s", apiBaseUrl(projectName), arguments.network()));
-        network.setSubnetwork(format("%s/regions/%s/subnetworks/%s",
-                apiBaseUrl(projectName),
-                arguments.region(),
-                arguments.subnet().orElse(arguments.network())));
+        network.setNetwork(isUrl(arguments.network())
+                ? arguments.network()
+                : format("projects/%s/global/networks/%s", projectName, arguments.network()));
+        String subnet = arguments.subnet().orElse(arguments.network());
+        network.setSubnetwork(isUrl(subnet)
+                ? subnet
+                : format("projects/%s/regions/%s/subnetworks/%s", projectName, arguments.region(), subnet));
         network.set("no-address", "true");
         instance.setNetworkInterfaces(singletonList(network));
+    }
+
+    private boolean isUrl(final String argument) {
+        return argument.startsWith("projects");
     }
 
     private Image attachDisks(Compute compute, Instance instance, VirtualMachineJobDefinition jobDefinition, String projectName,

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngine.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngine.java
@@ -25,6 +25,7 @@ import com.google.api.services.compute.model.NetworkInterface;
 import com.google.api.services.compute.model.Operation;
 import com.google.api.services.compute.model.Scheduling;
 import com.google.api.services.compute.model.ServiceAccount;
+import com.google.api.services.compute.model.Tags;
 import com.google.api.services.compute.model.Zone;
 import com.google.api.services.serviceusage.v1beta1.ServiceUsage;
 import com.google.auth.http.HttpCredentialsAdapter;
@@ -116,6 +117,7 @@ public class GoogleComputeEngine implements ComputeEngine {
                 Instance instance = lifecycleManager.newInstance();
                 instance.setName(vmName);
                 instance.setZone(currentZone.getName());
+                instance.setTags(new Tags().setItems(arguments.tags()));
                 if (arguments.usePreemptibleVms()) {
                     instance.setScheduling(new Scheduling().setPreemptible(true));
                 }
@@ -211,7 +213,10 @@ public class GoogleComputeEngine implements ComputeEngine {
     private void addNetworkInterface(Instance instance, String projectName) {
         NetworkInterface network = new NetworkInterface();
         network.setNetwork(format("%s/global/networks/%s", apiBaseUrl(projectName), arguments.network()));
-        network.setSubnetwork(format("%s/regions/%s/subnetworks/%s", apiBaseUrl(projectName), arguments.region(), arguments.network()));
+        network.setSubnetwork(format("%s/regions/%s/subnetworks/%s",
+                apiBaseUrl(projectName),
+                arguments.region(),
+                arguments.subnet().orElse(arguments.network())));
         network.set("no-address", "true");
         instance.setNetworkInterfaces(singletonList(network));
     }

--- a/cluster/src/test/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngineTest.java
@@ -225,6 +225,25 @@ public class GoogleComputeEngineTest {
     }
 
     @Test
+    public void usesNetworkAsSubnetWhenNotSpecified() {
+        returnSuccess();
+        victim = new GoogleComputeEngine(Arguments.testDefaultsBuilder().network("private").build(), compute, z -> {
+        }, lifecycleManager, bucketWatcher);
+        ArgumentCaptor<List<NetworkInterface>> interfaceCaptor = ArgumentCaptor.forClass(List.class);
+        victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
+
+        verify(instance).setNetworkInterfaces(interfaceCaptor.capture());
+        List<NetworkInterface> networkInterfaces = interfaceCaptor.getValue();
+        assertThat(networkInterfaces).hasSize(1);
+        assertThat(networkInterfaces.get(0).getNetwork()).isEqualTo(
+                "https://www.googleapis.com/compute/v1/projects/hmf-pipeline-development/global/networks/private");
+        assertThat(networkInterfaces.get(0).getSubnetwork()).isEqualTo(
+                "https://www.googleapis.com/compute/v1/projects/hmf-pipeline-development/regions/europe-west4/subnetworks/private");
+        assertThat(networkInterfaces.get(0).get("no-address")).isEqualTo("true");
+    }
+
+
+    @Test
     public void addsTagsToComputeEngineInstances() {
         returnSuccess();
         victim = new GoogleComputeEngine(Arguments.testDefaultsBuilder().tags(List.of("tag")).build(), compute, z -> {

--- a/cluster/src/test/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngineTest.java
@@ -23,6 +23,7 @@ import com.google.api.services.compute.model.InstanceList;
 import com.google.api.services.compute.model.NetworkInterface;
 import com.google.api.services.compute.model.Operation;
 import com.google.api.services.compute.model.Scheduling;
+import com.google.api.services.compute.model.Tags;
 import com.google.api.services.compute.model.Zone;
 import com.google.api.services.compute.model.ZoneList;
 import com.google.common.collect.Lists;
@@ -206,9 +207,9 @@ public class GoogleComputeEngineTest {
     }
 
     @Test
-    public void usesPrivateNetworkWhenSpecified() {
+    public void usesNetworkAndSubnetWhenSpecified() {
         returnSuccess();
-        victim = new GoogleComputeEngine(Arguments.testDefaultsBuilder().network("private").build(), compute, z -> {
+        victim = new GoogleComputeEngine(Arguments.testDefaultsBuilder().network("private").subnet("subnet").build(), compute, z -> {
         }, lifecycleManager, bucketWatcher);
         ArgumentCaptor<List<NetworkInterface>> interfaceCaptor = ArgumentCaptor.forClass(List.class);
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
@@ -219,8 +220,20 @@ public class GoogleComputeEngineTest {
         assertThat(networkInterfaces.get(0).getNetwork()).isEqualTo(
                 "https://www.googleapis.com/compute/v1/projects/hmf-pipeline-development/global/networks/private");
         assertThat(networkInterfaces.get(0).getSubnetwork()).isEqualTo(
-                "https://www.googleapis.com/compute/v1/projects/hmf-pipeline-development/regions/europe-west4/subnetworks/private");
+                "https://www.googleapis.com/compute/v1/projects/hmf-pipeline-development/regions/europe-west4/subnetworks/subnet");
         assertThat(networkInterfaces.get(0).get("no-address")).isEqualTo("true");
+    }
+
+    @Test
+    public void addsTagsToComputeEngineInstances() {
+        returnSuccess();
+        victim = new GoogleComputeEngine(Arguments.testDefaultsBuilder().tags(List.of("tag")).build(), compute, z -> {
+        }, lifecycleManager, bucketWatcher);
+        ArgumentCaptor<Tags> tagsArgumentCaptor = ArgumentCaptor.forClass(Tags.class);
+        victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
+
+        verify(instance).setTags(tagsArgumentCaptor.capture());
+        assertThat(tagsArgumentCaptor.getValue().getItems()).containsExactly("tag");
     }
 
     @Test
@@ -300,7 +313,8 @@ public class GoogleComputeEngineTest {
 
     @Test
     public void usesLatestImageFromCurrentFamilyWhenNoImageGiven() throws IOException {
-        victim = new GoogleComputeEngine(ARGUMENTS, compute, z -> {}, lifecycleManager, bucketWatcher);
+        victim = new GoogleComputeEngine(ARGUMENTS, compute, z -> {
+        }, lifecycleManager, bucketWatcher);
         returnSuccess();
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
         verify(images).getFromFamily(ARGUMENTS.project(), VirtualMachineJobDefinition.STANDARD_IMAGE);
@@ -311,7 +325,8 @@ public class GoogleComputeEngineTest {
         String imageName = "alternate_image";
         Compute.Images.Get specificImage = mock(Compute.Images.Get.class);
         when(specificImage.execute()).thenReturn(mock(Image.class));
-        victim = new GoogleComputeEngine(Arguments.testDefaultsBuilder().imageName(imageName).build(), compute, z -> {}, lifecycleManager, bucketWatcher);
+        victim = new GoogleComputeEngine(Arguments.testDefaultsBuilder().imageName(imageName).build(), compute, z -> {
+        }, lifecycleManager, bucketWatcher);
         when(images.get(VirtualMachineJobDefinition.HMF_IMAGE_PROJECT, imageName)).thenReturn(specificImage);
         returnSuccess();
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);

--- a/cluster/src/test/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngineTest.java
@@ -202,8 +202,7 @@ public class GoogleComputeEngineTest {
         verify(instance).setNetworkInterfaces(captor.capture());
         List<NetworkInterface> networkInterfaces = captor.getValue();
         assertThat(networkInterfaces.size()).isEqualTo(1);
-        assertThat(networkInterfaces.get(0).getNetwork()).isEqualTo(
-                "https://www.googleapis.com/compute/v1/projects/hmf-pipeline-development/global/networks/default");
+        assertThat(networkInterfaces.get(0).getNetwork()).isEqualTo("projects/hmf-pipeline-development/global/networks/default");
     }
 
     @Test
@@ -217,10 +216,9 @@ public class GoogleComputeEngineTest {
         verify(instance).setNetworkInterfaces(interfaceCaptor.capture());
         List<NetworkInterface> networkInterfaces = interfaceCaptor.getValue();
         assertThat(networkInterfaces).hasSize(1);
-        assertThat(networkInterfaces.get(0).getNetwork()).isEqualTo(
-                "https://www.googleapis.com/compute/v1/projects/hmf-pipeline-development/global/networks/private");
+        assertThat(networkInterfaces.get(0).getNetwork()).isEqualTo("projects/hmf-pipeline-development/global/networks/private");
         assertThat(networkInterfaces.get(0).getSubnetwork()).isEqualTo(
-                "https://www.googleapis.com/compute/v1/projects/hmf-pipeline-development/regions/europe-west4/subnetworks/subnet");
+                "projects/hmf-pipeline-development/regions/europe-west4/subnetworks/subnet");
         assertThat(networkInterfaces.get(0).get("no-address")).isEqualTo("true");
     }
 
@@ -235,13 +233,29 @@ public class GoogleComputeEngineTest {
         verify(instance).setNetworkInterfaces(interfaceCaptor.capture());
         List<NetworkInterface> networkInterfaces = interfaceCaptor.getValue();
         assertThat(networkInterfaces).hasSize(1);
-        assertThat(networkInterfaces.get(0).getNetwork()).isEqualTo(
-                "https://www.googleapis.com/compute/v1/projects/hmf-pipeline-development/global/networks/private");
+        assertThat(networkInterfaces.get(0).getNetwork()).isEqualTo("projects/hmf-pipeline-development/global/networks/private");
         assertThat(networkInterfaces.get(0).getSubnetwork()).isEqualTo(
-                "https://www.googleapis.com/compute/v1/projects/hmf-pipeline-development/regions/europe-west4/subnetworks/private");
+                "projects/hmf-pipeline-development/regions/europe-west4/subnetworks/private");
         assertThat(networkInterfaces.get(0).get("no-address")).isEqualTo("true");
     }
 
+    @Test
+    public void usesFullNetworkAndSubnetWhenSpecified() {
+        returnSuccess();
+        String networkUrl = "projects/private";
+        String subnetUrl = "projects/subnet";
+        victim = new GoogleComputeEngine(Arguments.testDefaultsBuilder().network(networkUrl).subnet(subnetUrl).build(), compute, z -> {
+        }, lifecycleManager, bucketWatcher);
+        ArgumentCaptor<List<NetworkInterface>> interfaceCaptor = ArgumentCaptor.forClass(List.class);
+        victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
+
+        verify(instance).setNetworkInterfaces(interfaceCaptor.capture());
+        List<NetworkInterface> networkInterfaces = interfaceCaptor.getValue();
+        assertThat(networkInterfaces).hasSize(1);
+        assertThat(networkInterfaces.get(0).getNetwork()).isEqualTo(networkUrl);
+        assertThat(networkInterfaces.get(0).getSubnetwork()).isEqualTo(subnetUrl);
+        assertThat(networkInterfaces.get(0).get("no-address")).isEqualTo("true");
+    }
 
     @Test
     public void addsTagsToComputeEngineInstances() {

--- a/cluster/src/test/java/com/hartwig/pipeline/smoke/SmokeTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/smoke/SmokeTest.java
@@ -27,9 +27,11 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+@Ignore
 @Category(value = IntegrationTest.class)
 public class SmokeTest {
     private static final String ARCHIVE_BUCKET = "hmf-output-test";


### PR DESCRIPTION
Subnet is optional, and if not specified the old behaviour of using the same name as the
network is used (and the region for everything else). Tags are added to the instance when
specified.