### PR TITLE
DEV-1881 Convert crams to bams if used for downstream algos

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/AlignmentOutput.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/AlignmentOutput.java
@@ -13,6 +13,7 @@ public interface AlignmentOutput extends StageOutput {
 
     String sample();
 
+    @Value.Default
     default String name() {
         return Aligner.NAMESPACE;
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/cram/CramConversion.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/cram/CramConversion.java
@@ -36,7 +36,7 @@ public class CramConversion implements Stage<CramOutput, SingleSampleRunMetadata
 
     private final InputDownload bamDownload;
     private final String outputCram;
-    private SampleType sampleType;
+    private final SampleType sampleType;
     private final ResourceFiles resourceFiles;
 
     public CramConversion(final AlignmentOutput alignmentOutput, final SampleType sampleType, ResourceFiles resourceFiles) {

--- a/cluster/src/main/java/com/hartwig/pipeline/cram2bam/Cram2Bam.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/cram2bam/Cram2Bam.java
@@ -1,0 +1,85 @@
+package com.hartwig.pipeline.cram2bam;
+
+import java.util.List;
+
+import com.hartwig.pipeline.Arguments;
+import com.hartwig.pipeline.ResultsDirectory;
+import com.hartwig.pipeline.alignment.AlignmentOutput;
+import com.hartwig.pipeline.calling.command.SamtoolsCommand;
+import com.hartwig.pipeline.datatypes.FileTypes;
+import com.hartwig.pipeline.execution.PipelineStatus;
+import com.hartwig.pipeline.execution.vm.Bash;
+import com.hartwig.pipeline.execution.vm.BashCommand;
+import com.hartwig.pipeline.execution.vm.BashStartupScript;
+import com.hartwig.pipeline.execution.vm.InputDownload;
+import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
+import com.hartwig.pipeline.execution.vm.VirtualMachinePerformanceProfile;
+import com.hartwig.pipeline.execution.vm.VmDirectories;
+import com.hartwig.pipeline.metadata.SingleSampleRunMetadata;
+import com.hartwig.pipeline.report.RunLogComponent;
+import com.hartwig.pipeline.stages.Stage;
+import com.hartwig.pipeline.storage.GoogleStorageLocation;
+import com.hartwig.pipeline.storage.RuntimeBucket;
+
+public class Cram2Bam implements Stage<AlignmentOutput, SingleSampleRunMetadata> {
+
+    private final InputDownload bamDownload;
+    private final SingleSampleRunMetadata.SampleType sampleType;
+
+    public Cram2Bam(final GoogleStorageLocation bamLocation, final SingleSampleRunMetadata.SampleType sampleType) {
+        this.bamDownload = new InputDownload(bamLocation);
+        this.sampleType = sampleType;
+    }
+
+    @Override
+    public List<BashCommand> inputs() {
+        return List.of(bamDownload);
+    }
+
+    @Override
+    public String namespace() {
+        return "cram2bam";
+    }
+
+    @Override
+    public List<BashCommand> commands(final SingleSampleRunMetadata metadata) {
+        String outputBam = VmDirectories.OUTPUT + "/" + FileTypes.bam(metadata.sampleName());
+        return List.of(new SamtoolsCommand("view", "-O", "bam", "-o", outputBam, "-@", Bash.allCpus(), bamDownload.getLocalTargetPath()),
+                new SamtoolsCommand("index", outputBam));
+    }
+
+    @Override
+    public VirtualMachineJobDefinition vmDefinition(final BashStartupScript bash, final ResultsDirectory resultsDirectory) {
+        return VirtualMachineJobDefinition.builder()
+                .workingDiskSpaceGb(sampleType.equals(SingleSampleRunMetadata.SampleType.REFERENCE) ? 650 : 950)
+                .performanceProfile(VirtualMachinePerformanceProfile.custom(6, 6))
+                .startupCommand(bash)
+                .namespacedResults(resultsDirectory)
+                .name(namespace())
+                .build();
+    }
+
+    @Override
+    public AlignmentOutput output(final SingleSampleRunMetadata metadata, final PipelineStatus jobStatus, final RuntimeBucket bucket,
+            final ResultsDirectory resultsDirectory) {
+        String bam = FileTypes.bam(metadata.sampleName());
+        return AlignmentOutput.builder()
+                .name(namespace())
+                .status(jobStatus)
+                .sample(metadata.sampleName())
+                .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
+                .maybeFinalBamLocation(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(bam)))
+                .maybeFinalBaiLocation(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(FileTypes.bai(bam))))
+                .build();
+    }
+
+    @Override
+    public AlignmentOutput skippedOutput(final SingleSampleRunMetadata metadata) {
+        return AlignmentOutput.builder().status(PipelineStatus.SKIPPED).build();
+    }
+
+    @Override
+    public boolean shouldRun(final Arguments arguments) {
+        return true;
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/datatypes/FileTypes.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/datatypes/FileTypes.java
@@ -9,6 +9,7 @@ public class FileTypes {
     public static final String TBI = ".tbi";
     public static final String BAI = ".bai";
     public static final String CRAI = ".crai";
+    public static final String CRAM = ".cram";
 
     public static String tabixIndex(final String vcf) {
         return vcf + TBI;
@@ -19,7 +20,7 @@ public class FileTypes {
     }
 
     public static String cram(final String sample) {
-        return sample + ".cram";
+        return sample + CRAM;
     }
 
     public static String crai(final String cram) {

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngine.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngine.java
@@ -134,7 +134,8 @@ public class GoogleComputeEngine implements ComputeEngine {
                         currentZone.getName(),
                         arguments.imageName().isPresent()
                                 ? compute.images()
-                                .get(VirtualMachineJobDefinition.HMF_IMAGE_PROJECT, arguments.imageName().get())
+                                .get(arguments.imageProject().orElse(VirtualMachineJobDefinition.HMF_IMAGE_PROJECT),
+                                        arguments.imageName().get())
                                 .execute()
                                 : resolveLatestImage(compute, jobDefinition.imageFamily(), arguments.imageProject().orElse(project)));
                 LOGGER.info("Submitting compute engine job [{}] using image [{}] in zone [{}]",

--- a/cluster/src/main/java/com/hartwig/pipeline/reruns/StartingPoint.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/reruns/StartingPoint.java
@@ -19,6 +19,8 @@ import com.hartwig.pipeline.flagstat.Flagstat;
 import com.hartwig.pipeline.metrics.BamMetrics;
 import com.hartwig.pipeline.snpgenotype.SnpGenotype;
 import com.hartwig.pipeline.tertiary.amber.Amber;
+import com.hartwig.pipeline.tertiary.bachelor.Bachelor;
+import com.hartwig.pipeline.tertiary.chord.Chord;
 import com.hartwig.pipeline.tertiary.cobalt.Cobalt;
 import com.hartwig.pipeline.tertiary.purple.Purple;
 
@@ -43,7 +45,16 @@ public class StartingPoint {
                         Amber.NAMESPACE,
                         SageGermlineCaller.NAMESPACE))),
         GRIPSS_COMPLETE(concat(CALLING_COMPLETE.namespaces, List.of(StructuralCallerPostProcess.NAMESPACE))),
-        PURPLE_COMPLETE(concat(GRIPSS_COMPLETE.namespaces, List.of(Purple.NAMESPACE)));
+        PURPLE_COMPLETE(concat(GRIPSS_COMPLETE.namespaces, List.of(Purple.NAMESPACE))),
+
+        RERUN_521(concat(ALIGNMENT_COMPLETE.namespaces,
+                List.of(SageSomaticCaller.NAMESPACE,
+                        StructuralCaller.NAMESPACE,
+                        StructuralCallerPostProcess.NAMESPACE,
+                        Cobalt.NAMESPACE,
+                        Amber.NAMESPACE,
+                        Chord.NAMESPACE,
+                        Bachelor.NAMESPACE)));
 
         private final List<String> namespaces;
 

--- a/cluster/src/test/java/com/hartwig/pipeline/cram2bam/Cram2BamTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/cram2bam/Cram2BamTest.java
@@ -1,0 +1,60 @@
+package com.hartwig.pipeline.cram2bam;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import com.hartwig.pipeline.Arguments;
+import com.hartwig.pipeline.alignment.AlignmentOutput;
+import com.hartwig.pipeline.datatypes.FileTypes;
+import com.hartwig.pipeline.metadata.SingleSampleRunMetadata;
+import com.hartwig.pipeline.stages.Stage;
+import com.hartwig.pipeline.stages.StageTest;
+import com.hartwig.pipeline.storage.GoogleStorageLocation;
+import com.hartwig.pipeline.testsupport.TestInputs;
+
+public class Cram2BamTest extends StageTest<AlignmentOutput, SingleSampleRunMetadata> {
+
+    @Override
+    protected Arguments createDisabledArguments() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void disabledAppropriately() {
+        assertThat(true).isTrue();
+    }
+
+    @Override
+    protected Stage<AlignmentOutput, SingleSampleRunMetadata> createVictim() {
+        return new Cram2Bam(GoogleStorageLocation.of(TestInputs.BUCKET, FileTypes.bam(TestInputs.tumorSample())),
+                SingleSampleRunMetadata.SampleType.TUMOR);
+    }
+
+    @Override
+    protected SingleSampleRunMetadata input() {
+        return TestInputs.tumorRunMetadata();
+    }
+
+    @Override
+    protected List<String> expectedInputs() {
+        return List.of(input("bucket/tumor.bam", "tumor.bam"));
+    }
+
+    @Override
+    protected String expectedRuntimeBucketName() {
+        return "run-tumor-test";
+    }
+
+    @Override
+    protected List<String> expectedCommands() {
+        return List.of("/opt/tools/samtools/1.10/samtools view -O bam -o /data/output/tumor.bam -@ $(grep -c '^processor' /proc/cpuinfo) "
+                + "/data/input/tumor.bam", "/opt/tools/samtools/1.10/samtools index /data/output/tumor.bam");
+    }
+
+    @Override
+    protected void validateOutput(final AlignmentOutput output) {
+        assertThat(output.finalBamLocation()).isEqualTo(GoogleStorageLocation.of("run-tumor-test/cram2bam", "results/tumor.bam"));
+        assertThat(output.finalBaiLocation()).isEqualTo(GoogleStorageLocation.of("run-tumor-test/cram2bam", "results/tumor.bam.bai"));
+    }
+}


### PR DESCRIPTION
Adds an optional stage between the aligner and other tools which will convert any alignment with the
extension .cram back to .bam and use that downstream.