### PR TITLE
DEV-1707 Increase disk for tumor CRAM conversions

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/SingleSamplePipeline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/SingleSamplePipeline.java
@@ -80,7 +80,7 @@ public class SingleSamplePipeline {
             Future<FlagstatOutput> flagstatOutputFuture =
                     executorService.submit(() -> stageRunner.run(metadata, new Flagstat(alignmentOutput)));
             Future<CramOutput> cramOutputFuture =
-                    executorService.submit(() -> stageRunner.run(metadata, new CramConversion(alignmentOutput, resourceFiles)));
+                    executorService.submit(() -> stageRunner.run(metadata, new CramConversion(alignmentOutput, metadata.type(), resourceFiles)));
 
             if (metadata.type().equals(SingleSampleRunMetadata.SampleType.REFERENCE)) {
                 Future<GermlineCallerOutput> germlineCallerFuture = executorService.submit(() -> stageRunner.run(metadata,

--- a/cluster/src/main/java/com/hartwig/pipeline/cram/CramConversion.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/cram/CramConversion.java
@@ -19,6 +19,7 @@ import com.hartwig.pipeline.execution.vm.VirtualMachinePerformanceProfile;
 import com.hartwig.pipeline.execution.vm.VmDirectories;
 import com.hartwig.pipeline.metadata.AddDatatypeToFile;
 import com.hartwig.pipeline.metadata.SingleSampleRunMetadata;
+import com.hartwig.pipeline.metadata.SingleSampleRunMetadata.SampleType;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.report.SingleFileComponent;
@@ -34,11 +35,13 @@ public class CramConversion implements Stage<CramOutput, SingleSampleRunMetadata
 
     private final InputDownload bamDownload;
     private final String outputCram;
+    private SampleType sampleType;
     private final ResourceFiles resourceFiles;
 
-    public CramConversion(final AlignmentOutput alignmentOutput, ResourceFiles resourceFiles) {
+    public CramConversion(final AlignmentOutput alignmentOutput, final SampleType sampleType, ResourceFiles resourceFiles) {
         bamDownload = new InputDownload(alignmentOutput.finalBamLocation());
         outputCram = VmDirectories.outputFile(FileTypes.cram(alignmentOutput.sample()));
+        this.sampleType = sampleType;
         this.resourceFiles = resourceFiles;
     }
 
@@ -63,7 +66,7 @@ public class CramConversion implements Stage<CramOutput, SingleSampleRunMetadata
                 .name("cram")
                 .startupCommand(bash)
                 .performanceProfile(VirtualMachinePerformanceProfile.custom(NUMBER_OF_CORES, 6))
-                .workingDiskSpaceGb(650)
+                .workingDiskSpaceGb(sampleType.equals(SingleSampleRunMetadata.SampleType.REFERENCE) ? 650 : 950)
                 .namespacedResults(resultsDirectory)
                 .build();
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
@@ -25,7 +25,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
 
     @Value.Default
     default long workingDiskSpaceGb() {
-        return 900L;
+        return 1200L;
     }
 
     BashStartupScript startupCommand();
@@ -44,9 +44,6 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
         int floor = Math.toIntExact(workingDiskSpaceGb() / localSsdDeviceSizeGb);
         long remainder = workingDiskSpaceGb() % localSsdDeviceSizeGb;
         if (remainder != 0) {
-            floor++;
-        }
-        if (floor % 2 != 0) {
             floor++;
         }
         return floor;

--- a/cluster/src/test/java/com/hartwig/pipeline/cram/CramConversionTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/cram/CramConversionTest.java
@@ -13,6 +13,7 @@ import com.hartwig.pipeline.execution.PipelineStatus;
 import com.hartwig.pipeline.metadata.AddDatatypeToFile;
 import com.hartwig.pipeline.metadata.ApiFileOperation;
 import com.hartwig.pipeline.metadata.SingleSampleRunMetadata;
+import com.hartwig.pipeline.metadata.SingleSampleRunMetadata.SampleType;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.stages.StageTest;
@@ -38,7 +39,7 @@ public class CramConversionTest extends StageTest<CramOutput, SingleSampleRunMet
 
     @Override
     protected Stage<CramOutput, SingleSampleRunMetadata> createVictim() {
-        return new CramConversion(TestInputs.referenceAlignmentOutput(), TestInputs.HG38_RESOURCE_FILES);
+        return new CramConversion(TestInputs.referenceAlignmentOutput(), SampleType.REFERENCE, TestInputs.HG38_RESOURCE_FILES);
     }
 
     @Override


### PR DESCRIPTION
There was a failure in production because of disk space limitations on
an unusually-large tumor sample.

Also since the initial writing of the pipeline I believe GCP relaxed
their requirement that SSDs be provisioned in pairs, so I've also
removed the code that bumped that up if the calculated value was odd.
As a consequence of this, I have also upped the default for disk space
from 900MB to 1200MB as very few jobs specify a non-default
number for the disk space. Previously, 900MB would be calculated to 3
disks but rounded up to 4 and I don't know what the jobs that don't
specify an explicit value, actually need.