### PR TITLE
DEV-2024 Use namespaces over filenames to differentiate analysis types

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/transfer/staged/InNamespace.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/transfer/staged/InNamespace.java
@@ -1,0 +1,28 @@
+package com.hartwig.pipeline.transfer.staged;
+
+import java.util.function.Predicate;
+
+import com.google.cloud.storage.Blob;
+
+public class InNamespace implements Predicate<Blob> {
+
+    private final String namespace;
+
+    private InNamespace(final String namespace) {
+        this.namespace = namespace;
+    }
+
+    public static InNamespace of(final String namespace) {
+        return new InNamespace(namespace);
+    }
+
+    @Override
+    public boolean test(final Blob blob) {
+        String[] path = blob.getName().split("/");
+        if (path.length < 2) {
+            return false;
+        }
+        String blobNamespace = path[path.length - 2];
+        return namespace.equals(blobNamespace);
+    }
+}

--- a/cluster/src/test/java/com/hartwig/pipeline/transfer/staged/InNamespaceTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/transfer/staged/InNamespaceTest.java
@@ -1,0 +1,33 @@
+package com.hartwig.pipeline.transfer.staged;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hartwig.pipeline.testsupport.TestBlobs;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class InNamespaceTest {
+
+    private InNamespace victim;
+
+    @Before
+    public void setUp() throws Exception {
+        victim = InNamespace.of("namespace");
+    }
+
+    @Test
+    public void pathWithNoNamespaceAlwaysFalse() {
+        assertThat(victim.test(TestBlobs.blob("no_namespace.txt"))).isFalse();
+    }
+
+    @Test
+    public void namespaceMatches() {
+        assertThat(victim.test(TestBlobs.blob("namespace/in_namespace.txt"))).isTrue();
+    }
+
+    @Test
+    public void namespaceDoesntMatch() {
+        assertThat(victim.test(TestBlobs.blob("another_namespace/not_in_namespace.txt"))).isFalse();
+    }
+}

--- a/cluster/src/test/java/com/hartwig/pipeline/transfer/staged/StagedOutputPublisherTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/transfer/staged/StagedOutputPublisherTest.java
@@ -70,12 +70,12 @@ public class StagedOutputPublisherTest {
 
     @Test
     public void publishesDnaSecondaryAnalysisOnBam() throws Exception {
-        verifySecondaryAnalysis("bam", "bai");
+        verifySecondaryAnalysis("bam", "bai", "aligner");
     }
 
     @Test
     public void publishesDnaSecondaryAnalysisOnCram() throws Exception {
-        verifySecondaryAnalysis("cram", "crai");
+        verifySecondaryAnalysis("cram", "crai", "cram");
     }
 
     @Test
@@ -113,15 +113,17 @@ public class StagedOutputPublisherTest {
         assertThat(result.blobs()).extracting(PipelineOutputBlob::filename).containsExactlyInAnyOrder(expectedFile);
     }
 
-    private void verifySecondaryAnalysis(final String extension, final String indexExtension)
+    private void verifySecondaryAnalysis(final String extension, final String indexExtension, final String namespace)
             throws com.fasterxml.jackson.core.JsonProcessingException {
         when(state.status()).thenReturn(PipelineStatus.SUCCESS);
-        Blob tumorBamBlob = withBucketAndMd5(blob(TestInputs.tumorSample() + "/aligner/" + TestInputs.tumorSample() + "." + extension));
+        Blob tumorBamBlob =
+                withBucketAndMd5(blob(TestInputs.tumorSample() + "/" + namespace + "/" + TestInputs.tumorSample() + "." + extension));
         Blob tumorBaiBlob = withBucketAndMd5(blob(
-                TestInputs.tumorSample() + "/aligner/" + TestInputs.tumorSample() + "." + extension + "." + indexExtension));
-        Blob refBamBlob = withBucketAndMd5(blob(TestInputs.tumorSample() + "/aligner/" + TestInputs.referenceSample() + "." + extension));
+                TestInputs.tumorSample() + "/" + namespace + "/" + TestInputs.tumorSample() + "." + extension + "." + indexExtension));
+        Blob refBamBlob =
+                withBucketAndMd5(blob(TestInputs.tumorSample() + "/" + namespace + "/" + TestInputs.referenceSample() + "." + extension));
         Blob refBaiBlob = withBucketAndMd5(blob(
-                TestInputs.tumorSample() + "/aligner/" + TestInputs.referenceSample() + "." + extension + "." + indexExtension));
+                TestInputs.tumorSample() + "/" + namespace + "/" + TestInputs.referenceSample() + "." + extension + "." + indexExtension));
         Page<Blob> page = pageOf(tumorBamBlob, tumorBaiBlob, refBamBlob, refBaiBlob);
         ArgumentCaptor<PubsubMessage> messageArgumentCaptor = publish(page);
 


### PR DESCRIPTION
And add the new namespaces for the secondary analysis. The idea being that these are extensions of the
secondary analysis (metrics and metadata).