### PR TITLE
DEV-2303 Make batch defaults safer

### DIFF
--- a/batch/src/main/java/com/hartwig/batch/BatchArguments.java
+++ b/batch/src/main/java/com/hartwig/batch/BatchArguments.java
@@ -36,7 +36,6 @@ public interface BatchArguments extends CommonArguments {
                     .project(commandLine.getOptionValue(PROJECT, CommonArguments.DEFAULT_DEVELOPMENT_PROJECT))
                     .region(commandLine.getOptionValue(REGION, CommonArguments.DEFAULT_REGION))
                     .useLocalSsds(parseBoolean(commandLine.getOptionValue(LOCAL_SSDS, "true")))
-                    .usePreemptibleVms(parseBoolean(commandLine.getOptionValue(PREEMPTIBLE_VMS, "true")))
                     .pollInterval(Integer.parseInt(commandLine.getOptionValue(POLL_INTERVAL, "60")))
                     .privateKeyPath(CommonArguments.privateKey(commandLine))
                     .cloudSdkPath(commandLine.getOptionValue(CLOUD_SDK, "/usr/bin"))
@@ -48,6 +47,7 @@ public interface BatchArguments extends CommonArguments {
                     .network(commandLine.getOptionValue(PRIVATE_NETWORK, DEFAULT_NETWORK))
                     .refGenomeVersion(RefGenomeVersion.V37)
                     .imageProject("hmf-pipeline-development")
+                    .usePreemptibleVms(true)
                     .build();
         } catch (ParseException e) {
             String message = "Failed to parse arguments";
@@ -76,8 +76,11 @@ public interface BatchArguments extends CommonArguments {
                 .addOption(stringOption(CLOUD_SDK, "Local directory containing gcloud command"))
                 .addOption(stringOption(CONCURRENCY, "Limit the number of VMs executing at once to this number"))
                 .addOption(stringOption(INPUT_FILE, "Read list of target resources from this inputs file"))
-                .addOption(booleanOption(LOCAL_SSDS, "Whether to use local SSDs for better performance and lower cost"))
-                .addOption(booleanOption(PREEMPTIBLE_VMS, "Use pre-emptible VMs to lower cost"))
+                .addOption(Option.builder(LOCAL_SSDS)
+                        .hasArg()
+                        .argName("true|false")
+                        .desc("Whether to use local SSDs for better performance and lower cost")
+                        .build())
                 .addOption(stringOption(PRIVATE_KEY_PATH, "Path to JSON file containing GCP credentials"))
                 .addOption(stringOption(SERVICE_ACCOUNT_EMAIL, "Email of service account"))
                 .addOption(stringOption(OUTPUT_BUCKET, "Output bucket (must exist and must be writable by the service account)"))
@@ -87,10 +90,6 @@ public interface BatchArguments extends CommonArguments {
 
     private static Option stringOption(final String option, final String description) {
         return Option.builder(option).hasArg().desc(description).build();
-    }
-
-    private static Option booleanOption(final String option, final String description) {
-        return Option.builder(option).hasArg().argName("true|false").desc(description).build();
     }
 
     static ImmutableBatchArguments.Builder builder() {

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/MachineType.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/MachineType.java
@@ -7,9 +7,6 @@ import org.immutables.value.Value;
 @Value.Immutable
 public interface MachineType {
 
-    String GOOGLE_STANDARD_16 = "n1-standard-16";
-    String GOOGLE_STANDARD_32 = "n1-standard-32";
-    String GOOGLE_HIGHMEM_32 = "n1-highmem-32";
     int DEFAULT_DISK_SIZE = 500;
 
     String uri();
@@ -24,23 +21,7 @@ public interface MachineType {
     }
 
     static MachineType defaultVm() {
-        return ImmutableMachineType.builder().uri(GOOGLE_STANDARD_32).memoryGB(120).cpus(32).build();
-    }
-
-    static MachineType defaultWorker() {
-        return highMemoryWorker();
-    }
-
-    static MachineType highMemoryWorker() {
-        return ImmutableMachineType.builder().uri(GOOGLE_HIGHMEM_32).memoryGB(208).cpus(32).diskSizeGB(250).build();
-    }
-
-    static MachineType defaultPreemtibleWorker() {
-        return ImmutableMachineType.builder().from(defaultWorker()).build();
-    }
-
-    static MachineType defaultMaster() {
-        return ImmutableMachineType.builder().uri(GOOGLE_STANDARD_16).memoryGB(60).cpus(16).diskSizeGB(1000).build();
+        return custom(8, 8);
     }
 
     static MachineType custom(int memoryGB, int cores) {

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
@@ -1,5 +1,7 @@
 package com.hartwig.pipeline.execution.vm;
 
+import static com.hartwig.pipeline.execution.vm.VirtualMachinePerformanceProfile.custom;
+
 import com.hartwig.pipeline.ResultsDirectory;
 import com.hartwig.pipeline.execution.JobDefinition;
 import com.hartwig.pipeline.tools.Versions;
@@ -63,7 +65,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
         return ImmutableVirtualMachineJobDefinition.builder()
                 .name("snpgenotype")
                 .startupCommand(startupScript)
-                .performanceProfile(VirtualMachinePerformanceProfile.custom(4, 16))
+                .performanceProfile(custom(4, 16))
                 .namespacedResults(resultsDirectory)
                 .build();
     }
@@ -72,7 +74,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
         return ImmutableVirtualMachineJobDefinition.builder()
                 .name("germline")
                 .startupCommand(startupScript)
-                .performanceProfile(VirtualMachinePerformanceProfile.custom(32, 40))
+                .performanceProfile(custom(32, 40))
                 .namespacedResults(resultsDirectory)
                 .build();
     }
@@ -81,6 +83,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
         return ImmutableVirtualMachineJobDefinition.builder()
                 .name("sage-somatic")
                 .startupCommand(startupScript)
+                .performanceProfile(custom(32, 120))
                 .namespacedResults(resultsDirectory)
                 .build();
     }
@@ -88,7 +91,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
     static VirtualMachineJobDefinition sageGermlineCalling(BashStartupScript startupScript, ResultsDirectory resultsDirectory) {
         return ImmutableVirtualMachineJobDefinition.builder()
                 .name("sage-germline")
-                .performanceProfile(VirtualMachinePerformanceProfile.custom(4, 16))
+                .performanceProfile(custom(4, 16))
                 .startupCommand(startupScript)
                 .namespacedResults(resultsDirectory)
                 .build();
@@ -98,7 +101,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
         return ImmutableVirtualMachineJobDefinition.builder()
                 .name("gridss")
                 .startupCommand(startupScript)
-                .performanceProfile(VirtualMachinePerformanceProfile.custom(12, 64))
+                .performanceProfile(custom(12, 64))
                 .namespacedResults(resultsDirectory)
                 .build();
     }
@@ -107,7 +110,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
         return ImmutableVirtualMachineJobDefinition.builder()
                 .name("gripss")
                 .startupCommand(startupScript)
-                .performanceProfile(VirtualMachinePerformanceProfile.custom(6, 30))
+                .performanceProfile(custom(6, 30))
                 .namespacedResults(resultsDirectory)
                 .build();
     }
@@ -117,7 +120,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
                 .name("purple")
                 .startupCommand(bash)
                 .namespacedResults(resultsDirectory)
-                .performanceProfile(VirtualMachinePerformanceProfile.custom(4, 16))
+                .performanceProfile(custom(4, 16))
                 .workingDiskSpaceGb(375)
                 .build();
     }
@@ -127,6 +130,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
                 .name("amber")
                 .startupCommand(startupScript)
                 .namespacedResults(resultsDirectory)
+                .performanceProfile(custom(32, 120))
                 .build();
     }
 
@@ -135,7 +139,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
                 .name("virusbreakend")
                 .startupCommand(startupScript)
                 .namespacedResults(resultsDirectory)
-                .performanceProfile(VirtualMachinePerformanceProfile.custom(12, 64))
+                .performanceProfile(custom(12, 64))
                 .build();
     }
 
@@ -144,7 +148,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
                 .name("cobalt")
                 .startupCommand(startupScript)
                 .namespacedResults(resultsDirectory)
-                .performanceProfile(VirtualMachinePerformanceProfile.custom(16, 16))
+                .performanceProfile(custom(16, 16))
                 .build();
     }
 
@@ -152,7 +156,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
         return ImmutableVirtualMachineJobDefinition.builder()
                 .name("bam-metrics")
                 .startupCommand(startupScript)
-                .performanceProfile(VirtualMachinePerformanceProfile.custom(8, 32))
+                .performanceProfile(custom(8, 32))
                 .namespacedResults(resultsDirectory)
                 .build();
     }
@@ -161,7 +165,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
         return ImmutableVirtualMachineJobDefinition.builder()
                 .name("health-checker")
                 .startupCommand(startupScript)
-                .performanceProfile(VirtualMachinePerformanceProfile.custom(8, 32))
+                .performanceProfile(custom(8, 32))
                 .namespacedResults(resultsDirectory)
                 .build();
     }
@@ -170,7 +174,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
         return ImmutableVirtualMachineJobDefinition.builder()
                 .name("flagstat")
                 .startupCommand(startupScript)
-                .performanceProfile(VirtualMachinePerformanceProfile.defaultVm())
+                .performanceProfile(custom(32, 120))
                 .namespacedResults(resultsDirectory)
                 .build();
     }
@@ -179,7 +183,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
         return ImmutableVirtualMachineJobDefinition.builder()
                 .name("aligner-" + lane)
                 .startupCommand(startupScript)
-                .performanceProfile(VirtualMachinePerformanceProfile.custom(96, 96))
+                .performanceProfile(custom(96, 96))
                 .namespacedResults(resultsDirectory)
                 .build();
     }
@@ -188,7 +192,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
         return ImmutableVirtualMachineJobDefinition.builder()
                 .name("merge-markdup")
                 .startupCommand(startupScript)
-                .performanceProfile(VirtualMachinePerformanceProfile.custom(32, 120))
+                .performanceProfile(custom(32, 120))
                 .namespacedResults(resultsDirectory)
                 .build();
     }
@@ -198,7 +202,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
                 .name("linx")
                 .startupCommand(startupScript)
                 .namespacedResults(resultsDirectory)
-                .performanceProfile(VirtualMachinePerformanceProfile.custom(4, 12))
+                .performanceProfile(custom(4, 12))
                 .workingDiskSpaceGb(375)
                 .build();
     }
@@ -208,7 +212,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
                 .name("chord")
                 .startupCommand(startupScript)
                 .namespacedResults(resultsDirectory)
-                .performanceProfile(VirtualMachinePerformanceProfile.custom(4, 12))
+                .performanceProfile(custom(4, 12))
                 .workingDiskSpaceGb(375)
                 .build();
     }


### PR DESCRIPTION
The batch framework currently makes it a bit too easy to create expensive
runs. This change removes the ability to use non-pre-emptible VMs, as the cost
difference is a factor of 5x.

Also change the default for VM definitions to a custom machine with 8 cores
and 8GB RAM. The references in the rest of the pipeline code have been updated
to use custom machines reflecting the original default.