### PR TITLE
DEV-1966 Add option to anonymize with barcodes

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
@@ -93,6 +93,8 @@ public interface Arguments extends CommonArguments {
 
     boolean useCrams();
 
+    boolean anonymize();
+
     static String workingDir() {
         return System.getProperty("user.dir");
     }
@@ -156,7 +158,8 @@ public interface Arguments extends CommonArguments {
                     .pollInterval(DEFAULT_POLL_INTERVAL)
                     .refGenomeVersion(DEFAULT_REF_GENOME_VERSION)
                     .maxConcurrentLanes(DEFAULT_MAX_CONCURRENT_LANES)
-                    .useCrams(false);
+                    .useCrams(false)
+                    .anonymize(false);
         } else if (profile.equals(DefaultsProfile.DEVELOPMENT)) {
             return ImmutableArguments.builder()
                     .profile(profile)
@@ -190,7 +193,8 @@ public interface Arguments extends CommonArguments {
                     .maxConcurrentLanes(DEFAULT_MAX_CONCURRENT_LANES)
                     .network(DEFAULT_NETWORK)
                     .useLocalSsds(true)
-                    .useCrams(false);
+                    .useCrams(false)
+                    .anonymize(false);
         } else if (profile.equals(DefaultsProfile.DEVELOPMENT_DOCKER)) {
             return ImmutableArguments.builder()
                     .profile(profile)
@@ -224,7 +228,8 @@ public interface Arguments extends CommonArguments {
                     .pollInterval(DEFAULT_POLL_INTERVAL)
                     .refGenomeVersion(DEFAULT_REF_GENOME_VERSION)
                     .maxConcurrentLanes(DEFAULT_MAX_CONCURRENT_LANES)
-                    .useCrams(false);
+                    .useCrams(false)
+                    .anonymize(false);
         } else if (profile.equals(DefaultsProfile.PUBLIC)) {
             return ImmutableArguments.builder()
                     .profile(profile)
@@ -258,7 +263,8 @@ public interface Arguments extends CommonArguments {
                     .refGenomeVersion(RefGenomeVersion.V38)
                     .maxConcurrentLanes(DEFAULT_MAX_CONCURRENT_LANES)
                     .imageName(VirtualMachineJobDefinition.PUBLIC_IMAGE_NAME)
-                    .useCrams(false);
+                    .useCrams(false)
+                    .anonymize(false);
         }
         throw new IllegalArgumentException(String.format("Unknown profile [%s], please create defaults for this profile.", profile));
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
@@ -74,6 +74,7 @@ public class CommandLineOptions {
     private static final String IMAGE_PROJECT_FLAG = "image_project";
     private static final String USE_CRAMS_FLAG = "use_crams";
     private static final String PUBSUB_PROJECT_FLAG = "pubsub_project";
+    private static final String ANONYMIZE_FLAG = "anonymize";
 
     private static Options options() {
         return new Options().addOption(profile())
@@ -134,7 +135,12 @@ public class CommandLineOptions {
                 .addOption(biopsy())
                 .addOption(imageProject())
                 .addOption(useCrams())
-                .addOption(pubsubProject());
+                .addOption(pubsubProject())
+                .addOption(anonymize());
+    }
+
+    private static Option anonymize() {
+        return optionWithArg(ANONYMIZE_FLAG, "Use barcodes instead of sample names in files, headers and annotations");
     }
 
     private static Option pubsubProject() {
@@ -343,6 +349,7 @@ public class CommandLineOptions {
                     .imageProject(imageProject(commandLine, defaults))
                     .useCrams(booleanOptionWithDefault(commandLine, USE_CRAMS_FLAG, defaults.useCrams()))
                     .pubsubProject(pubsubProject(commandLine, defaults))
+                    .anonymize(booleanOptionWithDefault(commandLine, ANONYMIZE_FLAG, defaults.anonymize()))
                     .build();
         } catch (ParseException e) {
             LOGGER.error("Could not parse command line args", e);

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/Anonymizer.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/Anonymizer.java
@@ -1,0 +1,17 @@
+package com.hartwig.pipeline.metadata;
+
+import com.hartwig.api.model.Sample;
+import com.hartwig.pipeline.Arguments;
+
+public class Anonymizer {
+
+    private final Arguments arguments;
+
+    public Anonymizer(final Arguments arguments) {
+        this.arguments = arguments;
+    }
+
+    public String sampleName(final Sample sample) {
+        return arguments.anonymize() ? sample.getBarcode() : sample.getName();
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/ResearchMetadataApi.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/ResearchMetadataApi.java
@@ -23,14 +23,16 @@ public class ResearchMetadataApi implements SomaticMetadataApi {
     private final String biopsyName;
     private final Arguments arguments;
     private final StagedOutputPublisher stagedOutput;
+    private final Anonymizer anonymizer;
 
     public ResearchMetadataApi(final SampleApi sampleApi, final SetApi setApi, final String biopsyName, final Arguments arguments,
-            final StagedOutputPublisher stagedOutput) {
+            final StagedOutputPublisher stagedOutput, final Anonymizer anonymizer) {
         this.sampleApi = sampleApi;
         this.setApi = setApi;
         this.biopsyName = biopsyName;
         this.arguments = arguments;
         this.stagedOutput = stagedOutput;
+        this.anonymizer = anonymizer;
     }
 
     @Override
@@ -59,7 +61,7 @@ public class ResearchMetadataApi implements SomaticMetadataApi {
                 .type(type)
                 .barcode(sample.getBarcode())
                 .set(biopsyName)
-                .sampleName(sample.getName())
+                .sampleName(anonymizer.sampleName(sample))
                 .bucket(arguments.outputBucket())
                 .build();
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/SomaticMetadataApiProvider.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/SomaticMetadataApiProvider.java
@@ -59,7 +59,8 @@ public class SomaticMetadataApiProvider {
                         publisher,
                         objectMapper,
                         new Run(),
-                        PipelineStaged.OutputTarget.DATABASE));
+                        PipelineStaged.OutputTarget.DATABASE),
+                new Anonymizer(arguments));
     }
 
     public SomaticMetadataApi clinicalRun(final Integer setId) {
@@ -75,6 +76,7 @@ public class SomaticMetadataApiProvider {
                         publisher,
                         objectMapper,
                         run,
-                        PipelineStaged.OutputTarget.PATIENT_REPORT));
+                        PipelineStaged.OutputTarget.PATIENT_REPORT),
+                new Anonymizer(arguments));
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/metadata/AnonymizerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/metadata/AnonymizerTest.java
@@ -1,0 +1,27 @@
+package com.hartwig.pipeline.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hartwig.api.model.Sample;
+import com.hartwig.pipeline.Arguments;
+
+import org.junit.Test;
+
+public class AnonymizerTest {
+
+    private static final String SAMPLE_NAME = "sample";
+    private static final String BARCODE = "barcode";
+    private static final Sample SAMPLE = new Sample().name(SAMPLE_NAME).barcode(BARCODE);
+
+    @Test
+    public void usesSampleNameWhenTurnedOff() {
+        Anonymizer victim = new Anonymizer(Arguments.testDefaultsBuilder().anonymize(false).build());
+        assertThat(victim.sampleName(SAMPLE)).isEqualTo(SAMPLE_NAME);
+    }
+
+    @Test
+    public void usesBarcodeNameWhenTurnedOff() {
+        Anonymizer victim = new Anonymizer(Arguments.testDefaultsBuilder().anonymize(true).build());
+        assertThat(victim.sampleName(SAMPLE)).isEqualTo(BARCODE);
+    }
+}


### PR DESCRIPTION
Introduces a simple class which takes a sample and produces an "anonymized" name, which now is
simply the barcode. Applied in both clinical and research api implementations.