### PR TITLE
DEV-2121 Ensure all germline data ends up the germline analysis bucket

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/transfer/staged/StagedOutputPublisher.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/transfer/staged/StagedOutputPublisher.java
@@ -26,6 +26,7 @@ import com.hartwig.pipeline.PipelineState;
 import com.hartwig.pipeline.StageOutput;
 import com.hartwig.pipeline.alignment.Aligner;
 import com.hartwig.pipeline.calling.germline.GermlineCaller;
+import com.hartwig.pipeline.calling.sage.SageGermlineCaller;
 import com.hartwig.pipeline.cram.CramConversion;
 import com.hartwig.pipeline.execution.PipelineStatus;
 import com.hartwig.pipeline.flagstat.Flagstat;
@@ -73,7 +74,6 @@ public class StagedOutputPublisher {
             ImmutablePipelineStaged.Builder germlineAnalysisEvent = eventBuilder(set, Type.GERMLINE, sampleName);
 
             OutputIterator.from(blob -> {
-                String blobPath  = blob.getName();
                 Optional<AddDatatype> dataType = addDatatypes.stream().filter(d -> blob.getName().endsWith(d.path())).findFirst();
                 Blob blobWithMd5 = sourceBucket.get(blob.getName());
                 if (isSecondary(blobWithMd5)) {
@@ -125,7 +125,10 @@ public class StagedOutputPublisher {
     }
 
     private boolean isGermline(final Blob blobWithMd5) {
-        return InNamespace.of(GermlineCaller.NAMESPACE).test(blobWithMd5);
+        return InNamespace.of(GermlineCaller.NAMESPACE)
+                .or(InNamespace.of(SageGermlineCaller.NAMESPACE))
+                .or(b -> b.getName().contains("germline"))
+                .test(blobWithMd5);
     }
 
     private boolean notSecondary(final Blob blobWithMd5) {

--- a/cluster/src/test/java/com/hartwig/pipeline/transfer/staged/StagedOutputPublisherTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/transfer/staged/StagedOutputPublisherTest.java
@@ -107,8 +107,23 @@ public class StagedOutputPublisherTest {
     }
 
     @Test
-    public void publishesGermlineTertiaryAnalysisOnGermlineVcf() throws Exception {
-        verifyGermline(".germline.vcf.gz", "reference.germline.vcf.gz");
+    public void publishesGermlineAnalysisOnGatkGermlineVcf() throws Exception {
+        verifyGermline(".germline.vcf.gz", "reference.germline.vcf.gz", "/germline_caller/");
+    }
+
+    @Test
+    public void publishesGermlineAnalysisOnGatkGermlineVcfIndex() throws Exception {
+        verifyGermline(".germline.vcf.gz.tbi", "reference.germline.vcf.gz.tbi", "/germline_caller/");
+    }
+
+    @Test
+    public void publishesGermlineAnalysisOnSageGermlineVcf() throws Exception {
+        verifyGermline(".germline.vcf.gz", "reference.germline.vcf.gz", "/sage_germline/");
+    }
+
+    @Test
+    public void publishesGermlineAnalysisOnPurpleGermlineVcf() throws Exception {
+        verifyGermline(".germline.vcf.gz", "reference.germline.vcf.gz", "/purple/");
     }
 
     @Test
@@ -119,11 +134,6 @@ public class StagedOutputPublisherTest {
         ArgumentCaptor<PubsubMessage> published = publish(page, TestInputs.defaultSingleSampleRunMetadata());
         PipelineStaged result = OBJECT_MAPPER.readValue(new String(published.getValue().getData().toByteArray()), PipelineStaged.class);
         assertThat(result.sample()).isEqualTo("reference");
-    }
-
-    @Test
-    public void publishesGermlineTertiaryAnalysisOnGermlineVcfIndex() throws Exception {
-        verifyGermline(".germline.vcf.gz.tbi", "reference.germline.vcf.gz.tbi");
     }
 
     @Test
@@ -143,9 +153,9 @@ public class StagedOutputPublisherTest {
         assertThat(result.blobs().get(0).barcode()).hasValue("barcode");
     }
 
-    public void verifyGermline(final String filename, final String expectedFile) throws com.fasterxml.jackson.core.JsonProcessingException {
+    public void verifyGermline(final String filename, final String expectedFile, final String namespace) throws com.fasterxml.jackson.core.JsonProcessingException {
         when(state.status()).thenReturn(PipelineStatus.SUCCESS);
-        Blob vcf = withBucketAndMd5(blob("/germline_caller/" + TestInputs.referenceSample() + filename));
+        Blob vcf = withBucketAndMd5(blob(namespace + TestInputs.referenceSample() + filename));
         Page<Blob> page = pageOf(vcf);
         ArgumentCaptor<PubsubMessage> messageArgumentCaptor = publish(page, TestInputs.defaultSomaticRunMetadata());
 


### PR DESCRIPTION
Add the sage germline namespace and then look for all files with germline in the name. Bit of a dirty trick
but at this point we don't have another option unless we inventory every file we archive.