### PR TITLE
DEV-2217 Fix up problems with imager

### DIFF
--- a/cluster/images/create_public_image.sh
+++ b/cluster/images/create_public_image.sh
@@ -3,7 +3,7 @@
 LOCATION="europe-west4"
 ZONE="${LOCATION}-a"
 PROJECT="hmf-pipeline-development"
-VERSION=5-23
+VERSION=5-24
 
 TOOLS_ONLY=false
 while getopts ':tf:' flag; do

--- a/cluster/images/mk_python_venv
+++ b/cluster/images/mk_python_venv
@@ -12,6 +12,7 @@ fi
 export PATH="/root/.pyenv/versions/${3}/bin:$PATH"
 python -m venv /opt/tools/${1}/${2}_venv
 source /opt/tools/${1}/${2}_venv/bin/activate
+pip install --upgrade pip
 grep -v '^$' /opt/tools/${1}/${2}/requirements.txt | while read l; do 
   pip install $l
 done

--- a/cluster/images/tools.cmds
+++ b/cluster/images/tools.cmds
@@ -8,16 +8,19 @@ sudo cpanm install Math::VecStat
 # Not currently a candidate for management by virtual environments, please leave intact
 sudo apt -y install python3-h5py
 
+sudo rm -rf /opt/tools/*
 sudo gsutil -m -o 'GSUtil:parallel_thread_count=1' -o 'GSUtil:sliced_object_download_max_components=4' cp -n -r gs://common-tools/* /opt/tools/
 
 # The below tarball is a capture of the result of running this on a live instance:
 # curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | sudo bash
 # Doing that every time blindly is not compatible with a secure environment
+sudo rm -rf /root/.pyenv
 sudo tar xvzf /opt/tools/python/pyenv.tar.gz -C /root
 
 sudo /root/.pyenv/bin/pyenv install 3.6.10
+sudo /root/.pyenv/versions/3.6.10/bin/pip install --upgrade pip
 sudo chmod a+x /tmp/mk_python_venv
-sudo /tmp/mk_python_venv peach 1.0 3.6.10
+sudo /tmp/mk_python_venv peach 1.0.210831 3.6.10
 sudo mkdir -p /opt/tools/cuppa-chart/1.4
 sudo unzip /opt/tools/cuppa/1.4/cuppa.jar cuppa-chart/* -d /tmp/cuppa-chart-1.4
 sudo mv /tmp/cuppa-chart-1.4/cuppa-chart/* /opt/tools/cuppa-chart/1.4/

--- a/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
@@ -77,6 +77,6 @@ public interface Versions {
     }
 
     static String imageVersion() {
-        return "5-23";
+        return "5-24";
     }
 }


### PR DESCRIPTION
There were a few problems here: (1) Another PR for PEACH was created
uner this same branch name to update one of the dependencies, as the
existing version had stopped building properly.

(2) Potentially frustrating things with the dependencies was the fact that
the `pip` command was not being properly propagated into the PyEnv
environments unless the copy that we extract from our tarball into
`/root/.pyenv` was first updated. The symptom was that the `pip` command
would be namespaced under Python version 3.5 instead of 3.6 in the
virtual environment, which if nothing else was confusing.

(3) I've added some cleanup commands in the `tools.cmds` to delete existing
PyEnv and tools as problems are caused by having the Python environments
already in place when running with the `-t` command.

Also bumped the versions to avoid confusion with the existing 5.23 images.