### PR TITLE
DEV-2082 Add datatype to the persisted output of bam metrics

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/metrics/BamMetrics.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metrics/BamMetrics.java
@@ -98,6 +98,7 @@ public class BamMetrics implements Stage<BamMetricsOutput, SingleSampleRunMetada
 
     @Override
     public BamMetricsOutput persistedOutput(final SingleSampleRunMetadata metadata) {
+        String outputFile = BamMetricsOutput.outputFile(metadata.sampleName());
         return BamMetricsOutput.builder()
                 .status(PipelineStatus.PERSISTED)
                 .sample(metadata.sampleName())
@@ -107,6 +108,9 @@ public class BamMetrics implements Stage<BamMetricsOutput, SingleSampleRunMetada
                                         metadata.sampleName(),
                                         namespace(),
                                         BamMetricsOutput.outputFile(metadata.sampleName())))))
+                .addDatatypes(new AddDatatype(DataType.WGSMETRICS,
+                        metadata.barcode(),
+                        new ArchivePath(Folder.from(metadata), namespace(), outputFile)))
                 .build();
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/metrics/BamMetricsTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/metrics/BamMetricsTest.java
@@ -21,6 +21,9 @@ import org.junit.Before;
 public class BamMetricsTest extends StageTest<BamMetricsOutput, SingleSampleRunMetadata> {
 
     public static final String REFERENCE_WGSMETRICS = "reference.wgsmetrics";
+    public static final AddDatatype ADD_DATATYPE = new AddDatatype(DataType.WGSMETRICS,
+            TestInputs.referenceRunMetadata().barcode(),
+            new ArchivePath(Folder.from(TestInputs.referenceRunMetadata()), BamMetrics.NAMESPACE, "reference.wgsmetrics"));
 
     @Override
     @Before
@@ -84,12 +87,11 @@ public class BamMetricsTest extends StageTest<BamMetricsOutput, SingleSampleRunM
     @Override
     protected void validatePersistedOutputFromPersistedDataset(final BamMetricsOutput output) {
         assertThat(output.metricsOutputFile()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, "bam_metrics/" + REFERENCE_WGSMETRICS));
+        assertThat(output.datatypes()).containsExactly(ADD_DATATYPE);
     }
 
     @Override
     protected List<AddDatatype> expectedFurtherOperations() {
-        return List.of(new AddDatatype(DataType.WGSMETRICS,
-                TestInputs.referenceRunMetadata().barcode(),
-                new ArchivePath(Folder.from(TestInputs.referenceRunMetadata()), BamMetrics.NAMESPACE, "reference.wgsmetrics")));
+        return List.of(ADD_DATATYPE);
     }
 }


### PR DESCRIPTION
This will be picked up by the StagedOutputPublisher even though the stage has not actually been run. Then the archiver
will receive the datatype and barcode and add the proper file api links.

As bam metrics are the only non-cram files grouped into the secondary staged event, we only pull this trick in one place.
Longer term it would be good to factor the code such that persisted results always honor the datatype of the normal
output generation.

Test plan:
- Run research pipeline in pilot
- Ensure that the file is persisted with api objects
- Run DB loader and check that MetricsLoader is run.