### PR TITLE
DEV-1798 Support HG38 Amber PON after all

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/resource/RefGenome38ResourceFiles.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/resource/RefGenome38ResourceFiles.java
@@ -49,7 +49,7 @@ public class RefGenome38ResourceFiles implements ResourceFiles {
 
     @Override
     public String amberSnpcheck() {
-        throw new UnsupportedOperationException("No hg38 version available");
+        return formPath(AMBER, "Amber.snpcheck.hg38.vcf");
     }
 
     @Override


### PR DESCRIPTION
The resources now contain a VCF so that the pipeline run will finish
if done under HG38. That VCF is currently a husk with no actual data in
it so the subsequent patient DB load will not actually put anything into
the database, however this will be resolved when a proper VCF for 38 is
available.