### PR TITLE
DEV-1965 Publish output target with stage events

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/ResearchMetadataApi.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/ResearchMetadataApi.java
@@ -16,7 +16,7 @@ import com.hartwig.pipeline.transfer.staged.StagedOutputPublisher;
 
 import org.jetbrains.annotations.NotNull;
 
-public class BiopsyMetadataApi implements SomaticMetadataApi {
+public class ResearchMetadataApi implements SomaticMetadataApi {
 
     private final SampleApi sampleApi;
     private final SetApi setApi;
@@ -24,7 +24,7 @@ public class BiopsyMetadataApi implements SomaticMetadataApi {
     private final Arguments arguments;
     private final StagedOutputPublisher stagedOutput;
 
-    public BiopsyMetadataApi(final SampleApi sampleApi, final SetApi setApi, final String biopsyName, final Arguments arguments,
+    public ResearchMetadataApi(final SampleApi sampleApi, final SetApi setApi, final String biopsyName, final Arguments arguments,
             final StagedOutputPublisher stagedOutput) {
         this.sampleApi = sampleApi;
         this.setApi = setApi;

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/SomaticMetadataApiProvider.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/SomaticMetadataApiProvider.java
@@ -8,6 +8,7 @@ import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.hartwig.api.HmfApi;
 import com.hartwig.api.model.Run;
+import com.hartwig.events.PipelineStaged;
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.alignment.sample.JsonSampleSource;
 import com.hartwig.pipeline.jackson.ObjectMappers;
@@ -33,8 +34,8 @@ public class SomaticMetadataApiProvider {
 
     public SomaticMetadataApi get() {
         return arguments.sbpApiRunId()
-                .map(this::productionStyleRun)
-                .orElseGet(() -> arguments.biopsy().map(this::biopsyBasedRerun).orElseGet(localRun()));
+                .map(this::clinicalRun)
+                .orElseGet(() -> arguments.biopsy().map(this::researchRun).orElseGet(localRun()));
     }
 
     @NotNull
@@ -45,18 +46,23 @@ public class SomaticMetadataApiProvider {
                         .orElseThrow(() -> new IllegalArgumentException("Sample JSON must be provided when running in local mode")));
     }
 
-    public SomaticMetadataApi biopsyBasedRerun(final String biopsyName) {
+    public SomaticMetadataApi researchRun(final String biopsyName) {
         HmfApi api = HmfApi.create(arguments.sbpApiUrl());
         Bucket sourceBucket = storage.get(arguments.outputBucket());
         ObjectMapper objectMapper = ObjectMappers.get();
-        return new BiopsyMetadataApi(api.samples(),
+        return new ResearchMetadataApi(api.samples(),
                 api.sets(),
                 biopsyName,
                 arguments,
-                new StagedOutputPublisher(api.sets(), sourceBucket, publisher, objectMapper, new Run()));
+                new StagedOutputPublisher(api.sets(),
+                        sourceBucket,
+                        publisher,
+                        objectMapper,
+                        new Run(),
+                        PipelineStaged.OutputTarget.DATABASE));
     }
 
-    public SomaticMetadataApi productionStyleRun(final Integer setId) {
+    public SomaticMetadataApi clinicalRun(final Integer setId) {
         HmfApi api = HmfApi.create(arguments.sbpApiUrl());
         Bucket sourceBucket = storage.get(arguments.outputBucket());
         ObjectMapper objectMapper = ObjectMappers.get();
@@ -64,6 +70,11 @@ public class SomaticMetadataApiProvider {
         return new ClinicalSomaticMetadataApi(run,
                 api.runs(),
                 api.samples(),
-                new StagedOutputPublisher(api.sets(), sourceBucket, publisher, objectMapper, run));
+                new StagedOutputPublisher(api.sets(),
+                        sourceBucket,
+                        publisher,
+                        objectMapper,
+                        run,
+                        PipelineStaged.OutputTarget.PATIENT_REPORT));
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/transfer/staged/StagedOutputPublisher.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/transfer/staged/StagedOutputPublisher.java
@@ -38,14 +38,16 @@ public class StagedOutputPublisher {
     private final Publisher publisher;
     private final ObjectMapper objectMapper;
     private final Run run;
+    private final PipelineStaged.OutputTarget target;
 
     public StagedOutputPublisher(final SetApi setApi, final Bucket sourceBucket, final Publisher publisher, final ObjectMapper objectMapper,
-            final Run run) {
+            final Run run, final PipelineStaged.OutputTarget target) {
         this.setApi = setApi;
         this.sourceBucket = sourceBucket;
         this.publisher = publisher;
         this.objectMapper = objectMapper;
         this.run = run;
+        this.target = target;
     }
 
     public void publish(final PipelineState state, final SomaticRunMetadata metadata) {
@@ -107,6 +109,7 @@ public class StagedOutputPublisher {
         return ImmutablePipelineStaged.builder()
                 .type(PipelineStaged.Type.DNA)
                 .analysis(secondary)
+                .target(target)
                 .version(Versions.pipelineMajorMinorVersion())
                 .sample(metadata.tumor().sampleName())
                 .runId(Optional.ofNullable(run.getId()))

--- a/cluster/src/test/java/com/hartwig/pipeline/metadata/ResearchMetadataApiTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/metadata/ResearchMetadataApiTest.java
@@ -43,7 +43,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
-public class BiopsyMetadataApiTest {
+public class ResearchMetadataApiTest {
 
     private static final String BIOPSY = "biopsy";
     private static final String TUMOR_NAME = "tumor";
@@ -54,7 +54,7 @@ public class BiopsyMetadataApiTest {
     public static final String SET_NAME = TestInputs.defaultSomaticRunMetadata().set();
     public static final long SET_ID = 3L;
     public static final long REF_SAMPLE_ID = 4L;
-    private BiopsyMetadataApi victim;
+    private ResearchMetadataApi victim;
     private SampleApi sampleApi;
     private SetApi setApi;
     private Bucket bucket;
@@ -67,11 +67,11 @@ public class BiopsyMetadataApiTest {
         bucket = mock(Bucket.class);
         publisher = mock(Publisher.class);
         ObjectMapper objectMapper = ObjectMappers.get();
-        victim = new BiopsyMetadataApi(sampleApi,
+        victim = new ResearchMetadataApi(sampleApi,
                 setApi,
                 BIOPSY,
                 Arguments.testDefaults(),
-                new StagedOutputPublisher(setApi, bucket, publisher, objectMapper, new Run()));
+                new StagedOutputPublisher(setApi, bucket, publisher, objectMapper, new Run(), PipelineStaged.OutputTarget.DATABASE));
     }
 
     @Test(expected = IllegalStateException.class)

--- a/cluster/src/test/java/com/hartwig/pipeline/transfer/staged/StagedOutputPublisherTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/transfer/staged/StagedOutputPublisherTest.java
@@ -51,7 +51,12 @@ public class StagedOutputPublisherTest {
         bucket = mock(Bucket.class);
         publisher = mock(Publisher.class);
         state = mock(PipelineState.class);
-        victim = new StagedOutputPublisher(setApi, bucket, publisher, OBJECT_MAPPER, new Run().ini(Ini.SOMATIC_INI.getValue()));
+        victim = new StagedOutputPublisher(setApi,
+                bucket,
+                publisher,
+                OBJECT_MAPPER,
+                new Run().ini(Ini.SOMATIC_INI.getValue()),
+                PipelineStaged.OutputTarget.PATIENT_REPORT);
     }
 
     @Test
@@ -85,8 +90,13 @@ public class StagedOutputPublisherTest {
     }
 
     @Test
-    public void publishesDnaShallowAnalysisOnRunWithShallowSeqIni() throws Exception{
-        victim = new StagedOutputPublisher(setApi, bucket, publisher, OBJECT_MAPPER, new Run().ini(Ini.SHALLOWSEQ_INI.getValue()));
+    public void publishesDnaShallowAnalysisOnRunWithShallowSeqIni() throws Exception {
+        victim = new StagedOutputPublisher(setApi,
+                bucket,
+                publisher,
+                OBJECT_MAPPER,
+                new Run().ini(Ini.SHALLOWSEQ_INI.getValue()),
+                PipelineStaged.OutputTarget.PATIENT_REPORT);
         when(state.status()).thenReturn(PipelineStatus.SUCCESS);
         Blob vcf = withBucketAndMd5(blob("/sage/" + TestInputs.tumorSample() + ".vcf"));
         Blob cram = withBucketAndMd5(blob(TestInputs.tumorSample() + "/aligner/" + TestInputs.tumorSample() + ".cram"));
@@ -113,6 +123,7 @@ public class StagedOutputPublisherTest {
 
         PipelineStaged result =
                 OBJECT_MAPPER.readValue(new String(messageArgumentCaptor.getValue().getData().toByteArray()), PipelineStaged.class);
+        assertThat(result.target()).isEqualTo(PipelineStaged.OutputTarget.PATIENT_REPORT);
         assertThat(result.analysis()).isEqualTo(PipelineStaged.Analysis.SECONDARY);
         assertThat(result.blobs()).hasSize(4);
         assertThat(result.blobs()).extracting(PipelineOutputBlob::filename)

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <htsjdk.version>2.22.0</htsjdk.version>
         <org-reflections.version>0.9.11</org-reflections.version>
         <google-api-services-serviceusage.version>v1beta1-rev20200804-1.30.10</google-api-services-serviceusage.version>
-        <pipeline-events.version>1.1.8</pipeline-events.version>
+        <pipeline-events.version>1.1.10</pipeline-events.version>
         <java-client.version>1.1.23</java-client.version>
     </properties>
 


### PR DESCRIPTION
Depending on the context. The clinical API publishes the "patient report" target and the research api
publishes the "database" target.