### PR TITLE
DEV-2227 Populate start and end time on both diag and research runs

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/ApiRunStatus.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/ApiRunStatus.java
@@ -4,32 +4,20 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.hartwig.api.RunApi;
 import com.hartwig.api.model.Run;
 import com.hartwig.api.model.RunFailure;
 import com.hartwig.api.model.Status;
 import com.hartwig.api.model.UpdateRun;
 import com.hartwig.pipeline.execution.PipelineStatus;
-import com.hartwig.pipeline.jackson.ObjectMappers;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ApiRunStatus {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ApiRunStatus.class);
     private static final String PIPELINE_SOURCE = "Pipeline";
     private static final String HEALTH_CHECK = "HealthCheck";
 
     static void start(final RunApi runApi, final Run run) {
-        UpdateRun update = new UpdateRun().failure(null).status(Status.PROCESSING).startTime(timestamp());
-        try {
-            LOGGER.info("Updating API with run status and result [{}]", ObjectMappers.get().writeValueAsString(update));
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
-        }
-        runApi.update(run.getId(), update);
+        runApi.update(run.getId(), new UpdateRun().failure(null).status(Status.PROCESSING).startTime(timestamp()));
     }
 
     static void finish(final RunApi runApi, final Run run, final PipelineStatus status) {

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/ApiRunStatus.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/ApiRunStatus.java
@@ -1,0 +1,54 @@
+package com.hartwig.pipeline.metadata;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.hartwig.api.RunApi;
+import com.hartwig.api.model.Run;
+import com.hartwig.api.model.RunFailure;
+import com.hartwig.api.model.Status;
+import com.hartwig.api.model.UpdateRun;
+import com.hartwig.pipeline.execution.PipelineStatus;
+import com.hartwig.pipeline.jackson.ObjectMappers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ApiRunStatus {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApiRunStatus.class);
+    private static final String PIPELINE_SOURCE = "Pipeline";
+    private static final String HEALTH_CHECK = "HealthCheck";
+
+    static void start(final RunApi runApi, final Run run) {
+        UpdateRun update = new UpdateRun().failure(null).status(Status.PROCESSING).startTime(timestamp());
+        try {
+            LOGGER.info("Updating API with run status and result [{}]", ObjectMappers.get().writeValueAsString(update));
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        runApi.update(run.getId(), update);
+    }
+
+    static void finish(final RunApi runApi, final Run run, final PipelineStatus status) {
+        runApi.update(run.getId(), statusUpdate(status).endTime(timestamp()));
+    }
+
+    private static UpdateRun statusUpdate(final PipelineStatus status) {
+        switch (status) {
+            case FAILED:
+                return new UpdateRun().status(Status.FAILED)
+                        .failure(new RunFailure().type(RunFailure.TypeEnum.TECHNICALFAILURE).source(PIPELINE_SOURCE));
+            case QC_FAILED:
+                return new UpdateRun().status(Status.FAILED)
+                        .failure(new RunFailure().type(RunFailure.TypeEnum.QCFAILURE).source(HEALTH_CHECK));
+            default:
+                return new UpdateRun().status(Status.FINISHED);
+        }
+    }
+
+    private static String timestamp() {
+        return LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME);
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/ApiRunStatus.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/ApiRunStatus.java
@@ -1,6 +1,7 @@
 package com.hartwig.pipeline.metadata;
 
-import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -49,6 +50,6 @@ public class ApiRunStatus {
     }
 
     private static String timestamp() {
-        return LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME);
+        return ZonedDateTime.now(ZoneOffset.UTC).toLocalDateTime().format(DateTimeFormatter.ISO_DATE_TIME);
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/ResearchMetadataApi.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/ResearchMetadataApi.java
@@ -6,9 +6,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.hartwig.api.RunApi;
 import com.hartwig.api.SampleApi;
 import com.hartwig.api.SetApi;
 import com.hartwig.api.helpers.OnlyOne;
+import com.hartwig.api.model.Run;
 import com.hartwig.api.model.Sample;
 import com.hartwig.api.model.SampleSet;
 import com.hartwig.api.model.SampleType;
@@ -22,15 +24,19 @@ public class ResearchMetadataApi implements SomaticMetadataApi {
 
     private final SampleApi sampleApi;
     private final SetApi setApi;
+    private final RunApi runApi;
+    private final Run run;
     private final String biopsyName;
     private final Arguments arguments;
     private final StagedOutputPublisher stagedOutput;
     private final Anonymizer anonymizer;
 
-    public ResearchMetadataApi(final SampleApi sampleApi, final SetApi setApi, final String biopsyName, final Arguments arguments,
-            final StagedOutputPublisher stagedOutput, final Anonymizer anonymizer) {
+    public ResearchMetadataApi(final SampleApi sampleApi, final SetApi setApi, final RunApi runApi, final Run run, final String biopsyName,
+            final Arguments arguments, final StagedOutputPublisher stagedOutput, final Anonymizer anonymizer) {
         this.sampleApi = sampleApi;
         this.setApi = setApi;
+        this.runApi = runApi;
+        this.run = run;
         this.biopsyName = biopsyName;
         this.arguments = arguments;
         this.stagedOutput = stagedOutput;
@@ -72,11 +78,12 @@ public class ResearchMetadataApi implements SomaticMetadataApi {
 
     @Override
     public void start() {
-        // do nothing
+        ApiRunStatus.start(runApi, run);
     }
 
     @Override
     public void complete(final PipelineState state, final SomaticRunMetadata metadata) {
         stagedOutput.publish(state, metadata);
+        ApiRunStatus.finish(runApi, run, state.status());
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/SomaticMetadataApiProvider.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/SomaticMetadataApiProvider.java
@@ -50,8 +50,11 @@ public class SomaticMetadataApiProvider {
         HmfApi api = HmfApi.create(arguments.sbpApiUrl());
         Bucket sourceBucket = storage.get(arguments.outputBucket());
         ObjectMapper objectMapper = ObjectMappers.get();
+        Run run = api.runs().get((long) arguments.sbpApiRunId().orElseThrow());
         return new ResearchMetadataApi(api.samples(),
                 api.sets(),
+                api.runs(),
+                run,
                 biopsyName,
                 arguments,
                 new StagedOutputPublisher(api.sets(),
@@ -60,7 +63,8 @@ public class SomaticMetadataApiProvider {
                         objectMapper,
                         new Run(),
                         Context.RESEARCH,
-                        arguments.outputCram(), true),
+                        arguments.outputCram(),
+                        true),
                 new Anonymizer(arguments));
     }
 
@@ -78,7 +82,8 @@ public class SomaticMetadataApiProvider {
                         objectMapper,
                         run,
                         arguments.analysisContext(),
-                        arguments.outputCram(), false),
+                        arguments.outputCram(),
+                        false),
                 new Anonymizer(arguments));
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/metadata/DiagnosticSomaticMetadataApiTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/metadata/DiagnosticSomaticMetadataApiTest.java
@@ -140,13 +140,14 @@ public class DiagnosticSomaticMetadataApiTest {
     }
 
     @Test
-    public void setsStatusToProcessingAndResultNullOnStartup() {
+    public void setsStatusToProcessingResultNullAndStartTimeOnStartup() {
         victim.start();
         verify(runApi).update(runIdCaptor.capture(), updateCaptor.capture());
         assertThat(runIdCaptor.getValue()).isEqualTo(RUN_ID);
         UpdateRun update = updateCaptor.getValue();
         assertThat(update.getFailure()).isNull();
         assertThat(update.getStatus()).isEqualTo(Status.PROCESSING);
+        assertThat(update.getStartTime()).isNotNull();
     }
 
     @Test
@@ -160,5 +161,14 @@ public class DiagnosticSomaticMetadataApiTest {
         when(pipelineState.status()).thenReturn(PipelineStatus.FAILED);
         victim.complete(pipelineState, somaticRunMetadata);
         verify(publisher, never()).publish(pipelineState, somaticRunMetadata);
+    }
+
+    @Test
+    public void setsEndTimeOnCompletion() {
+        when(pipelineState.status()).thenReturn(PipelineStatus.FAILED);
+        victim.complete(pipelineState, somaticRunMetadata);
+        verify(runApi).update(runIdCaptor.capture(), updateCaptor.capture());
+        UpdateRun update = updateCaptor.getValue();
+        assertThat(update.getEndTime()).isNotNull();
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/metadata/ResearchMetadataApiTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/metadata/ResearchMetadataApiTest.java
@@ -18,6 +18,7 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.pubsub.v1.PubsubMessage;
+import com.hartwig.api.RunApi;
 import com.hartwig.api.SampleApi;
 import com.hartwig.api.SetApi;
 import com.hartwig.api.model.Run;
@@ -25,6 +26,8 @@ import com.hartwig.api.model.Sample;
 import com.hartwig.api.model.SampleSet;
 import com.hartwig.api.model.SampleStatus;
 import com.hartwig.api.model.SampleType;
+import com.hartwig.api.model.Status;
+import com.hartwig.api.model.UpdateRun;
 import com.hartwig.events.Analysis.Context;
 import com.hartwig.events.Analysis.Molecule;
 import com.hartwig.events.PipelineOutputBlob;
@@ -53,13 +56,16 @@ public class ResearchMetadataApiTest {
     private static final String TUMOR_BARCODE = "FR22222222";
     private static final String REF_NAME = "reference";
     private static final String REF_BARCODE = "FR11111111";
-    public static final long TUMOR_SAMPLE_ID = 2L;
-    public static final String SET_NAME = TestInputs.defaultSomaticRunMetadata().set();
-    public static final long SET_ID = 3L;
-    public static final long REF_SAMPLE_ID = 4L;
+    private static final long TUMOR_SAMPLE_ID = 2L;
+    private static final String SET_NAME = TestInputs.defaultSomaticRunMetadata().set();
+    private static final long SET_ID = 3L;
+    private static final long REF_SAMPLE_ID = 4L;
+    private static final long RUN_ID = 1L;
     private ResearchMetadataApi victim;
     private SampleApi sampleApi;
     private SetApi setApi;
+    private RunApi runApi;
+    private Run run;
     private Bucket bucket;
     private Publisher publisher;
 
@@ -68,10 +74,14 @@ public class ResearchMetadataApiTest {
         sampleApi = mock(SampleApi.class);
         setApi = mock(SetApi.class);
         bucket = mock(Bucket.class);
+        runApi = mock(RunApi.class);
+        run = new Run().id(RUN_ID);
         publisher = mock(Publisher.class);
         ObjectMapper objectMapper = ObjectMappers.get();
         victim = new ResearchMetadataApi(sampleApi,
                 setApi,
+                runApi,
+                run,
                 BIOPSY,
                 Arguments.testDefaults(),
                 new StagedOutputPublisher(setApi, bucket, publisher, objectMapper, new Run(), Context.RESEARCH, false, true),
@@ -119,6 +129,8 @@ public class ResearchMetadataApiTest {
     public void anonymizesSampleNameWhenActivated() {
         victim = new ResearchMetadataApi(sampleApi,
                 setApi,
+                runApi,
+                run,
                 BIOPSY,
                 Arguments.testDefaults(),
                 new StagedOutputPublisher(setApi, bucket, publisher, ObjectMappers.get(), new Run(), Context.RESEARCH, true, true),
@@ -206,6 +218,32 @@ public class ResearchMetadataApiTest {
         state.add(TestOutput.builder().status(PipelineStatus.FAILED).build());
         victim.complete(state, TestInputs.defaultSomaticRunMetadata());
         verify(publisher, never()).publish(any());
+    }
+
+    @Test
+    public void setsStatusAndStartTimeOnStart() {
+        ArgumentCaptor<Long> runIdArgumentCaptor = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<UpdateRun> updateRunArgumentCaptor = ArgumentCaptor.forClass(UpdateRun.class);
+        when(runApi.update(runIdArgumentCaptor.capture(), updateRunArgumentCaptor.capture())).thenReturn(run);
+        victim.start();
+        assertThat(runIdArgumentCaptor.getValue()).isEqualTo(RUN_ID);
+        UpdateRun updateRun = updateRunArgumentCaptor.getValue();
+        assertThat(updateRun.getStartTime()).isNotNull();
+        assertThat(updateRun.getStatus()).isEqualTo(Status.PROCESSING);
+    }
+
+    @Test
+    public void setsStatusAndEndTimeOnComplete() {
+        ArgumentCaptor<Long> runIdArgumentCaptor = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<UpdateRun> updateRunArgumentCaptor = ArgumentCaptor.forClass(UpdateRun.class);
+        when(runApi.update(runIdArgumentCaptor.capture(), updateRunArgumentCaptor.capture())).thenReturn(run);
+        PipelineState state = new PipelineState();
+        state.add(TestOutput.builder().status(PipelineStatus.FAILED).build());
+        victim.complete(state, TestInputs.defaultSomaticRunMetadata());
+        assertThat(runIdArgumentCaptor.getValue()).isEqualTo(RUN_ID);
+        UpdateRun updateRun = updateRunArgumentCaptor.getValue();
+        assertThat(updateRun.getEndTime()).isNotNull();
+        assertThat(updateRun.getStatus()).isEqualTo(Status.FAILED);
     }
 
     private static Sample tumor() {


### PR DESCRIPTION
Diagnostics already populated the status, so extracted that code to be shared between the apis and added
the time population to them.  Using a standard ISO format for date (UTC)