### PR TITLE
DEV-2197 R dependencies for Debian 10

### DIFF
--- a/cluster/images/installDependencies.R.cran40
+++ b/cluster/images/installDependencies.R.cran40
@@ -8,16 +8,18 @@
 #
 #   1. Start a VM and MAKE SURE `/usr/local/lib/R/site-library` both exists and is empty. 
 #   2. Confirm `/usr/local/lib/R/site-library` is first in the output of `.libPaths()` from an R shell
-#   3. Install required packages with `apt install libcurl4-openssl-dev libssl-dev libxml2-dev dirmngr apt-transport-https ca-certificates software-properties-common gnupg2`
+#   3. Install required packages with `apt install libcurl4-openssl-dev libssl-dev libxml2-dev dirmngr apt-transport-https ca-certificates software-properties-common gnupg2 libmagick++-dev`
 #   4. Install cran40 R:
 #      a. `add-apt-repository 'deb https://cloud.r-project.org/bin/linux/debian buster-cran40/'`
 #      b. `apt update`
 #      c. `apt install r-base`
-#   3. Run this script with `Rscript ./installDependencies.R`
-#   4. Make sure `/usr/local/lib/R/site-library` was populated as expected
-#   5. Make a new tarball: `cd /; tar cvf rlibs.tar /usr/local/lib/R/site-library`
-#   6. Create a backup of the existing tarball in the tools bucket, then copy the new tarball over the original
-#   7. Re-run the imaging script and verify installed versions of R libs. See `./listInstalledLibs.R`.
+#   5. Run this script with `Rscript ./installDependencies.R | tee rebuild.log`
+#   6. Make sure `/usr/local/lib/R/site-library` was populated as expected
+#   7. Check for errors/missing libraries in the rebuild log as the whole build may exit with 0 but if an underlying library is
+#      missing then it won't build the R extension
+#   8. Make a new tarball: `cd /; tar cvf rlibs.tar /usr/local/lib/R/site-library`
+#   9. Create a backup of the existing tarball in the tools bucket, then copy the new tarball over the original
+#   0. Re-run the imaging script and verify installed versions of R libs. See `./listInstalledLibs.R`.
 #
 # Once built the dependencies are placed in the "tools" bucket on GCP we use for imaging. See `package.cmds` for
 # the current bucket name. The tarball is extracted at image creation time so if any R dependencies have to be updated a new

--- a/cluster/images/installDependencies.R.cran40
+++ b/cluster/images/installDependencies.R.cran40
@@ -1,0 +1,76 @@
+# Use this build the R dependencies for the pipeline.  It is not an automated part of image creation to keep the imaging time down
+# but can be invoked manually when the dependencies are in need of updating.
+#
+# NOTE: This file is not yet relevant to Pipeline5, we will have to update the base image the pipeline is running against and at
+# that point this file may be needed. This file is only relevant when we have switched to Debian 10.
+#
+# These instructions assume you're starting from a new VM imaged with the GCP Debian 10 image:
+#
+#   1. Start a VM and MAKE SURE `/usr/local/lib/R/site-library` both exists and is empty. 
+#   2. Confirm `/usr/local/lib/R/site-library` is first in the output of `.libPaths()` from an R shell
+#   3. Install required packages with `apt install libcurl4-openssl-dev libssl-dev libxml2-dev dirmngr apt-transport-https ca-certificates software-properties-common gnupg2`
+#   4. Install cran40 R:
+#      a. `add-apt-repository 'deb https://cloud.r-project.org/bin/linux/debian buster-cran40/'`
+#      b. `apt update`
+#      c. `apt install r-base`
+#   3. Run this script with `Rscript ./installDependencies.R`
+#   4. Make sure `/usr/local/lib/R/site-library` was populated as expected
+#   5. Make a new tarball: `cd /; tar cvf rlibs.tar /usr/local/lib/R/site-library`
+#   6. Create a backup of the existing tarball in the tools bucket, then copy the new tarball over the original
+#   7. Re-run the imaging script and verify installed versions of R libs. See `./listInstalledLibs.R`.
+#
+# Once built the dependencies are placed in the "tools" bucket on GCP we use for imaging. See `package.cmds` for
+# the current bucket name. The tarball is extracted at image creation time so if any R dependencies have to be updated a new
+# tarball must be created and pushed to the bucket and then the regular imaging script run. 
+#
+# We make the assumption that any libraries installed in the R library search path (try `.libPaths()` from an R shell) will not
+# contain anything other than what has been packaged with the in-use R distribution. We do not use a custom library path via
+# `R_LIBS_USER` because it complicates all R client programs.
+
+install.packages("BiocManager")
+install.packages("usethis")
+install.packages("httr")
+install.packages("roxygen2")
+install.packages("rversions")
+install.packages("devtools")
+library(BiocManager)
+library(devtools)
+
+install.packages("dplyr")
+install.packages("ggplot2", update = T, ask = F)
+install.packages("magick", update = T, ask = F)
+install.packages("VariantAnnotation", update = T, ask = F)
+install.packages("copynumber", update = T, ask = F)
+install.packages("cowplot", update = T, ask = F)
+
+install.packages("argparser", update = T, ask = F)
+install.packages("XML", update = T, ask = F)
+install.packages("rtracklayer", update = T, ask = F)
+install.packages("BSgenome", update = T, ask = F)
+install.packages("BSgenome.Hsapiens.UCSC.hg19", update = T, ask = F)
+install.packages("BSgenome.Hsapiens.UCSC.hg38", update = T, ask = F)
+install.packages("tidyverse", update = T, ask = F)
+install.packages("rlang", update = T, ask = F)
+install.packages("R6", update = T, ask = F)
+
+BiocManager::install("VariantAnnotation")
+BiocManager::install("StructuralVariantAnnotation")
+BiocManager::install("BSgenome.Hsapiens.UCSC.hg19")
+BiocManager::install("BSgenome.Hsapiens.UCSC.hg38")
+BiocManager::install("BiocGenerics")
+BiocManager::install("S4Vectors")
+BiocManager::install("IRanges")
+BiocManager::install("GenomeInfoDb")
+BiocManager::install("GenomicRanges")
+BiocManager::install("Biostrings")
+BiocManager::install("Rsamtools")
+BiocManager::install("GenomicAlignments")
+BiocManager::install("Gviz")
+
+install.packages("testthat", update = T, ask = F)
+install.packages("stringdist", update = T, ask = F)
+install.packages("assertthat", update = T, ask = F)
+
+
+# apt install libcurl4-openssl-dev libssl-dev libxml2-dev
+#


### PR DESCRIPTION
This file is not yet used but when we are ready to move to Debian 10
from the already-deprecated Debian 9 for the pipeline we'll need to
rebuild the R libraries.

R libraries are coupled to the environment they were compiled in and our
current production version uses cran35 while the new one uses cran40.