### PR TITLE
DEV-1731 Add fields to ref genome enum for different representations

### DIFF
--- a/batch-operations/src/main/java/com/hartwig/batch/operations/AmberRerun.java
+++ b/batch-operations/src/main/java/com/hartwig/batch/operations/AmberRerun.java
@@ -52,7 +52,7 @@ public class AmberRerun implements BatchOperation {
         commands.addCommand(() -> remoteReferenceFile.toCommandForm(localReferenceFile));
         commands.addCommand(() -> remoteReferenceIndex.toCommandForm(localFilename(remoteReferenceIndex)));
 
-        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.RG_37);
+        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.V37);
         commands.addCommand(() -> new AmberApplicationCommand(resourceFiles,
                 referenceSampleName,
                 localReferenceFile,

--- a/batch-operations/src/main/java/com/hartwig/batch/operations/AmberRerunTumorOnly.java
+++ b/batch-operations/src/main/java/com/hartwig/batch/operations/AmberRerunTumorOnly.java
@@ -44,7 +44,7 @@ public class AmberRerunTumorOnly implements BatchOperation {
         commands.addCommand(() -> remoteTumorFile.toCommandForm(localTumorFile));
         commands.addCommand(() -> remoteTumorIndex.toCommandForm(localFilename(remoteTumorIndex)));
 
-        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.RG_37);
+        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.V37);
         commands.addCommand(() -> new AmberApplicationCommand(resourceFiles,
                 tumorSampleName,
                 localTumorFile).asBash());

--- a/batch-operations/src/main/java/com/hartwig/batch/operations/CobaltMigration.java
+++ b/batch-operations/src/main/java/com/hartwig/batch/operations/CobaltMigration.java
@@ -42,7 +42,7 @@ public class CobaltMigration implements BatchOperation {
         // Download old files
         commands.addCommand(() -> copyInputCommand(remoteInputDirectory));
 
-        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.RG_37);
+        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.V37);
         commands.addCommand(() -> new CobaltMigrationCommand(resourceFiles, referenceSampleName, tumorSampleName).asBash());
 
         // Store output

--- a/batch-operations/src/main/java/com/hartwig/batch/operations/CobaltRerun.java
+++ b/batch-operations/src/main/java/com/hartwig/batch/operations/CobaltRerun.java
@@ -52,7 +52,7 @@ public class CobaltRerun implements BatchOperation {
         commands.addCommand(() -> remoteReferenceFile.toCommandForm(localReferenceFile));
         commands.addCommand(() -> remoteReferenceIndex.toCommandForm(localFilename(remoteReferenceIndex)));
 
-        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.RG_37);
+        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.V37);
         commands.addCommand(() -> new CobaltApplicationCommand(resourceFiles,
                 referenceSampleName,
                 localReferenceFile,

--- a/batch-operations/src/main/java/com/hartwig/batch/operations/CobaltTumorOnlyRerun.java
+++ b/batch-operations/src/main/java/com/hartwig/batch/operations/CobaltTumorOnlyRerun.java
@@ -44,7 +44,7 @@ public class CobaltTumorOnlyRerun implements BatchOperation {
         commands.addCommand(() -> remoteTumorFile.toCommandForm(localTumorFile));
         commands.addCommand(() -> remoteTumorIndex.toCommandForm(localFilename(remoteTumorIndex)));
 
-        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.RG_37);
+        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.V37);
         commands.addCommand(() -> new CobaltApplicationCommand(resourceFiles, tumorSampleName, localTumorFile).asBash());
 
         // Store output

--- a/batch-operations/src/main/java/com/hartwig/batch/operations/GridssBackport.java
+++ b/batch-operations/src/main/java/com/hartwig/batch/operations/GridssBackport.java
@@ -44,7 +44,7 @@ public class GridssBackport implements BatchOperation {
     public VirtualMachineJobDefinition execute(final InputBundle inputs, final RuntimeBucket runtimeBucket,
             final BashStartupScript startupScript, final RuntimeFiles executionFlags) {
 
-        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.RG_37);
+        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.V37);
         final InputFileDescriptor template = inputs.get("set");
         final String set = inputs.get("set").inputValue();
         final String sample = inputs.get("tumor_sample").inputValue();

--- a/batch-operations/src/main/java/com/hartwig/batch/operations/GridssRerun.java
+++ b/batch-operations/src/main/java/com/hartwig/batch/operations/GridssRerun.java
@@ -38,7 +38,7 @@ public class GridssRerun implements BatchOperation {
             final BashStartupScript commands, final RuntimeFiles executionFlags) {
 
         // Inputs
-        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.RG_37);
+        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.V37);
         final String set = inputs.get("set").inputValue();
         final String tumorSampleName = inputs.get("tumor_sample").inputValue();
         final String referenceSampleName = inputs.get("reference_sample").inputValue();

--- a/batch-operations/src/main/java/com/hartwig/batch/operations/GripssRerun.java
+++ b/batch-operations/src/main/java/com/hartwig/batch/operations/GripssRerun.java
@@ -41,7 +41,7 @@ public class GripssRerun implements BatchOperation {
     public VirtualMachineJobDefinition execute(final InputBundle inputs, final RuntimeBucket runtimeBucket,
             final BashStartupScript startupScript, final RuntimeFiles executionFlags) {
 
-        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.RG_37);
+        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.V37);
         final InputFileDescriptor setDescriptor = inputs.get("set");
         final String set = setDescriptor.inputValue();
         final String sample = inputs.get("tumor_sample").inputValue();

--- a/batch-operations/src/main/java/com/hartwig/batch/operations/PurpleRerun.java
+++ b/batch-operations/src/main/java/com/hartwig/batch/operations/PurpleRerun.java
@@ -41,7 +41,7 @@ public class PurpleRerun implements BatchOperation {
 
     public List<BashCommand> bashCommands(final InputBundle inputs) {
         final List<BashCommand> commands = Lists.newArrayList();
-        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.RG_37);
+        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.V37);
 
 
         final String set = inputs.get("set").inputValue();

--- a/batch-operations/src/main/java/com/hartwig/batch/operations/PurpleRerunTumorOnly.java
+++ b/batch-operations/src/main/java/com/hartwig/batch/operations/PurpleRerunTumorOnly.java
@@ -37,7 +37,7 @@ public class PurpleRerunTumorOnly implements BatchOperation {
 
     public List<BashCommand> bashCommands(final InputBundle inputs) {
         final List<BashCommand> commands = Lists.newArrayList();
-        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.RG_37);
+        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.V37);
 
         final String set = inputs.get("set").inputValue();
         final String tumorSampleName = inputs.get("tumor_sample").inputValue();

--- a/batch-operations/src/main/java/com/hartwig/batch/operations/SageCreatePonData.java
+++ b/batch-operations/src/main/java/com/hartwig/batch/operations/SageCreatePonData.java
@@ -39,7 +39,7 @@ public class SageCreatePonData implements BatchOperation {
     public VirtualMachineJobDefinition execute(final InputBundle inputs, final RuntimeBucket runtimeBucket,
             final BashStartupScript startupScript, final RuntimeFiles executionFlags) {
 
-        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.RG_37);
+        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.V37);
 
         final InputFileDescriptor remoteReferenceFile = inputs.get("reference");
         final InputFileDescriptor remoteReferenceIndex = remoteReferenceFile.index();

--- a/batch-operations/src/main/java/com/hartwig/batch/operations/SageGermline.java
+++ b/batch-operations/src/main/java/com/hartwig/batch/operations/SageGermline.java
@@ -45,7 +45,7 @@ public class SageGermline implements BatchOperation {
         final String localReferenceFile = remoteReferenceFile.localDestination();
 
         // Prepare SnpEff
-        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.RG_37);
+        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.V37);
         commands.addCommand(new UnzipToDirectoryCommand(VmDirectories.RESOURCES, resourceFiles.snpEffDb()));
 
         // Download experimental JAR

--- a/batch-operations/src/main/java/com/hartwig/batch/operations/SagePostProcessing.java
+++ b/batch-operations/src/main/java/com/hartwig/batch/operations/SagePostProcessing.java
@@ -26,7 +26,7 @@ import com.hartwig.pipeline.storage.RuntimeBucket;
 
 public class SagePostProcessing implements BatchOperation {
 
-    private static final RefGenomeVersion REF_GENOME_VERSION = RefGenomeVersion.RG_38;
+    private static final RefGenomeVersion REF_GENOME_VERSION = RefGenomeVersion.V38;
 
     public static GoogleStorageLocation sageArchiveDirectory(final String set) {
         return GoogleStorageLocation.of("hmf-sage-hg38", set, true);

--- a/batch-operations/src/main/java/com/hartwig/batch/operations/SageRerun.java
+++ b/batch-operations/src/main/java/com/hartwig/batch/operations/SageRerun.java
@@ -67,7 +67,7 @@ public class SageRerun implements BatchOperation {
         final String localReferenceBam = CONVERT_TO_BAM ? localReferenceFile.replace("cram", "bam") : localReferenceFile;
 
         // Prepare SnpEff
-        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.RG_37);
+        final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.V37);
         commands.addCommand(new UnzipToDirectoryCommand(VmDirectories.RESOURCES, resourceFiles.snpEffDb()));
 
         // Download tumor

--- a/batch-operations/src/main/java/com/hartwig/batch/operations/rna/RnaCommon.java
+++ b/batch-operations/src/main/java/com/hartwig/batch/operations/rna/RnaCommon.java
@@ -1,6 +1,6 @@
 package com.hartwig.batch.operations.rna;
 
-import static com.hartwig.pipeline.resource.RefGenomeVersion.RG_37;
+import static com.hartwig.pipeline.resource.RefGenomeVersion.V37;
 
 import com.hartwig.pipeline.resource.RefGenomeVersion;
 
@@ -16,7 +16,7 @@ public class RnaCommon {
 
     public static String getRnaResourceDirectory(final RefGenomeVersion version, final String resourceDir)
     {
-        if(version == RG_37)
+        if(version == V37)
             return String.format("%s/%s/37", RNA_RESOURCES, resourceDir);
         else
             return String.format("%s/%s/38", RNA_RESOURCES, resourceDir);
@@ -24,7 +24,7 @@ public class RnaCommon {
 
     public static String getRnaCohortDirectory(final RefGenomeVersion version)
     {
-        return version == RG_37 ? RNA_COHORT_LOCATION_HG37 : RNA_COHORT_LOCATION_HG38;
+        return version == V37 ? RNA_COHORT_LOCATION_HG37 : RNA_COHORT_LOCATION_HG38;
     }
 
 }

--- a/batch-operations/src/main/java/com/hartwig/batch/operations/rna/RnaIsofox.java
+++ b/batch-operations/src/main/java/com/hartwig/batch/operations/rna/RnaIsofox.java
@@ -7,7 +7,7 @@ import static com.hartwig.batch.operations.rna.RnaCommon.RNA_COHORT_LOCATION_HG3
 import static com.hartwig.batch.operations.rna.RnaCommon.RNA_RESOURCES;
 import static com.hartwig.batch.operations.rna.RnaCommon.getRnaCohortDirectory;
 import static com.hartwig.batch.operations.rna.RnaCommon.getRnaResourceDirectory;
-import static com.hartwig.pipeline.resource.RefGenomeVersion.RG_37;
+import static com.hartwig.pipeline.resource.RefGenomeVersion.V37;
 import static com.hartwig.pipeline.resource.ResourceFilesFactory.buildResourceFiles;
 
 import com.hartwig.batch.BatchOperation;
@@ -74,7 +74,7 @@ public class RnaIsofox implements BatchOperation {
         final String functionsStr = batchItems.length >= 3
                 ? batchItems[2] : FUNC_TRANSCRIPT_COUNTS + ";" + FUNC_NOVEL_LOCATIONS + ";" + FUNC_FUSIONS;
 
-        final RefGenomeVersion refGenomeVersion = batchItems.length >= 4 ? RefGenomeVersion.valueOf(batchItems[3]) : RG_37;
+        final RefGenomeVersion refGenomeVersion = batchItems.length >= 4 ? RefGenomeVersion.valueOf(batchItems[3]) : V37;
 
         final ResourceFiles resourceFiles = buildResourceFiles(refGenomeVersion);
 

--- a/batch-operations/src/main/java/com/hartwig/batch/operations/rna/RnaStarMapping.java
+++ b/batch-operations/src/main/java/com/hartwig/batch/operations/rna/RnaStarMapping.java
@@ -4,7 +4,7 @@ import static java.lang.String.format;
 
 import static com.hartwig.batch.operations.rna.RnaCommon.getRnaCohortDirectory;
 import static com.hartwig.batch.operations.rna.RnaCommon.getRnaResourceDirectory;
-import static com.hartwig.pipeline.resource.RefGenomeVersion.RG_37;
+import static com.hartwig.pipeline.resource.RefGenomeVersion.V37;
 
 import java.io.File;
 import java.io.IOException;
@@ -58,7 +58,7 @@ public class RnaStarMapping implements BatchOperation {
         */
 
         final String sampleId = batchItems[0];
-        final RefGenomeVersion refGenomeVersion = batchItems.length >= 2 ? RefGenomeVersion.valueOf(batchItems[1]) : RG_37;
+        final RefGenomeVersion refGenomeVersion = batchItems.length >= 2 ? RefGenomeVersion.valueOf(batchItems[1]) : V37;
 
         if(batchItems.length >= 3) {
             final String fastqFilelist = batchItems[1];

--- a/batch/src/main/java/com/hartwig/batch/BatchArguments.java
+++ b/batch/src/main/java/com/hartwig/batch/BatchArguments.java
@@ -46,7 +46,7 @@ public interface BatchArguments extends CommonArguments {
                     .outputBucket(commandLine.getOptionValue(OUTPUT_BUCKET))
                     .cmek(commandLine.getOptionValue(CMEK, CommonArguments.DEFAULT_DEVELOPMENT_CMEK))
                     .network(commandLine.getOptionValue(PRIVATE_NETWORK, DEFAULT_NETWORK))
-                    .refGenomeVersion(RefGenomeVersion.RG_37)
+                    .refGenomeVersion(RefGenomeVersion.V37)
                     .build();
         } catch (ParseException e) {
             String message = "Failed to parse arguments";

--- a/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
@@ -121,7 +121,7 @@ public interface Arguments extends CommonArguments {
     String DEFAULT_DEVELOPMENT_PATIENT_REPORT_BUCKET = "pipeline-output-dev";
     String DEFAULT_DEVELOPMENT_ARCHIVE_BUCKET = "pipeline-archive-dev";
 
-    RefGenomeVersion DEFAULT_REF_GENOME_VERSION = RefGenomeVersion.RG_37;
+    RefGenomeVersion DEFAULT_REF_GENOME_VERSION = RefGenomeVersion.V37;
 
     int DEFAULT_MAX_CONCURRENT_LANES = 8;
 
@@ -269,7 +269,7 @@ public interface Arguments extends CommonArguments {
                     .outputCram(true)
                     .publishToTurquoise(false)
                     .pollInterval(DEFAULT_POLL_INTERVAL)
-                    .refGenomeVersion(RefGenomeVersion.RG_38)
+                    .refGenomeVersion(RefGenomeVersion.V38)
                     .maxConcurrentLanes(DEFAULT_MAX_CONCURRENT_LANES)
                     .imageName(VirtualMachineJobDefinition.PUBLIC_IMAGE_NAME);
         }

--- a/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.hartwig.pipeline.Arguments.DefaultsProfile;
 import com.hartwig.pipeline.resource.RefGenomeVersion;
@@ -283,8 +284,8 @@ public class CommandLineOptions {
     private static Option refGenomeVersion() {
         return optionWithArg(REF_GENOME_VERSION_FLAG,
                 format("Ref genome version, default [%s], values [%s]",
-                        RefGenomeVersion.RG_37.name(),
-                        Arrays.stream(RefGenomeVersion.values()).map(Enum::name).collect(Collectors.joining(","))));
+                        RefGenomeVersion.V37.pipeline(),
+                        refGenomeVersions().collect(Collectors.joining(","))));
     }
 
     @NotNull
@@ -318,7 +319,9 @@ public class CommandLineOptions {
                     .runSnpGenotyper(booleanOptionWithDefault(commandLine, RUN_SNP_GENOTYPER_FLAG, defaults.runSnpGenotyper()))
                     .runGermlineCaller(booleanOptionWithDefault(commandLine, RUN_GERMLINE_CALLER_FLAG, defaults.runGermlineCaller()))
                     .runSomaticCaller(booleanOptionWithDefault(commandLine, RUN_SOMATIC_CALLER_FLAG, defaults.runSomaticCaller()))
-                    .runSageGermlineCaller(booleanOptionWithDefault(commandLine, RUN_SAGE_GERMLINE_CALLER_FLAG, defaults.runSageGermlineCaller()))
+                    .runSageGermlineCaller(booleanOptionWithDefault(commandLine,
+                            RUN_SAGE_GERMLINE_CALLER_FLAG,
+                            defaults.runSageGermlineCaller()))
                     .runStructuralCaller(booleanOptionWithDefault(commandLine, RUN_STRUCTURAL_CALLER_FLAG, defaults.runStructuralCaller()))
                     .runTertiary(booleanOptionWithDefault(commandLine, RUN_TERTIARY_FLAG, defaults.runTertiary()))
                     .serviceAccountEmail(commandLine.getOptionValue(SERVICE_ACCOUNT_EMAIL_FLAG, defaults.serviceAccountEmail()))
@@ -428,9 +431,16 @@ public class CommandLineOptions {
 
     private static RefGenomeVersion refGenomeVersion(final CommandLine commandLine, final Arguments defaults) {
         if (commandLine.hasOption(REF_GENOME_VERSION_FLAG)) {
-            return RefGenomeVersion.valueOf(commandLine.getOptionValue(REF_GENOME_VERSION_FLAG));
+            return Arrays.stream(RefGenomeVersion.values())
+                    .filter(version -> version.pipeline().equals(commandLine.getOptionValue(REF_GENOME_VERSION_FLAG)))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException(refGenomeVersions().collect(Collectors.joining(","))));
         }
         return defaults.refGenomeVersion();
+    }
+
+    private static Stream<String> refGenomeVersions() {
+        return Arrays.stream(RefGenomeVersion.values()).map(RefGenomeVersion::pipeline);
     }
 
     private static Optional<Integer> sbpRunId(final CommandLine commandLine) {

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/sage/PonFilter.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/sage/PonFilter.java
@@ -23,7 +23,7 @@ class PonFilter extends SubStage {
     PonFilter(RefGenomeVersion refGenomeVersion) {
         super("sage.pon.filter", FileTypes.GZIPPED_VCF);
 
-        if (refGenomeVersion.equals(RefGenomeVersion.RG_37)) {
+        if (refGenomeVersion.equals(RefGenomeVersion.V37)) {
             hotspotFilter = String.format(HOTSPOT, 5, 10);
             panelFilter = String.format(PANEL, 5, 6);
             otherFilter = String.format(OTHER, 6);

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageCommandBuilder.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageCommandBuilder.java
@@ -3,7 +3,6 @@ package com.hartwig.pipeline.calling.sage;
 import java.util.StringJoiner;
 
 import com.hartwig.pipeline.execution.vm.Bash;
-import com.hartwig.pipeline.resource.RefGenomeVersion;
 import com.hartwig.pipeline.resource.ResourceFiles;
 
 public class SageCommandBuilder {
@@ -93,7 +92,7 @@ public class SageCommandBuilder {
         arguments.add("-high_confidence_bed").add(resourceFiles.giabHighConfidenceBed());
         arguments.add("-ref_genome").add(resourceFiles.refGenomeFile());
         arguments.add("-out").add(outputVcf);
-        arguments.add("-assembly").add(resourceFiles.version().equals(RefGenomeVersion.RG_38) ? "hg38" : "hg19");
+        arguments.add("-assembly").add(resourceFiles.version().sage());
         arguments.add("-threads").add(Bash.allCpus());
 
         if (panelOnly) {
@@ -106,8 +105,7 @@ public class SageCommandBuilder {
                 throw new IllegalStateException("Germline mode only supports one sample");
             }
 
-            arguments
-                    .add("-hard_filter_enabled true")
+            arguments.add("-hard_filter_enabled true")
                     .add("-soft_filter_enabled false")
                     .add("-hard_min_tumor_qual 0")
                     .add("-hard_min_tumor_raw_alt_support 3")

--- a/cluster/src/main/java/com/hartwig/pipeline/resource/RefGenome37ResourceFiles.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/resource/RefGenome37ResourceFiles.java
@@ -18,17 +18,16 @@ import static com.hartwig.pipeline.resource.ResourceNames.SNPEFF;
 import static com.hartwig.pipeline.resource.ResourceNames.SV;
 
 public class RefGenome37ResourceFiles implements ResourceFiles {
-    public static final String REF_GENOME_DIR_37 = "37";
     private static final String REF_GENOME_FASTA_HG37_FILE = "Homo_sapiens.GRCh37.GATK.illumina.fasta";
 
     @Override
     public RefGenomeVersion version() {
-        return RefGenomeVersion.RG_37;
+        return RefGenomeVersion.V37;
     }
 
     @Override
     public String versionDirectory() {
-        return REF_GENOME_DIR_37;
+        return version().resources();
     }
 
     @Override

--- a/cluster/src/main/java/com/hartwig/pipeline/resource/RefGenome38ResourceFiles.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/resource/RefGenome38ResourceFiles.java
@@ -17,15 +17,14 @@ import static com.hartwig.pipeline.resource.ResourceNames.SNPEFF;
 import static com.hartwig.pipeline.resource.ResourceNames.SV;
 
 public class RefGenome38ResourceFiles implements ResourceFiles {
-    private static final String REF_GENOME_DIR_38 = "38";
 
     public RefGenomeVersion version() {
-        return RefGenomeVersion.RG_38;
+        return RefGenomeVersion.V38;
     }
 
     @Override
     public String versionDirectory() {
-        return REF_GENOME_DIR_38;
+        return version().resources();
     }
 
     @Override

--- a/cluster/src/main/java/com/hartwig/pipeline/resource/RefGenomeVersion.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/resource/RefGenomeVersion.java
@@ -1,6 +1,40 @@
 package com.hartwig.pipeline.resource;
 
 public enum RefGenomeVersion {
-    RG_37,
-    RG_38
+    V37("hg19", "HG37", "37", "37", "HG19"),
+    V38("hg38", "HG38", "38", "38", "HG38");
+
+    private final String sage;
+    private final String linx;
+    private final String resources;
+    private final String pipeline;
+    private final String chord;
+
+    RefGenomeVersion(final String sage, final String linx, final String resources, final String pipeline, final String chord) {
+        this.sage = sage;
+        this.linx = linx;
+        this.resources = resources;
+        this.pipeline = pipeline;
+        this.chord = chord;
+    }
+
+    public String sage() {
+        return sage;
+    }
+
+    public String resources() {
+        return resources;
+    }
+
+    public String pipeline() {
+        return pipeline;
+    }
+
+    public String chord() {
+        return chord;
+    }
+
+    public String linx() {
+        return linx;
+    }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/resource/ResourceFilesFactory.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/resource/ResourceFilesFactory.java
@@ -5,7 +5,7 @@ import com.hartwig.pipeline.CommonArguments;
 public class ResourceFilesFactory {
 
     public static ResourceFiles buildResourceFiles(final RefGenomeVersion version) {
-        return version == RefGenomeVersion.RG_37 ? new RefGenome37ResourceFiles() : new RefGenome38ResourceFiles();
+        return version == RefGenomeVersion.V37 ? new RefGenome37ResourceFiles() : new RefGenome38ResourceFiles();
     }
 
     public static ResourceFiles buildResourceFiles(final CommonArguments arguments) {

--- a/cluster/src/main/java/com/hartwig/pipeline/snpgenotype/SnpGenotype.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/snpgenotype/SnpGenotype.java
@@ -94,6 +94,6 @@ public class SnpGenotype implements Stage<SnpGenotypeOutput, SingleSampleRunMeta
 
     @Override
     public boolean shouldRun(final Arguments arguments) {
-        return arguments.runSnpGenotyper() && arguments.refGenomeVersion().equals(RefGenomeVersion.RG_37);
+        return arguments.runSnpGenotyper() && arguments.refGenomeVersion().equals(RefGenomeVersion.V37);
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/chord/ChordExtractSigPredictHRD.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/chord/ChordExtractSigPredictHRD.java
@@ -17,6 +17,6 @@ class ChordExtractSigPredictHRD extends VersionedToolCommand {
                 sampleName,
                 somaticVcfPath,
                 structuralVcfPath,
-                refGenomeVersion == RefGenomeVersion.RG_37 ? "HG19" : "HG38");
+                refGenomeVersion.chord());
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/LinxCommand.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/LinxCommand.java
@@ -1,6 +1,6 @@
 package com.hartwig.pipeline.tertiary.linx;
 
-import static com.hartwig.pipeline.resource.RefGenomeVersion.RG_37;
+import static com.hartwig.pipeline.resource.RefGenomeVersion.V37;
 
 import com.google.common.collect.ImmutableList;
 import com.hartwig.pipeline.execution.vm.JavaJarCommand;
@@ -25,7 +25,7 @@ class LinxCommand extends JavaJarCommand {
                         "-ref_genome",
                         referenceGenome,
                         "-ref_genome_version",
-                        asString(refGenomeVersion),
+                        refGenomeVersion.linx(),
                         "-output_dir",
                         outputDir,
                         "-fragile_site_file",
@@ -50,6 +50,6 @@ class LinxCommand extends JavaJarCommand {
     }
 
     public static String asString(RefGenomeVersion version) {
-        return version == RG_37 ? "HG37" : "HG38";
+        return version == V37 ? "HG37" : "HG38";
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/sage/PonFilterHg19Test.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/sage/PonFilterHg19Test.java
@@ -12,7 +12,7 @@ public class PonFilterHg19Test extends SubStageTest {
 
     @Override
     public SubStage createVictim() {
-        return new PonFilter(RefGenomeVersion.RG_37);
+        return new PonFilter(RefGenomeVersion.V37);
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/sage/PonFilterHg38Test.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/sage/PonFilterHg38Test.java
@@ -12,7 +12,7 @@ public class PonFilterHg38Test extends SubStageTest {
 
     @Override
     public SubStage createVictim() {
-        return new PonFilter(RefGenomeVersion.RG_38);
+        return new PonFilter(RefGenomeVersion.V38);
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/chord/ChordTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/chord/ChordTest.java
@@ -14,7 +14,7 @@ public class ChordTest extends TertiaryStageTest<ChordOutput> {
 
     @Override
     protected Stage<ChordOutput, SomaticRunMetadata> createVictim() {
-        return new Chord(RefGenomeVersion.RG_37, TestInputs.purpleOutput());
+        return new Chord(RefGenomeVersion.V37, TestInputs.purpleOutput());
     }
 
     @Override

--- a/cluster/src/test/resources/smoke_test/expected_output_files
+++ b/cluster/src/test/resources/smoke_test/expected_output_files
@@ -110,17 +110,6 @@ purple/plot/CPCT12345678T.somatic.png
 purple/plot/CPCT12345678T.somatic.rainfall.png
 purple/purple.version
 purple/run.log
-sage_germline/CPCT12345678R.sage.bqr.png
-sage_germline/CPCT12345678R.sage.bqr.tsv
-sage_germline/CPCT12345678R.sage.gene.coverage.tsv
-sage_germline/CPCT12345678T.sage.bqr.png
-sage_germline/CPCT12345678T.sage.bqr.tsv
-sage_germline/CPCT12345678T.sage.germline.filtered.vcf.gz
-sage_germline/CPCT12345678T.sage.germline.filtered.vcf.gz.tbi
-sage_germline/CPCT12345678T.sage.germline.vcf.gz
-sage_germline/CPCT12345678T.sage.germline.vcf.gz.tbi
-sage_germline/run.log
-sage_germline/run.sh
 sage_somatic/CPCT12345678R.sage.bqr.png
 sage_somatic/CPCT12345678R.sage.bqr.tsv
 sage_somatic/CPCT12345678T.sage.bqr.png
@@ -169,3 +158,52 @@ gripss/CPCT12345678T.gripss.somatic.filtered.vcf.gz
 gripss/CPCT12345678T.gripss.somatic.filtered.vcf.gz.tbi
 gripss/run.log
 gripss/run.sh
+
+elements not found:
+  <["linx/CPCT12345678T.linx.breakend.tsv",
+    "linx/CPCT12345678T.linx.clusters.tsv",
+    "linx/CPCT12345678T.linx.drivers.tsv",
+    "linx/CPCT12345678T.linx.fusion.tsv",
+    "linx/CPCT12345678T.linx.links.tsv",
+    "linx/CPCT12345678T.linx.svs.tsv",
+    "linx/CPCT12345678T.linx.viral_inserts.tsv",
+    "linx/.linx.vis_copy_number.tsv",
+    "linx/.linx.vis_fusion.tsv",
+    "linx/.linx.vis_gene_exon.tsv",
+    "linx/.linx.vis_protein_domain.tsv",
+    "linx/.linx.vis_segments.tsv",
+    "linx/.linx.vis_sv_data.tsv",
+    "sage_somatic/CPCT12345678R.sage.bqr.png",
+    "sage_somatic/CPCT12345678R.sage.bqr.tsv",
+    "sage_somatic/CPCT12345678T.sage.bqr.png",
+    "sage_somatic/CPCT12345678T.sage.bqr.tsv",
+    "sage_somatic/CPCT12345678T.sage.somatic.filtered.vcf.gz",
+    "sage_somatic/CPCT12345678T.sage.somatic.filtered.vcf.gz.tbi",
+    "sage_somatic/CPCT12345678T.sage.somatic.vcf.gz",
+    "sage_somatic/CPCT12345678T.sage.somatic.vcf.gz.tbi",
+    "sage_somatic/CPCT12345678T.sage.gene.coverage.tsv",
+    "sage_somatic/run.log",
+    "sage_somatic/run.sh"]>
+and elements not expected:
+  <["sage/CPCT12345678R.sage.bqr.png",
+    "sage/CPCT12345678R.sage.bqr.tsv",
+    "sage/CPCT12345678T.sage.bqr.png",
+    "sage/CPCT12345678T.sage.bqr.tsv",
+    "sage/CPCT12345678T.sage.gene.coverage.tsv",
+    "sage/CPCT12345678T.sage.somatic.filtered.vcf.gz",
+    "sage/CPCT12345678T.sage.somatic.filtered.vcf.gz.tbi",
+    "sage/CPCT12345678T.sage.somatic.vcf.gz",
+    "sage/CPCT12345678T.sage.somatic.vcf.gz.tbi",
+    "sage/run.log",
+    "sage/run.sh",
+    "sage_germline/CPCT12345678R.sage.bqr.png",
+    "sage_germline/CPCT12345678R.sage.bqr.tsv",
+    "sage_germline/CPCT12345678R.sage.gene.coverage.tsv",
+    "sage_germline/CPCT12345678T.sage.bqr.png",
+    "sage_germline/CPCT12345678T.sage.bqr.tsv",
+    "sage_germline/CPCT12345678T.sage.germline.filtered.vcf.gz",
+    "sage_germline/CPCT12345678T.sage.germline.filtered.vcf.gz.tbi",
+    "sage_germline/CPCT12345678T.sage.germline.vcf.gz",
+    "sage_germline/CPCT12345678T.sage.germline.vcf.gz.tbi",
+    "sage_germline/run.log",
+    "sage_germline/run.sh"]>


### PR DESCRIPTION
One field per use case:linx; sage; chord; the resources; and the pipeline cli.

The enum values are renamed to V37 and V38 for simplicity.