### PR TITLE
DEV-2022 Wire in GS based upload classes to "SBP" providers

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/AlignerProvider.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/AlignerProvider.java
@@ -25,9 +25,7 @@ import com.hartwig.pipeline.storage.CloudCopy;
 import com.hartwig.pipeline.storage.CloudSampleUpload;
 import com.hartwig.pipeline.storage.GSFileSource;
 import com.hartwig.pipeline.storage.GSUtilCloudCopy;
-import com.hartwig.pipeline.storage.RCloneCloudCopy;
 import com.hartwig.pipeline.storage.SampleUpload;
-import com.hartwig.pipeline.storage.SbpS3FileSource;
 
 public abstract class AlignerProvider {
 
@@ -108,11 +106,8 @@ public abstract class AlignerProvider {
         BwaAligner wireUp(GoogleCredentials credentials, Storage storage, ResultsDirectory resultsDirectory) throws Exception {
             SbpRestApi sbpRestApi = SbpRestApi.newInstance(getArguments().sbpApiUrl());
             SampleSource sampleSource = new SbpS3SampleSource(new SbpSampleReader(sbpRestApi));
-            CloudCopy cloudCopy = new RCloneCloudCopy(getArguments().rclonePath(),
-                    getArguments().rcloneGcpRemote(),
-                    getArguments().rcloneS3RemoteDownload(),
-                    ProcessBuilder::new);
-            SampleUpload sampleUpload = new CloudSampleUpload(new SbpS3FileSource(), cloudCopy);
+            CloudCopy cloudCopy = new GSUtilCloudCopy(getArguments().cloudSdkPath());
+            SampleUpload sampleUpload = new CloudSampleUpload(new GSFileSource(), cloudCopy);
             return AlignerProvider.constructVmAligner(getArguments(), credentials, storage, sampleSource, sampleUpload, resultsDirectory);
         }
     }


### PR DESCRIPTION
Bit of an interim fix for this to minimize impact, but removes references to the rclone and
s3 sample uploading from the production alignment.