### PR TITLE
DEV-2296 Fix intermittent failure in batch

### DIFF
--- a/batch-operations/src/main/java/com/hartwig/batch/operations/TeloBatch.java
+++ b/batch-operations/src/main/java/com/hartwig/batch/operations/TeloBatch.java
@@ -11,7 +11,16 @@ import com.hartwig.batch.api.RemoteLocationsApi;
 import com.hartwig.batch.input.InputBundle;
 import com.hartwig.batch.input.InputFileDescriptor;
 import com.hartwig.pipeline.ResultsDirectory;
-import com.hartwig.pipeline.execution.vm.*;
+import com.hartwig.pipeline.execution.vm.Bash;
+import com.hartwig.pipeline.execution.vm.BashCommand;
+import com.hartwig.pipeline.execution.vm.BashStartupScript;
+import com.hartwig.pipeline.execution.vm.ImmutableVirtualMachineJobDefinition;
+import com.hartwig.pipeline.execution.vm.InputDownload;
+import com.hartwig.pipeline.execution.vm.OutputUpload;
+import com.hartwig.pipeline.execution.vm.RuntimeFiles;
+import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
+import com.hartwig.pipeline.execution.vm.VirtualMachinePerformanceProfile;
+import com.hartwig.pipeline.execution.vm.VmDirectories;
 import com.hartwig.pipeline.resource.RefGenomeVersion;
 import com.hartwig.pipeline.resource.ResourceFiles;
 import com.hartwig.pipeline.resource.ResourceFilesFactory;
@@ -57,10 +66,10 @@ public class TeloBatch implements BatchOperation
                 /*() -> format("gsutil -u hmf-crunch cp gs://%s/%s/%s %s",
                 COMMON_RESOURCES, TELO_DIR, TELO_JAR, VmDirectories.TOOLS));*/
 
-        InputDownload tumorBamDownload = new InputDownload(locationsApi.getTumorAlignment());
-        InputDownload tumorBamIndexDownload = new InputDownload(locationsApi.getTumorAlignmentIndex());
-        InputDownload referenceBamDownload = new InputDownload(locationsApi.getReferenceAlignment());
-        InputDownload referenceBamIndexDownload = new InputDownload(locationsApi.getReferenceAlignmentIndex());
+        InputDownload tumorBamDownload = InputDownload.turbo(locationsApi.getTumorAlignment());
+        InputDownload tumorBamIndexDownload = InputDownload.turbo(locationsApi.getTumorAlignmentIndex());
+        InputDownload referenceBamDownload = InputDownload.turbo(locationsApi.getReferenceAlignment());
+        InputDownload referenceBamIndexDownload = InputDownload.turbo(locationsApi.getReferenceAlignmentIndex());
 
         // ref genome
         final ResourceFiles resourceFiles = ResourceFilesFactory.buildResourceFiles(RefGenomeVersion.V37);
@@ -88,7 +97,8 @@ public class TeloBatch implements BatchOperation
                 .name("telo")
                 .startupCommand(commands)
                 .namespacedResults(ResultsDirectory.defaultDirectory())
-                .workingDiskSpaceGb(750)
+                .workingDiskSpaceGb(500)
+                .performanceProfile(VirtualMachinePerformanceProfile.custom(16, 16))
                 .build();
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/InputDownload.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/InputDownload.java
@@ -2,20 +2,36 @@ package com.hartwig.pipeline.execution.vm;
 
 import static java.lang.String.format;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 
 public class InputDownload implements BashCommand {
 
     private final GoogleStorageLocation sourceLocation;
     private final String localTargetPath;
+    private final List<String> gsutilOptions;
 
     public InputDownload(final GoogleStorageLocation sourceLocation) {
         this(sourceLocation, localPath(sourceLocation));
     }
 
     public InputDownload(final GoogleStorageLocation sourceLocation, final String localTargetPath) {
+        this(sourceLocation, localTargetPath, Collections.emptyList());
+    }
+
+    private InputDownload(final GoogleStorageLocation sourceLocation, final String localTargetPath, final List<String> gsutilOptions) {
         this.sourceLocation = sourceLocation;
         this.localTargetPath = localTargetPath;
+        this.gsutilOptions = new ArrayList<>(gsutilOptions);
+    }
+
+    public static InputDownload turbo(final GoogleStorageLocation sourceLocation) {
+        return new InputDownload(sourceLocation, localPath(sourceLocation), List.of("'GSUtil:parallel_thread_count=1'",
+                "GSUtil:sliced_object_download_max_components=$(nproc)"));
     }
 
     private static String localPath(final GoogleStorageLocation sourceLocation) {
@@ -25,8 +41,13 @@ public class InputDownload implements BashCommand {
 
     @Override
     public String asBash() {
+        String topLevelArgs = format("%s%s", gsutilOptions.stream().map(o -> "-o " + o).collect(Collectors.joining(" ")),
+                sourceLocation.billingProject().map(p -> " -u " + p + " ").orElse("")).trim();
+        if (!topLevelArgs.isEmpty()) {
+            topLevelArgs = topLevelArgs + " ";
+        }
         return format("gsutil %s-qm cp -r -n gs://%s/%s%s %s%s",
-                sourceLocation.billingProject().map(p -> "-u " + p + " ").orElse(""),
+                topLevelArgs,
                 sourceLocation.bucket(),
                 sourceLocation.path(),
                 sourceLocation.isDirectory() ? "/*" : "",

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/QuotaConstrainedComputeEngine.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/QuotaConstrainedComputeEngine.java
@@ -14,15 +14,15 @@ public class QuotaConstrainedComputeEngine implements ComputeEngine {
     private final ServiceUsage serviceUsage;
     private final String project;
     private final String region;
-    private final double contrainByPercentage;
+    private final double constrainByPercentage;
 
     public QuotaConstrainedComputeEngine(final ComputeEngine decorated, final ServiceUsage serviceUsage, final String region,
-            final String project, final double contrainByPercentage) {
+            final String project, final double constrainByPercentage) {
         this.decorated = decorated;
         this.serviceUsage = serviceUsage;
         this.project = project;
         this.region = region;
-        this.contrainByPercentage = contrainByPercentage;
+        this.constrainByPercentage = constrainByPercentage;
     }
 
     @Override
@@ -47,7 +47,7 @@ public class QuotaConstrainedComputeEngine implements ComputeEngine {
                     .filter(b -> region(b).equals(region))
                     .findFirst()
                     .orElseThrow();
-            int maxCPU = (int) (regionalQuota.getEffectiveLimit().intValue() * contrainByPercentage);
+            int maxCPU = (int) (regionalQuota.getEffectiveLimit().intValue() * constrainByPercentage);
             if (machineType.cpus() > maxCPU) {
                 double reductionRatio = (double) maxCPU / machineType.cpus();
                 constrained = VirtualMachineJobDefinition.builder()


### PR DESCRIPTION
The symptoms of the problem were that the "finished" counter in the batches
was incrementing rather quickly but this did not appear to be tied to actual VM
lifecycles.

Turns out this was due to failing to consider the API in the creation of the
VM configuration. The inputs were being resolved against the dataset but the
traffic on the API was too much and it was falling over.

I've introduced retry mechanisms on the API communication and also am now
properly handling failures such that exceptions outside
of the ComputeEngine are now rippled back up to the status reporter as
pipeline failures.

Also correct typo I happened across and commit the tunings I did to the
TeloBatch.