### PR TITLE
DEV-2186 Populate DOIDs in research metadata api

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/ResearchMetadataApi.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/ResearchMetadataApi.java
@@ -1,7 +1,9 @@
 package com.hartwig.pipeline.metadata;
 
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.hartwig.api.SampleApi;
@@ -64,6 +66,7 @@ public class ResearchMetadataApi implements SomaticMetadataApi {
                 .set(set)
                 .sampleName(anonymizer.sampleName(sample))
                 .bucket(arguments.outputBucket())
+                .primaryTumorDoids(Optional.ofNullable(sample.getPrimaryTumorDoids()).orElse(Collections.emptyList()))
                 .build();
     }
 

--- a/cluster/src/test/java/com/hartwig/pipeline/metadata/ResearchMetadataApiTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/metadata/ResearchMetadataApiTest.java
@@ -111,6 +111,7 @@ public class ResearchMetadataApiTest {
         assertThat(somaticRunMetadata.tumor().barcode()).isEqualTo(TUMOR_BARCODE);
         assertThat(somaticRunMetadata.reference().sampleName()).isEqualTo(REF_NAME);
         assertThat(somaticRunMetadata.reference().barcode()).isEqualTo(REF_BARCODE);
+        assertThat(somaticRunMetadata.tumor().primaryTumorDoids()).containsOnly("1234", "5678");
     }
 
     @Test
@@ -207,7 +208,12 @@ public class ResearchMetadataApiTest {
     }
 
     private static Sample tumor() {
-        return new Sample().id(TUMOR_SAMPLE_ID).name(TUMOR_NAME).barcode(TUMOR_BARCODE).type(SampleType.TUMOR).status(SampleStatus.READY);
+        return new Sample().id(TUMOR_SAMPLE_ID)
+                .name(TUMOR_NAME)
+                .barcode(TUMOR_BARCODE)
+                .type(SampleType.TUMOR)
+                .status(SampleStatus.READY)
+                .primaryTumorDoids(List.of("1234", "5678"));
     }
 
     private static Sample ref() {


### PR DESCRIPTION
The research api implementation is used in reruns, to this point didn't populate the DOID on the
tumor sample.