### PR TITLE
DEV-2221 Update PEACH arguments

### DIFF
--- a/batch-operations/src/main/java/com/hartwig/batch/operations/LilacBatch.java
+++ b/batch-operations/src/main/java/com/hartwig/batch/operations/LilacBatch.java
@@ -195,5 +195,4 @@ public class LilacBatch implements BatchOperation {
             return GoogleStorageLocation.of(HLA_BAMS_BUCKET, getTumor() + "/" + getTumor() + ".hla.bam.bai");
         }
     }
-
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/peach/Peach.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/peach/Peach.java
@@ -57,10 +57,9 @@ public class Peach implements Stage<PeachOutput, SomaticRunMetadata> {
                 List.of("--vcf", purpleGermlineVcfDownload.getLocalTargetPath(),
                         "--sample_t_id", metadata.tumor().sampleName(),
                         "--sample_r_id", metadata.reference().sampleName(),
-                        "--version", Versions.PEACH,
+                        "--tool_version", Versions.PEACH,
                         "--outputdir", VmDirectories.OUTPUT,
-                        "--panel", resourceFiles.peachFilterBed(),
-                        "--vcftools", "/usr/bin/vcftools")));
+                        "--panel", resourceFiles.peachFilterBed())));
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/peach/PeachTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/peach/PeachTest.java
@@ -55,8 +55,8 @@ public class PeachTest extends TertiaryStageTest<PeachOutput> {
     @Override
     protected List<String> expectedCommands() {
         return Collections.singletonList("/opt/tools/peach/1.3_venv/bin/python /opt/tools/peach/1.3/src/main.py "
-                + "--vcf /data/input/tumor.purple.germline.vcf.gz --sample_t_id tumor --sample_r_id reference --version 1.3 "
-                + "--outputdir /data/output --panel /opt/resources/peach/37/min_DPYD.json --vcftools /usr/bin/vcftools");
+                + "--vcf /data/input/tumor.purple.germline.vcf.gz --sample_t_id tumor --sample_r_id reference --tool_version 1.3 "
+                + "--outputdir /data/output --panel /opt/resources/peach/37/min_DPYD.json");
     }
 
     @Override


### PR DESCRIPTION
Remove the disused vctools argument and update the name of the version argument
to tool_version.

Separately to this the resources were also updated and a new image made.
