### PR TITLE
DEV-1786 All add datatypes use a path to an actual file

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/bwa/BwaAligner.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/bwa/BwaAligner.java
@@ -34,6 +34,7 @@ import com.hartwig.pipeline.execution.vm.RuntimeFiles;
 import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
 import com.hartwig.pipeline.failsafe.DefaultBackoffPolicy;
 import com.hartwig.pipeline.metadata.AddDatatype;
+import com.hartwig.pipeline.metadata.ArchivePath;
 import com.hartwig.pipeline.metadata.SingleSampleRunMetadata;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.report.ReportComponent;
@@ -171,13 +172,11 @@ public class BwaAligner implements Aligner {
                                 bai(bam(metadata.sampleName())),
                                 resultsDirectory))
                         .addFurtherOperations(new AddDatatype(DataType.ALIGNED_READS,
-                                        Folder.from(metadata),
-                                        format("%s/%s", BwaAligner.NAMESPACE, bam(metadata.sampleName())),
-                                        metadata.barcode()),
+                                        metadata.barcode(),
+                                        new ArchivePath(Folder.from(metadata), BwaAligner.NAMESPACE, bam(metadata.sampleName()))),
                                 new AddDatatype(DataType.ALIGNED_READS_INDEX,
-                                        Folder.from(metadata),
-                                        format("%s/%s", BwaAligner.NAMESPACE, bai(bam(metadata.sampleName()))),
-                                        metadata.barcode()));
+                                        metadata.barcode(),
+                                        new ArchivePath(Folder.from(metadata), BwaAligner.NAMESPACE, bai(metadata.sampleName()))));
             }
             output = outputBuilder.build();
         } else {

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/germline/GermlineCaller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/germline/GermlineCaller.java
@@ -1,7 +1,5 @@
 package com.hartwig.pipeline.calling.germline;
 
-import static java.lang.String.format;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +23,7 @@ import com.hartwig.pipeline.execution.vm.VmDirectories;
 import com.hartwig.pipeline.execution.vm.unix.MvCommand;
 import com.hartwig.pipeline.execution.vm.unix.UnzipToDirectoryCommand;
 import com.hartwig.pipeline.metadata.AddDatatype;
+import com.hartwig.pipeline.metadata.ArchivePath;
 import com.hartwig.pipeline.metadata.SingleSampleRunMetadata;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.report.RunLogComponent;
@@ -140,9 +139,8 @@ public class GermlineCaller implements Stage<GermlineCallerOutput, SingleSampleR
                         outputFile.fileName(),
                         resultsDirectory))
                 .addFurtherOperations(new AddDatatype(DataType.GERMLINE_VARIANTS,
-                        Folder.from(metadata),
-                        format("%s/%s", namespace(), outputFile.fileName()),
-                        metadata.barcode()))
+                        metadata.barcode(),
+                        new ArchivePath(Folder.from(metadata), namespace(), outputFile.fileName())))
                 .build();
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageCaller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageCaller.java
@@ -9,6 +9,7 @@ import com.hartwig.pipeline.execution.PipelineStatus;
 import com.hartwig.pipeline.execution.vm.BashStartupScript;
 import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
 import com.hartwig.pipeline.metadata.AddDatatype;
+import com.hartwig.pipeline.metadata.ArchivePath;
 import com.hartwig.pipeline.metadata.SingleSampleRunMetadata;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.Folder;
@@ -68,9 +69,8 @@ public abstract class SageCaller extends TertiaryStage<SageOutput> {
                 .addReportComponents(new RunLogComponent(bucket, namespace(), Folder.root(), resultsDirectory))
                 .addReportComponents(new StartupScriptComponent(bucket, namespace(), Folder.root()))
                 .addFurtherOperations(new AddDatatype(dataType,
-                        Folder.root(),
-                        format("%s/%s", namespace(), filteredOutputFile),
-                        metadata.barcode()));
+                        metadata.barcode(),
+                        new ArchivePath(Folder.root(), namespace(), filteredOutputFile)));
     }
 
     @Override

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/structural/StructuralCaller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/structural/StructuralCaller.java
@@ -24,6 +24,7 @@ import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
 import com.hartwig.pipeline.execution.vm.VmDirectories;
 import com.hartwig.pipeline.execution.vm.unix.ExportPathCommand;
 import com.hartwig.pipeline.metadata.AddDatatype;
+import com.hartwig.pipeline.metadata.ArchivePath;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.EntireOutputComponent;
 import com.hartwig.pipeline.report.Folder;
@@ -124,9 +125,8 @@ public class StructuralCaller implements Stage<StructuralCallerOutput, SomaticRu
                 .addReportComponents(new RunLogComponent(bucket, NAMESPACE, Folder.root(), resultsDirectory))
                 .addReportComponents(new StartupScriptComponent(bucket, NAMESPACE, Folder.root()))
                 .addFurtherOperations(new AddDatatype(DataType.STRUCTURAL_VARIANTS_GRIDSS,
-                        Folder.root(),
-                        format("%s/%s", namespace(), basename(unfilteredVcf)),
-                        metadata.barcode()))
+                        metadata.barcode(),
+                        new ArchivePath(Folder.root(), namespace(), basename(unfilteredVcf))))
                 .build();
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/structural/StructuralCallerPostProcess.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/structural/StructuralCallerPostProcess.java
@@ -19,6 +19,7 @@ import com.hartwig.pipeline.execution.vm.BashStartupScript;
 import com.hartwig.pipeline.execution.vm.InputDownload;
 import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
 import com.hartwig.pipeline.metadata.AddDatatype;
+import com.hartwig.pipeline.metadata.ArchivePath;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.report.RunLogComponent;
@@ -113,13 +114,11 @@ public class StructuralCallerPostProcess implements Stage<StructuralCallerPostPr
                 .addReportComponents(new RunLogComponent(bucket, NAMESPACE, Folder.root(), resultsDirectory))
                 .addReportComponents(new StartupScriptComponent(bucket, NAMESPACE, Folder.root()))
                 .addFurtherOperations(new AddDatatype(DataType.STRUCTURAL_VARIANTS_GRIPSS_RECOVERY,
-                                Folder.root(),
-                                format("%s/%s", namespace(), basename(somaticVcf)),
-                                metadata.barcode()),
+                                metadata.barcode(),
+                                new ArchivePath(Folder.root(), namespace(), basename(somaticVcf))),
                         new AddDatatype(DataType.STRUCTURAL_VARIANTS_GRIPSS,
-                                Folder.root(),
-                                format("%s/%s", namespace(), basename(somaticFilteredVcf)),
-                                metadata.barcode()))
+                                metadata.barcode(),
+                                new ArchivePath(Folder.root(), namespace(), basename(somaticFilteredVcf))))
                 .build();
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/cram/CramConversion.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/cram/CramConversion.java
@@ -1,7 +1,5 @@
 package com.hartwig.pipeline.cram;
 
-import static java.lang.String.format;
-
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
@@ -20,6 +18,7 @@ import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
 import com.hartwig.pipeline.execution.vm.VirtualMachinePerformanceProfile;
 import com.hartwig.pipeline.execution.vm.VmDirectories;
 import com.hartwig.pipeline.metadata.AddDatatype;
+import com.hartwig.pipeline.metadata.ArchivePath;
 import com.hartwig.pipeline.metadata.SingleSampleRunMetadata;
 import com.hartwig.pipeline.metadata.SingleSampleRunMetadata.SampleType;
 import com.hartwig.pipeline.report.Folder;
@@ -88,13 +87,11 @@ public class CramConversion implements Stage<CramOutput, SingleSampleRunMetadata
                         new SingleFileComponent(bucket, NAMESPACE, folder, cram, cram, resultsDirectory),
                         new SingleFileComponent(bucket, NAMESPACE, folder, crai, crai, resultsDirectory))
                 .addFurtherOperations(new AddDatatype(DataType.ALIGNED_READS,
-                                Folder.from(metadata),
-                                format("%s/%s", namespace(), cram),
-                                metadata.barcode()),
+                                metadata.barcode(),
+                                new ArchivePath(Folder.from(metadata), namespace(), cram)),
                         new AddDatatype(DataType.ALIGNED_READS_INDEX,
-                                Folder.from(metadata),
-                                format("%s/%s", namespace(), crai),
-                                metadata.barcode()))
+                                metadata.barcode(),
+                                new ArchivePath(Folder.from(metadata), namespace(), crai)))
                 .build();
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/AddDatatype.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/AddDatatype.java
@@ -5,7 +5,6 @@ import static java.lang.String.format;
 import java.util.Objects;
 
 import com.hartwig.pipeline.datatypes.DataType;
-import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.sbpapi.AddFileApiResponse;
 import com.hartwig.pipeline.sbpapi.SbpRestApi;
 
@@ -14,10 +13,10 @@ public class AddDatatype implements ApiFileOperation {
     private final DataType datatype;
     private final String barcode;
 
-    public AddDatatype(final DataType datatype, final Folder folder, final String filePath, final String barcode) {
+    public AddDatatype(final DataType datatype, final String barcode, final ArchivePath path) {
         this.datatype = datatype;
         this.barcode = barcode;
-        path = folder.name().isEmpty() ? filePath : folder.name() + filePath;
+        this.path = path.path();
     }
 
     @Override

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/ArchivePath.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/ArchivePath.java
@@ -1,0 +1,20 @@
+package com.hartwig.pipeline.metadata;
+
+import com.hartwig.pipeline.report.Folder;
+
+public class ArchivePath {
+
+    private final Folder folder;
+    private final String namespace;
+    private final String filename;
+
+    public ArchivePath(final Folder folder, final String namespace, final String filename) {
+        this.folder = folder;
+        this.namespace = namespace;
+        this.filename = filename;
+    }
+
+    public String path() {
+        return folder.name() + namespace + "/" + filename;
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/metrics/BamMetrics.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metrics/BamMetrics.java
@@ -1,7 +1,5 @@
 package com.hartwig.pipeline.metrics;
 
-import static java.lang.String.format;
-
 import java.util.Collections;
 import java.util.List;
 
@@ -16,6 +14,7 @@ import com.hartwig.pipeline.execution.vm.InputDownload;
 import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
 import com.hartwig.pipeline.execution.vm.VmDirectories;
 import com.hartwig.pipeline.metadata.AddDatatype;
+import com.hartwig.pipeline.metadata.ArchivePath;
 import com.hartwig.pipeline.metadata.SingleSampleRunMetadata;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.report.RunLogComponent;
@@ -87,9 +86,8 @@ public class BamMetrics implements Stage<BamMetricsOutput, SingleSampleRunMetada
                         outputFile,
                         resultsDirectory))
                 .addFurtherOperations(new AddDatatype(DataType.WGSMETRICS,
-                        Folder.from(metadata),
-                        format("%s/%s", namespace(), outputFile),
-                        metadata.barcode()))
+                        metadata.barcode(),
+                        new ArchivePath(Folder.from(metadata), namespace(), outputFile)))
                 .build();
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/amber/Amber.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/amber/Amber.java
@@ -1,7 +1,5 @@
 package com.hartwig.pipeline.tertiary.amber;
 
-import static java.lang.String.format;
-
 import java.io.File;
 import java.util.List;
 
@@ -15,6 +13,7 @@ import com.hartwig.pipeline.execution.vm.BashStartupScript;
 import com.hartwig.pipeline.execution.vm.CopyResourceToOutput;
 import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
 import com.hartwig.pipeline.metadata.AddDatatype;
+import com.hartwig.pipeline.metadata.ArchivePath;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.EntireOutputComponent;
 import com.hartwig.pipeline.report.Folder;
@@ -66,11 +65,12 @@ public class Amber extends TertiaryStage<AmberOutput> {
                 .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .maybeOutputDirectory(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(), true))
                 .addReportComponents(new EntireOutputComponent(bucket, Folder.root(), namespace(), resultsDirectory))
-                .addFurtherOperations(new AddDatatype(DataType.AMBER, Folder.root(), namespace(), metadata.barcode()),
+                .addFurtherOperations(new AddDatatype(DataType.AMBER,
+                                metadata.barcode(),
+                                new ArchivePath(Folder.root(), namespace(), String.format("%s.amber.baf.tsv", metadata.tumor().sampleName()))),
                         new AddDatatype(DataType.AMBER_SNPCHECK,
-                                Folder.root(),
-                                format("%s/%s", namespace(), new File(resourceFiles.amberSnpcheck()).getName()),
-                                metadata.barcode()))
+                                metadata.barcode(),
+                                new ArchivePath(Folder.root(), namespace(), new File(resourceFiles.amberSnpcheck()).getName())))
                 .build();
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/bachelor/Bachelor.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/bachelor/Bachelor.java
@@ -16,6 +16,7 @@ import com.hartwig.pipeline.execution.vm.InputDownload;
 import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
 import com.hartwig.pipeline.execution.vm.VmDirectories;
 import com.hartwig.pipeline.metadata.AddDatatype;
+import com.hartwig.pipeline.metadata.ArchivePath;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.EntireOutputComponent;
 import com.hartwig.pipeline.report.Folder;
@@ -37,7 +38,8 @@ public class Bachelor implements Stage<BachelorOutput, SomaticRunMetadata> {
     private final InputDownload germlineVcfDownload;
     private final InputDownload germlineVcfIndexDownload;
 
-    public Bachelor(final ResourceFiles resourceFiles, final PurpleOutput purpleOutput, AlignmentOutput tumorAlignmentOutput, GermlineCallerOutput germlineCallerOutput) {
+    public Bachelor(final ResourceFiles resourceFiles, final PurpleOutput purpleOutput, AlignmentOutput tumorAlignmentOutput,
+            GermlineCallerOutput germlineCallerOutput) {
         this.resourceFiles = resourceFiles;
         this.purpleOutputDownload = new InputDownload(purpleOutput.outputDirectory());
         this.tumorBamDownload = new InputDownload(tumorAlignmentOutput.finalBamLocation());
@@ -80,7 +82,9 @@ public class Bachelor implements Stage<BachelorOutput, SomaticRunMetadata> {
                 .status(jobStatus)
                 .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .addReportComponents(new EntireOutputComponent(bucket, Folder.root(), NAMESPACE, resultsDirectory))
-                .addFurtherOperations(new AddDatatype(DataType.BACHELOR, Folder.root(), namespace(), metadata.barcode()))
+                .addFurtherOperations(new AddDatatype(DataType.BACHELOR,
+                        metadata.barcode(),
+                        new ArchivePath(Folder.root(), namespace(), metadata.tumor().sampleName() + ".bachelor.germline_variant.tsv")))
                 .build();
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/chord/Chord.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/chord/Chord.java
@@ -1,7 +1,5 @@
 package com.hartwig.pipeline.tertiary.chord;
 
-import static java.lang.String.format;
-
 import java.util.Collections;
 import java.util.List;
 
@@ -15,6 +13,7 @@ import com.hartwig.pipeline.execution.vm.BashStartupScript;
 import com.hartwig.pipeline.execution.vm.InputDownload;
 import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
 import com.hartwig.pipeline.metadata.AddDatatype;
+import com.hartwig.pipeline.metadata.ArchivePath;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.EntireOutputComponent;
 import com.hartwig.pipeline.report.Folder;
@@ -69,9 +68,8 @@ public class Chord implements Stage<ChordOutput, SomaticRunMetadata> {
                 .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .addReportComponents(new EntireOutputComponent(bucket, Folder.root(), namespace(), resultsDirectory))
                 .addFurtherOperations(new AddDatatype(DataType.CHORD_PREDICTION,
-                        Folder.root(),
-                        format("%s/%s_chord_prediction.txt", namespace(), metadata.tumor().sampleName()),
-                        metadata.barcode()))
+                        metadata.barcode(),
+                        new ArchivePath(Folder.root(), namespace(), metadata.tumor().sampleName() + "_chord_prediction.txt")))
                 .build();
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/cobalt/Cobalt.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/cobalt/Cobalt.java
@@ -11,6 +11,7 @@ import com.hartwig.pipeline.execution.vm.BashCommand;
 import com.hartwig.pipeline.execution.vm.BashStartupScript;
 import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
 import com.hartwig.pipeline.metadata.AddDatatype;
+import com.hartwig.pipeline.metadata.ArchivePath;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.EntireOutputComponent;
 import com.hartwig.pipeline.report.Folder;
@@ -62,7 +63,9 @@ public class Cobalt extends TertiaryStage<CobaltOutput> {
                 .maybeOutputDirectory(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(), true))
                 .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .addReportComponents(new EntireOutputComponent(bucket, Folder.root(), NAMESPACE, resultsDirectory))
-                .addFurtherOperations(new AddDatatype(DataType.COBALT, Folder.root(), namespace(), metadata.barcode()))
+                .addFurtherOperations(new AddDatatype(DataType.COBALT,
+                        metadata.barcode(),
+                        new ArchivePath(Folder.root(), namespace(), metadata.tumor().sampleName() + ".cobalt.ratio.tsv")))
                 .build();
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/Linx.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/Linx.java
@@ -13,6 +13,7 @@ import com.hartwig.pipeline.execution.vm.InputDownload;
 import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
 import com.hartwig.pipeline.execution.vm.VmDirectories;
 import com.hartwig.pipeline.metadata.AddDatatype;
+import com.hartwig.pipeline.metadata.ArchivePath;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.EntireOutputComponent;
 import com.hartwig.pipeline.report.Folder;
@@ -77,7 +78,9 @@ public class Linx implements Stage<LinxOutput, SomaticRunMetadata> {
                 .status(jobStatus)
                 .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .addReportComponents(new EntireOutputComponent(bucket, Folder.root(), NAMESPACE, resultsDirectory))
-                .addFurtherOperations(new AddDatatype(DataType.LINX, Folder.root(), namespace(), metadata.barcode()))
+                .addFurtherOperations(new AddDatatype(DataType.LINX,
+                        metadata.barcode(),
+                        new ArchivePath(Folder.root(), namespace(), metadata.tumor().sampleName() + ".linx.breakend.tsv")))
                 .build();
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/purple/Purple.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/purple/Purple.java
@@ -1,7 +1,5 @@
 package com.hartwig.pipeline.tertiary.purple;
 
-import static java.lang.String.format;
-
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
@@ -18,6 +16,7 @@ import com.hartwig.pipeline.execution.vm.BashStartupScript;
 import com.hartwig.pipeline.execution.vm.InputDownload;
 import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
 import com.hartwig.pipeline.metadata.AddDatatype;
+import com.hartwig.pipeline.metadata.ArchivePath;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.EntireOutputComponent;
 import com.hartwig.pipeline.report.Folder;
@@ -117,13 +116,11 @@ public class Purple implements Stage<PurpleOutput, SomaticRunMetadata> {
                 .maybeStructuralVcf(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(svVcf(metadata))))
                 .addReportComponents(new EntireOutputComponent(bucket, Folder.root(), NAMESPACE, resultsDirectory))
                 .addFurtherOperations(new AddDatatype(DataType.SOMATIC_VARIANTS_PURPLE,
-                                Folder.root(),
-                                format("%s/%s", namespace(), somaticVcf(metadata)),
-                                metadata.barcode()),
+                                metadata.barcode(),
+                                new ArchivePath(Folder.root(), namespace(), somaticVcf(metadata))),
                         new AddDatatype(DataType.STRUCTURAL_VARIANTS_PURPLE,
-                                Folder.root(),
-                                format("%s/%s", namespace(), svVcf(metadata)),
-                                metadata.barcode()))
+                                metadata.barcode(),
+                                new ArchivePath(Folder.root(), namespace(), svVcf(metadata))))
                 .build();
     }
 

--- a/cluster/src/test/java/com/hartwig/pipeline/cram/CramConversionTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/cram/CramConversionTest.java
@@ -12,6 +12,7 @@ import com.hartwig.pipeline.datatypes.DataType;
 import com.hartwig.pipeline.execution.PipelineStatus;
 import com.hartwig.pipeline.metadata.AddDatatype;
 import com.hartwig.pipeline.metadata.ApiFileOperation;
+import com.hartwig.pipeline.metadata.ArchivePath;
 import com.hartwig.pipeline.metadata.SingleSampleRunMetadata;
 import com.hartwig.pipeline.metadata.SingleSampleRunMetadata.SampleType;
 import com.hartwig.pipeline.report.Folder;
@@ -20,7 +21,7 @@ import com.hartwig.pipeline.stages.StageTest;
 import com.hartwig.pipeline.testsupport.TestInputs;
 
 public class CramConversionTest extends StageTest<CramOutput, SingleSampleRunMetadata> {
-    private static String BUCKET_NAME = "run-reference-test";
+    private static final String BUCKET_NAME = "run-reference-test";
 
     @Override
     protected Arguments createDisabledArguments() {
@@ -88,12 +89,10 @@ public class CramConversionTest extends StageTest<CramOutput, SingleSampleRunMet
     @Override
     protected List<ApiFileOperation> expectedFurtherOperations() {
         return List.of(new AddDatatype(DataType.ALIGNED_READS,
-                        Folder.from(TestInputs.referenceRunMetadata()),
-                        format("%s/%s", CramConversion.NAMESPACE, "reference.cram"),
-                        TestInputs.referenceRunMetadata().barcode()),
+                        TestInputs.referenceRunMetadata().barcode(),
+                        new ArchivePath(Folder.from(TestInputs.referenceRunMetadata()), CramConversion.NAMESPACE, "reference.cram")),
                 new AddDatatype(DataType.ALIGNED_READS_INDEX,
-                        Folder.from(TestInputs.referenceRunMetadata()),
-                        format("%s/%s", CramConversion.NAMESPACE, "reference.cram.crai"),
-                        TestInputs.referenceRunMetadata().barcode()));
+                        TestInputs.referenceRunMetadata().barcode(),
+                        new ArchivePath(Folder.from(TestInputs.referenceRunMetadata()), CramConversion.NAMESPACE, "reference.cram.crai")));
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/metadata/AddDatatypeTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/metadata/AddDatatypeTest.java
@@ -1,8 +1,5 @@
 package com.hartwig.pipeline.metadata;
 
-import static java.lang.String.format;
-
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -21,24 +18,9 @@ public class AddDatatypeTest {
         SbpRestApi api = mock(SbpRestApi.class);
         AddFileApiResponse file = mock(AddFileApiResponse.class);
         when(file.id()).thenReturn(id);
-        AddDatatype victim = new AddDatatype(DataType.ALIGNED_READS, Folder.root(), format("%s/%s", "namespace", "filename"), "barcode");
+        AddDatatype victim = new AddDatatype(DataType.ALIGNED_READS, "barcode", new ArchivePath(Folder.root(), "namespace", "filename"));
         victim.apply(api, file);
         verify(api).patchFile(id, "datatype", DataType.ALIGNED_READS.toString().toLowerCase());
         verify(api).linkFileToSample(id, "barcode");
-    }
-
-    @Test
-    public void shouldIncludeFolderNameInPathWhenItIsSet() {
-        SingleSampleRunMetadata metadata = mock(SingleSampleRunMetadata.class);
-        when(metadata.sampleName()).thenReturn("sample_name");
-        AddDatatype victim =
-                new AddDatatype(DataType.ALIGNED_READS, Folder.from(metadata), format("%s/%s", "namespace", "filename"), "barcode");
-        assertThat(victim.path()).isEqualTo("sample_name/namespace/filename");
-    }
-
-    @Test
-    public void shouldBuildPathWhenFolderHasNoName() {
-        AddDatatype victim = new AddDatatype(DataType.ALIGNED_READS, Folder.root(), "namespace", "barcode");
-        assertThat(victim.path()).isEqualTo("namespace");
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/metadata/ArchivePathTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/metadata/ArchivePathTest.java
@@ -1,0 +1,22 @@
+package com.hartwig.pipeline.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hartwig.pipeline.report.Folder;
+import com.hartwig.pipeline.testsupport.TestInputs;
+
+import org.junit.Test;
+
+public class ArchivePathTest {
+
+    @Test
+    public void pathWithRootFolder() {
+        assertThat(new ArchivePath(Folder.root(), "namespace", "filename").path()).isEqualTo("namespace/filename");
+    }
+
+    @Test
+    public void pathWithSingleSampleFolder() {
+        assertThat(new ArchivePath(Folder.from(TestInputs.referenceRunMetadata()), "namespace", "filename").path()).isEqualTo(
+                "reference/namespace/filename");
+    }
+}

--- a/cluster/src/test/java/com/hartwig/pipeline/metrics/BamMetricsTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/metrics/BamMetricsTest.java
@@ -1,7 +1,5 @@
 package com.hartwig.pipeline.metrics;
 
-import static java.lang.String.format;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
@@ -11,6 +9,7 @@ import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.datatypes.DataType;
 import com.hartwig.pipeline.metadata.AddDatatype;
 import com.hartwig.pipeline.metadata.ApiFileOperation;
+import com.hartwig.pipeline.metadata.ArchivePath;
 import com.hartwig.pipeline.metadata.SingleSampleRunMetadata;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.stages.Stage;
@@ -91,8 +90,7 @@ public class BamMetricsTest extends StageTest<BamMetricsOutput, SingleSampleRunM
     @Override
     protected List<ApiFileOperation> expectedFurtherOperations() {
         return List.of(new AddDatatype(DataType.WGSMETRICS,
-                Folder.from(TestInputs.referenceRunMetadata()),
-                format("%s/%s", BamMetrics.NAMESPACE, "reference.wgsmetrics"),
-                TestInputs.referenceRunMetadata().barcode()));
+                TestInputs.referenceRunMetadata().barcode(),
+                new ArchivePath(Folder.from(TestInputs.referenceRunMetadata()), BamMetrics.NAMESPACE, "reference.wgsmetrics")));
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/amber/AmberTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/amber/AmberTest.java
@@ -1,7 +1,5 @@
 package com.hartwig.pipeline.tertiary.amber;
 
-import static java.lang.String.format;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
@@ -9,6 +7,7 @@ import java.util.List;
 import com.hartwig.pipeline.datatypes.DataType;
 import com.hartwig.pipeline.metadata.AddDatatype;
 import com.hartwig.pipeline.metadata.ApiFileOperation;
+import com.hartwig.pipeline.metadata.ArchivePath;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.stages.Stage;
@@ -34,11 +33,12 @@ public class AmberTest extends TertiaryStageTest<AmberOutput> {
     protected List<ApiFileOperation> expectedFurtherOperations() {
         String basenameSnpcheck = TestInputs.REG_GENOME_37_RESOURCE_FILES.amberSnpcheck()
                 .substring(TestInputs.REG_GENOME_37_RESOURCE_FILES.amberSnpcheck().lastIndexOf("/") + 1);
-        return List.of(new AddDatatype(DataType.AMBER, Folder.root(), Amber.NAMESPACE, TestInputs.defaultSomaticRunMetadata().barcode()),
+        return List.of(new AddDatatype(DataType.AMBER,
+                        TestInputs.defaultSomaticRunMetadata().barcode(),
+                        new ArchivePath(Folder.root(), Amber.NAMESPACE, "tumor.amber.baf.tsv")),
                 new AddDatatype(DataType.AMBER_SNPCHECK,
-                        Folder.root(),
-                        format("%s/%s", Amber.NAMESPACE, basenameSnpcheck),
-                        TestInputs.defaultSomaticRunMetadata().barcode()));
+                        TestInputs.defaultSomaticRunMetadata().barcode(),
+                        new ArchivePath(Folder.root(), Amber.NAMESPACE, basenameSnpcheck)));
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/bachelor/BachelorTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/bachelor/BachelorTest.java
@@ -10,6 +10,7 @@ import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.datatypes.DataType;
 import com.hartwig.pipeline.metadata.AddDatatype;
 import com.hartwig.pipeline.metadata.ApiFileOperation;
+import com.hartwig.pipeline.metadata.ArchivePath;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.stages.Stage;
@@ -29,7 +30,10 @@ public class BachelorTest extends TertiaryStageTest<BachelorOutput> {
 
     @Override
     protected Stage<BachelorOutput, SomaticRunMetadata> createVictim() {
-        return new Bachelor(TestInputs.REG_GENOME_37_RESOURCE_FILES, TestInputs.purpleOutput(), TestInputs.tumorAlignmentOutput(), TestInputs.germlineCallerOutput());
+        return new Bachelor(TestInputs.REG_GENOME_37_RESOURCE_FILES,
+                TestInputs.purpleOutput(),
+                TestInputs.tumorAlignmentOutput(),
+                TestInputs.germlineCallerOutput());
     }
 
     @Override
@@ -53,9 +57,8 @@ public class BachelorTest extends TertiaryStageTest<BachelorOutput> {
     @Override
     protected List<ApiFileOperation> expectedFurtherOperations() {
         return List.of(new AddDatatype(DataType.BACHELOR,
-                Folder.root(),
-                Bachelor.NAMESPACE,
-                TestInputs.defaultSomaticRunMetadata().barcode()));
+                TestInputs.defaultSomaticRunMetadata().barcode(),
+                new ArchivePath(Folder.root(), Bachelor.NAMESPACE, "tumor.bachelor.germline_variant.tsv")));
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/chord/ChordTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/chord/ChordTest.java
@@ -1,7 +1,5 @@
 package com.hartwig.pipeline.tertiary.chord;
 
-import static java.lang.String.format;
-
 import java.util.Collections;
 import java.util.List;
 
@@ -9,6 +7,7 @@ import com.google.common.collect.ImmutableList;
 import com.hartwig.pipeline.datatypes.DataType;
 import com.hartwig.pipeline.metadata.AddDatatype;
 import com.hartwig.pipeline.metadata.ApiFileOperation;
+import com.hartwig.pipeline.metadata.ArchivePath;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.resource.RefGenomeVersion;
@@ -48,8 +47,7 @@ public class ChordTest extends TertiaryStageTest<ChordOutput> {
     @Override
     protected List<ApiFileOperation> expectedFurtherOperations() {
         return List.of(new AddDatatype(DataType.CHORD_PREDICTION,
-                Folder.root(),
-                format("%s/%s", Chord.NAMESPACE, "tumor_chord_prediction.txt"),
-                TestInputs.defaultSomaticRunMetadata().barcode()));
+                TestInputs.defaultSomaticRunMetadata().barcode(),
+                new ArchivePath(Folder.root(), Chord.NAMESPACE, "tumor_chord_prediction.txt")));
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/cobalt/CobaltTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/cobalt/CobaltTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import com.hartwig.pipeline.datatypes.DataType;
 import com.hartwig.pipeline.metadata.AddDatatype;
 import com.hartwig.pipeline.metadata.ApiFileOperation;
+import com.hartwig.pipeline.metadata.ArchivePath;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.stages.Stage;
@@ -52,7 +53,9 @@ public class CobaltTest extends TertiaryStageTest<CobaltOutput> {
 
     @Override
     protected List<ApiFileOperation> expectedFurtherOperations() {
-        return List.of(new AddDatatype(DataType.COBALT, Folder.root(), Cobalt.NAMESPACE, TestInputs.defaultSomaticRunMetadata().barcode()));
+        return List.of(new AddDatatype(DataType.COBALT,
+                TestInputs.defaultSomaticRunMetadata().barcode(),
+                new ArchivePath(Folder.root(), Cobalt.NAMESPACE, "tumor.cobalt.ratio.tsv")));
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/linx/LinxTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/linx/LinxTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.hartwig.pipeline.datatypes.DataType;
 import com.hartwig.pipeline.metadata.AddDatatype;
 import com.hartwig.pipeline.metadata.ApiFileOperation;
+import com.hartwig.pipeline.metadata.ArchivePath;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.stages.Stage;
@@ -48,7 +49,9 @@ public class LinxTest extends TertiaryStageTest<LinxOutput> {
 
     @Override
     protected List<ApiFileOperation> expectedFurtherOperations() {
-        return List.of(new AddDatatype(DataType.LINX, Folder.root(), Linx.NAMESPACE, TestInputs.defaultSomaticRunMetadata().barcode()));
+        return List.of(new AddDatatype(DataType.LINX,
+                TestInputs.defaultSomaticRunMetadata().barcode(),
+                new ArchivePath(Folder.root(), Linx.NAMESPACE, "tumor.linx.breakend.tsv")));
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/purple/PurpleTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/purple/PurpleTest.java
@@ -1,7 +1,5 @@
 package com.hartwig.pipeline.tertiary.purple;
 
-import static java.lang.String.format;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
@@ -11,6 +9,7 @@ import com.google.common.collect.ImmutableList;
 import com.hartwig.pipeline.datatypes.DataType;
 import com.hartwig.pipeline.metadata.AddDatatype;
 import com.hartwig.pipeline.metadata.ApiFileOperation;
+import com.hartwig.pipeline.metadata.ArchivePath;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.reruns.NoopPersistedDataset;
@@ -52,8 +51,7 @@ public class PurpleTest extends TertiaryStageTest<PurpleOutput> {
 
     @Override
     protected List<String> expectedInputs() {
-        return ImmutableList.of(
-                input(expectedRuntimeBucketName() + "/sage_somatic/results/tumor.somatic.vcf.gz", "tumor.somatic.vcf.gz"),
+        return ImmutableList.of(input(expectedRuntimeBucketName() + "/sage_somatic/results/tumor.somatic.vcf.gz", "tumor.somatic.vcf.gz"),
                 input(expectedRuntimeBucketName() + "/sage_germline/results/tumor.germline.vcf.gz", "tumor.germline.vcf.gz"),
                 input(expectedRuntimeBucketName() + "/gripss/results/tumor.gripss.filtered.vcf.gz", "tumor.gripss.filtered.vcf.gz"),
                 input(expectedRuntimeBucketName() + "/gripss/results/tumor.gripss.filtered.vcf.gz.tbi", "tumor.gripss.filtered.vcf.gz.tbi"),
@@ -65,16 +63,15 @@ public class PurpleTest extends TertiaryStageTest<PurpleOutput> {
 
     @Override
     protected List<String> expectedCommands() {
-        return Collections.singletonList(
-                "java -Xmx12G -jar /opt/tools/purple/2.52/purple.jar "
-                        + "-reference reference -germline_vcf /data/input/tumor.germline.vcf.gz -germline_hotspots /opt/resources/sage/37/KnownHotspots.germline.hg19.vcf.gz "
-                        + "-tumor tumor -output_dir /data/output -amber /data/input/results -cobalt /data/input/results -gc_profile /opt/resources/gc/37/GC_profile.1000bp.cnp "
-                        + "-somatic_vcf /data/input/tumor.somatic.vcf.gz -structural_vcf /data/input/tumor.gripss.filtered.vcf.gz "
-                        + "-sv_recovery_vcf /data/input/tumor.gripss.full.vcf.gz -circos /opt/tools/circos/0.69.6/bin/circos "
-                        + "-ref_genome /opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta "
-                        + "-driver_catalog -somatic_hotspots /opt/resources/sage/37/KnownHotspots.somatic.hg19.vcf.gz "
-                        + "-driver_gene_panel /opt/resources/gene_panel/37/DriverGenePanel.hg19.tsv "
-                        + "-threads $(grep -c '^processor' /proc/cpuinfo)");
+        return Collections.singletonList("java -Xmx12G -jar /opt/tools/purple/2.52/purple.jar "
+                + "-reference reference -germline_vcf /data/input/tumor.germline.vcf.gz -germline_hotspots /opt/resources/sage/37/KnownHotspots.germline.hg19.vcf.gz "
+                + "-tumor tumor -output_dir /data/output -amber /data/input/results -cobalt /data/input/results -gc_profile /opt/resources/gc/37/GC_profile.1000bp.cnp "
+                + "-somatic_vcf /data/input/tumor.somatic.vcf.gz -structural_vcf /data/input/tumor.gripss.filtered.vcf.gz "
+                + "-sv_recovery_vcf /data/input/tumor.gripss.full.vcf.gz -circos /opt/tools/circos/0.69.6/bin/circos "
+                + "-ref_genome /opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta "
+                + "-driver_catalog -somatic_hotspots /opt/resources/sage/37/KnownHotspots.somatic.hg19.vcf.gz "
+                + "-driver_gene_panel /opt/resources/gene_panel/37/DriverGenePanel.hg19.tsv "
+                + "-threads $(grep -c '^processor' /proc/cpuinfo)");
     }
 
     @Test
@@ -127,12 +124,10 @@ public class PurpleTest extends TertiaryStageTest<PurpleOutput> {
     @Override
     protected List<ApiFileOperation> expectedFurtherOperations() {
         return List.of(new AddDatatype(DataType.SOMATIC_VARIANTS_PURPLE,
-                        Folder.root(),
-                        format("%s/%s", "purple", TUMOR_PURPLE_SOMATIC_VCF_GZ),
-                        TestInputs.defaultSomaticRunMetadata().barcode()),
+                        TestInputs.defaultSomaticRunMetadata().barcode(),
+                        new ArchivePath(Folder.root(), Purple.NAMESPACE, TUMOR_PURPLE_SOMATIC_VCF_GZ)),
                 new AddDatatype(DataType.STRUCTURAL_VARIANTS_PURPLE,
-                        Folder.root(),
-                        format("%s/%s", "purple", TUMOR_PURPLE_SV_VCF_GZ),
-                        TestInputs.defaultSomaticRunMetadata().barcode()));
+                        TestInputs.defaultSomaticRunMetadata().barcode(),
+                        new ArchivePath(Folder.root(), Purple.NAMESPACE, TUMOR_PURPLE_SV_VCF_GZ)));
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/transfer/SbpFileApiUpdateTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/transfer/SbpFileApiUpdateTest.java
@@ -1,7 +1,5 @@
 package com.hartwig.pipeline.transfer;
 
-import static java.lang.String.format;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -15,6 +13,7 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Bucket;
 import com.hartwig.pipeline.datatypes.DataType;
 import com.hartwig.pipeline.metadata.AddDatatype;
+import com.hartwig.pipeline.metadata.ArchivePath;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.sbpapi.AddFileApiResponse;
 import com.hartwig.pipeline.sbpapi.SbpFileMetadata;
@@ -47,7 +46,7 @@ public class SbpFileApiUpdateTest {
                 run,
                 sourceBucket,
                 sbpRestApi,
-                Set.of(new AddDatatype(DataType.AMBER, Folder.root(), format("%s/%s", "namespace", "blob"), "barcode")));
+                Set.of(new AddDatatype(DataType.AMBER, "barcode", new ArchivePath(Folder.root(), "namespace", "blob"))));
     }
 
     @Test


### PR DESCRIPTION
Extracted the path creation logic into a simple path class to remove some duplication and make it
a little clearer what AddDatatype accepts.

Otherwise linx we use the first of the tsvs in alphabetical order, and bachelor we use the germline
variant tsv as that is where the "main" data resides.