### PR TITLE
DEV-2017: Override hotspot qual cutoff to 40 in Sage somatic caller w…

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/SomaticPipeline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/SomaticPipeline.java
@@ -84,7 +84,6 @@ public class SomaticPipeline {
     }
 
     public PipelineState run(AlignmentPair pair) {
-
         PipelineState state = new PipelineState();
 
         SomaticRunMetadata metadata = setMetadataApi.get();
@@ -101,7 +100,7 @@ public class SomaticPipeline {
                 Future<VirusBreakendOutput> virusBreakendOutputFuture =
                         executorService.submit(() -> stageRunner.run(metadata, new VirusBreakend(pair, resourceFiles)));
                 Future<SageOutput> sageSomaticOutputFuture = executorService.submit(() -> stageRunner.run(metadata,
-                        new SageSomaticCaller(pair, resourceFiles, persistedDataset)));
+                        new SageSomaticCaller(pair, resourceFiles, persistedDataset, arguments.shallow())));
                 Future<SageOutput> sageGermlineOutputFuture = executorService.submit(() -> stageRunner.run(metadata,
                         new SageGermlineCaller(pair, resourceFiles, persistedDataset)));
                 Future<StructuralCallerOutput> structuralCallerOutputFuture = executorService.submit(() -> stageRunner.run(metadata,

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageCommandBuilder.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageCommandBuilder.java
@@ -143,14 +143,6 @@ public class SageCommandBuilder {
             throw new IllegalStateException("Shallow somatic mode enabled while not in shallow mode");
         }
 
-        if (somaticMode && germlineMode) {
-            throw new IllegalStateException("Somatic mode and germline mode both set while mutually exclusive");
-        }
-
-        if (!somaticMode && !germlineMode) {
-            throw new IllegalStateException("Neither somatic mode nor germline set while either needs to be enabled");
-        }
-
         final String tumorBamFiles = String.join(",", tumorBam);
         arguments.add("-tumor").add(tumor.toString()).add("-tumor_bam").add(tumorBamFiles);
         if (reference.length() > 0) {
@@ -164,9 +156,10 @@ public class SageCommandBuilder {
             if (shallowSomaticMode) {
                 arguments.add("-hotspot_min_tumor_qual").add("40");
             }
-        }
+        } else {
+            // Somatic mode and germline mode are mutually exclusive and this can't be controlled from outside this class.
+            assert germlineMode;
 
-        if (germlineMode) {
             arguments.add("-hotspots").add(resourceFiles.sageGermlineHotspots());
             arguments.add("-panel_bed").add(resourceFiles.sageGermlineCodingPanel());
             arguments.add("-hotspot_min_tumor_qual").add("50");

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageCommandBuilder.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageCommandBuilder.java
@@ -23,6 +23,7 @@ public class SageCommandBuilder {
     private boolean ponMode = false;
     private boolean somaticMode = true;
     private boolean germlineMode = false;
+    private boolean shallowSomaticMode = false;
     private int tumorSamples = 0;
 
     public SageCommandBuilder(ResourceFiles resourceFiles) {
@@ -65,6 +66,11 @@ public class SageCommandBuilder {
 
     public SageCommandBuilder addCoverage() {
         this.coverage = true;
+        return this;
+    }
+
+    public SageCommandBuilder addShallowSomaticMode() {
+        this.shallowSomaticMode = true;
         return this;
     }
 
@@ -143,6 +149,9 @@ public class SageCommandBuilder {
         if (somaticMode) {
             arguments.add("-hotspots").add(resourceFiles.sageSomaticHotspots());
             arguments.add("-panel_bed").add(resourceFiles.sageSomaticCodingPanel());
+            if (shallowSomaticMode) {
+                arguments.add("-hotspot_min_tumor_qual").add("40");
+            }
         }
 
         if (germlineMode) {
@@ -166,6 +175,7 @@ public class SageCommandBuilder {
         if (panelOnly) {
             arguments.add("-panel_only");
         }
+
         if (coverage) {
             arguments.add("-coverage_bed");
             if (germlineMode) {
@@ -176,7 +186,6 @@ public class SageCommandBuilder {
         }
 
         if (ponMode) {
-
             arguments.add("-hotspots").add(resourceFiles.sageSomaticHotspots());
             arguments.add("-panel_bed").add(resourceFiles.sageSomaticCodingPanel());
 

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageCommandBuilder.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageCommandBuilder.java
@@ -139,6 +139,18 @@ public class SageCommandBuilder {
             throw new IllegalStateException("Must be at least one tumor");
         }
 
+        if (shallowSomaticMode && !somaticMode) {
+            throw new IllegalStateException("Shallow somatic mode enabled while not in shallow mode");
+        }
+
+        if (somaticMode && germlineMode) {
+            throw new IllegalStateException("Somatic mode and germline mode both set while mutually exclusive");
+        }
+
+        if (!somaticMode && !germlineMode) {
+            throw new IllegalStateException("Neither somatic mode nor germline set while either needs to be enabled");
+        }
+
         final String tumorBamFiles = String.join(",", tumorBam);
         arguments.add("-tumor").add(tumor.toString()).add("-tumor_bam").add(tumorBamFiles);
         if (reference.length() > 0) {

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageCommandBuilderTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageCommandBuilderTest.java
@@ -11,6 +11,8 @@ import com.hartwig.pipeline.testsupport.TestInputs;
 
 import org.junit.Test;
 
+import joptsimple.internal.Strings;
+
 public class SageCommandBuilderTest {
 
     private static final String TUMOR = "COLO829v003T";
@@ -19,8 +21,8 @@ public class SageCommandBuilderTest {
     private static final String REFERENCE_BAM = VmDirectories.INPUT + "/" + REFERENCE + ".bam";
 
     private static final String REFERENCE_OUT = VmDirectories.OUTPUT + "/" + REFERENCE + ".out.vcf.gz";
-    private static final String REFERENCE_SAGE_COMMAND = "java -Xmx15G -cp /opt/tools/sage/2.8/sage.jar com.hartwig.hmftools.sage.SageApplication -tumor COLO829v003R -tumor_bam /data/input/COLO829v003R.bam -reference COLO829v003T -reference_bam /data/input/COLO829v003T.bam -hotspots /opt/resources/sage/37/KnownHotspots.germline.37.vcf.gz -panel_bed /opt/resources/sage/37/ActionableCodingPanel.germline.37.bed.gz -hotspot_min_tumor_qual 50 -panel_min_tumor_qual 75 -hotspot_max_germline_vaf 100 -hotspot_max_germline_rel_raw_base_qual 100 -panel_max_germline_vaf 100 -panel_max_germline_rel_raw_base_qual 100 -mnv_filter_enabled false -high_confidence_bed /opt/resources/giab_high_conf/37/NA12878_GIAB_highconf_IllFB-IllGATKHC-CG-Ion-Solid_ALLCHROM_v3.2.2_highconf.bed.gz -ref_genome /opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta -out /data/output/COLO829v003R.out.vcf.gz -assembly hg19 -threads $(grep -c '^processor' /proc/cpuinfo) -panel_only";
-
+    private static final String REFERENCE_SAGE_COMMAND =
+            "java -Xmx15G -cp /opt/tools/sage/2.8/sage.jar com.hartwig.hmftools.sage.SageApplication -tumor COLO829v003R -tumor_bam /data/input/COLO829v003R.bam -reference COLO829v003T -reference_bam /data/input/COLO829v003T.bam -hotspots /opt/resources/sage/37/KnownHotspots.germline.37.vcf.gz -panel_bed /opt/resources/sage/37/ActionableCodingPanel.germline.37.bed.gz -hotspot_min_tumor_qual 50 -panel_min_tumor_qual 75 -hotspot_max_germline_vaf 100 -hotspot_max_germline_rel_raw_base_qual 100 -panel_max_germline_vaf 100 -panel_max_germline_rel_raw_base_qual 100 -mnv_filter_enabled false -high_confidence_bed /opt/resources/giab_high_conf/37/NA12878_GIAB_highconf_IllFB-IllGATKHC-CG-Ion-Solid_ALLCHROM_v3.2.2_highconf.bed.gz -ref_genome /opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta -out /data/output/COLO829v003R.out.vcf.gz -assembly hg19 -threads $(grep -c '^processor' /proc/cpuinfo) -panel_only";
 
     @Test
     public void testGermlineBam() {
@@ -38,11 +40,25 @@ public class SageCommandBuilderTest {
         List<String> bash = victim.build(REFERENCE_OUT).stream().map(BashCommand::asBash).collect(Collectors.toList());
         assertEquals(5, bash.size());
 
-        assertEquals(bash.get(0), "/opt/tools/samtools/1.10/samtools view -T /opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta -L /opt/resources/sage/37/SlicePanel.germline.37.bed.gz -o /data/input/COLO829v003T.bam -u -@ $(grep -c '^processor' /proc/cpuinfo) -M /data/input/COLO829v003T.cram");
+        assertEquals(bash.get(0),
+                "/opt/tools/samtools/1.10/samtools view -T /opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta -L /opt/resources/sage/37/SlicePanel.germline.37.bed.gz -o /data/input/COLO829v003T.bam -u -@ $(grep -c '^processor' /proc/cpuinfo) -M /data/input/COLO829v003T.cram");
         assertEquals(bash.get(1), "/opt/tools/samtools/1.10/samtools index /data/input/COLO829v003T.bam");
-        assertEquals(bash.get(2), "/opt/tools/samtools/1.10/samtools view -T /opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta -L /opt/resources/sage/37/SlicePanel.germline.37.bed.gz -o /data/input/COLO829v003R.bam -u -@ $(grep -c '^processor' /proc/cpuinfo) -M /data/input/COLO829v003R.cram");
+        assertEquals(bash.get(2),
+                "/opt/tools/samtools/1.10/samtools view -T /opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta -L /opt/resources/sage/37/SlicePanel.germline.37.bed.gz -o /data/input/COLO829v003R.bam -u -@ $(grep -c '^processor' /proc/cpuinfo) -M /data/input/COLO829v003R.cram");
         assertEquals(bash.get(3), "/opt/tools/samtools/1.10/samtools index /data/input/COLO829v003R.bam");
         assertEquals(bash.get(4), REFERENCE_SAGE_COMMAND);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testExceptionOnNoTumorSet() {
+        new SageCommandBuilder(TestInputs.REF_GENOME_37_RESOURCE_FILES).build(Strings.EMPTY);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testExceptionOnShallowInGermline() {
+        new SageCommandBuilder(TestInputs.REF_GENOME_37_RESOURCE_FILES).germlineMode(REFERENCE, REFERENCE_BAM, TUMOR, TUMOR_BAM)
+                .addShallowSomaticMode()
+                .build(Strings.EMPTY);
     }
 
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageCommandBuilderTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageCommandBuilderTest.java
@@ -25,7 +25,7 @@ public class SageCommandBuilderTest {
             "java -Xmx15G -cp /opt/tools/sage/2.8/sage.jar com.hartwig.hmftools.sage.SageApplication -tumor COLO829v003R -tumor_bam /data/input/COLO829v003R.bam -reference COLO829v003T -reference_bam /data/input/COLO829v003T.bam -hotspots /opt/resources/sage/37/KnownHotspots.germline.37.vcf.gz -panel_bed /opt/resources/sage/37/ActionableCodingPanel.germline.37.bed.gz -hotspot_min_tumor_qual 50 -panel_min_tumor_qual 75 -hotspot_max_germline_vaf 100 -hotspot_max_germline_rel_raw_base_qual 100 -panel_max_germline_vaf 100 -panel_max_germline_rel_raw_base_qual 100 -mnv_filter_enabled false -high_confidence_bed /opt/resources/giab_high_conf/37/NA12878_GIAB_highconf_IllFB-IllGATKHC-CG-Ion-Solid_ALLCHROM_v3.2.2_highconf.bed.gz -ref_genome /opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta -out /data/output/COLO829v003R.out.vcf.gz -assembly hg19 -threads $(grep -c '^processor' /proc/cpuinfo) -panel_only";
 
     @Test
-    public void testGermlineBam() {
+    public void runsOnGermlineBam() {
         SageCommandBuilder victim = new SageCommandBuilder(TestInputs.REF_GENOME_37_RESOURCE_FILES);
         victim.germlineMode(REFERENCE, REFERENCE_BAM, TUMOR, TUMOR_BAM);
         List<String> bash = victim.build(REFERENCE_OUT).stream().map(BashCommand::asBash).collect(Collectors.toList());
@@ -34,7 +34,7 @@ public class SageCommandBuilderTest {
     }
 
     @Test
-    public void testGermlineCram() {
+    public void runsOnGermlineCram() {
         SageCommandBuilder victim = new SageCommandBuilder(TestInputs.REF_GENOME_37_RESOURCE_FILES);
         victim.germlineMode(REFERENCE, REFERENCE_BAM.replace(".bam", ".cram"), TUMOR, TUMOR_BAM.replace(".bam", ".cram"));
         List<String> bash = victim.build(REFERENCE_OUT).stream().map(BashCommand::asBash).collect(Collectors.toList());
@@ -50,12 +50,12 @@ public class SageCommandBuilderTest {
     }
 
     @Test(expected = IllegalStateException.class)
-    public void testExceptionOnNoTumorSet() {
+    public void throwsExceptionOnNoTumorSet() {
         new SageCommandBuilder(TestInputs.REF_GENOME_37_RESOURCE_FILES).build(Strings.EMPTY);
     }
 
     @Test(expected = IllegalStateException.class)
-    public void testExceptionOnShallowInGermline() {
+    public void throwsExceptionOnShallowModeInGermline() {
         new SageCommandBuilder(TestInputs.REF_GENOME_37_RESOURCE_FILES).germlineMode(REFERENCE, REFERENCE_BAM, TUMOR, TUMOR_BAM)
                 .addShallowSomaticMode()
                 .build(Strings.EMPTY);

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageSomaticCallerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageSomaticCallerTest.java
@@ -14,12 +14,20 @@ import com.hartwig.pipeline.tertiary.TertiaryStageTest;
 import com.hartwig.pipeline.testsupport.TestInputs;
 
 import org.junit.Before;
+import org.junit.Test;
 
 public class SageSomaticCallerTest extends TertiaryStageTest<SageOutput> {
 
     @Before
     public void setUp() throws Exception {
         super.setUp();
+    }
+
+    @Test
+    public void shallowModeUsesHotspotQualOverride() {
+        SageSomaticCaller victim =
+                new SageSomaticCaller(TestInputs.defaultPair(), TestInputs.REF_GENOME_37_RESOURCE_FILES, new NoopPersistedDataset(), true);
+        assertThat(victim.commands(input()).get(1).asBash()).contains("-hotspot_min_tumor_qual 40");
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageSomaticCallerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageSomaticCallerTest.java
@@ -24,7 +24,7 @@ public class SageSomaticCallerTest extends TertiaryStageTest<SageOutput> {
 
     @Override
     protected Stage<SageOutput, SomaticRunMetadata> createVictim() {
-        return new SageSomaticCaller(TestInputs.defaultPair(), TestInputs.REF_GENOME_37_RESOURCE_FILES, new NoopPersistedDataset());
+        return new SageSomaticCaller(TestInputs.defaultPair(), TestInputs.REF_GENOME_37_RESOURCE_FILES, new NoopPersistedDataset(), false);
     }
 
     @Override


### PR DESCRIPTION
When we run SAGE in shallow mode we should reduce the cutoff for hotspots to retain roughly similar sensitivity. 

Analysis showed 40 is a good tradeoff between FP and FN/TP.