### PR TITLE
DEV-2221 Upgrade PEACH to v1.3

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/peach/Peach.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/peach/Peach.java
@@ -54,13 +54,13 @@ public class Peach implements Stage<PeachOutput, SomaticRunMetadata> {
         return List.of(new Python3Command("peach",
                 Versions.PEACH,
                 "src/main.py",
-                List.of(purpleGermlineVcfDownload.getLocalTargetPath(),
-                        metadata.tumor().sampleName(),
-                        metadata.reference().sampleName(),
-                        Versions.PEACH,
-                        VmDirectories.OUTPUT,
-                        resourceFiles.peachFilterBed(),
-                        "/usr/bin/vcftools")));
+                List.of("--vcf", purpleGermlineVcfDownload.getLocalTargetPath(),
+                        "--sample_t_id", metadata.tumor().sampleName(),
+                        "--sample_r_id", metadata.reference().sampleName(),
+                        "--version", Versions.PEACH,
+                        "--outputdir", VmDirectories.OUTPUT,
+                        "--panel", resourceFiles.peachFilterBed(),
+                        "--vcftools", "/usr/bin/vcftools")));
     }
 
     @Override

--- a/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
@@ -34,7 +34,7 @@ public interface Versions {
     String REPEAT_MASKER = "4.1.1";
     String KRAKEN = "2.1.0";
     String CUPPA = "1.4";
-    String PEACH = "1.0";
+    String PEACH = "1.3";
     String SIGS = "1.0";
 
     static void printAll() {

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/peach/PeachTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/peach/PeachTest.java
@@ -54,9 +54,9 @@ public class PeachTest extends TertiaryStageTest<PeachOutput> {
 
     @Override
     protected List<String> expectedCommands() {
-        return Collections.singletonList("/opt/tools/peach/1.0_venv/bin/python /opt/tools/peach/1.0/src/main.py "
-                + "/data/input/tumor.purple.germline.vcf.gz tumor reference 1.0 /data/output /opt/resources/peach/37/min_DPYD.json "
-                + "/usr/bin/vcftools");
+        return Collections.singletonList("/opt/tools/peach/1.3_venv/bin/python /opt/tools/peach/1.3/src/main.py "
+                + "--vcf /data/input/tumor.purple.germline.vcf.gz --sample_t_id tumor --sample_r_id reference --version 1.3 "
+                + "--outputdir /data/output --panel /opt/resources/peach/37/min_DPYD.json --vcftools /usr/bin/vcftools");
     }
 
     @Override


### PR DESCRIPTION
This is required to properly fix the problems we were having with resolving
Python dependencies as this version updates one of those which was no longer
installable.

Also sometime between the previous 1.0 version and this one the format of the
command line changed so that has been updated too.