### PR TITLE
DEV-2268 Override resources per-directory

### DIFF
--- a/cluster/images/create_public_image.sh
+++ b/cluster/images/create_public_image.sh
@@ -35,7 +35,6 @@ generated_script=$(mktemp -t image_script_generated_XXXXX.sh)
 echo "#!/usr/bin/env bash"
 echo
 echo "set -e"
-echo "gsutil cp $(dirname $0)/mk_python_venv gs://common-tools/"
 echo $GCL instances create $sourceInstance --description=\"Instance for pipeline5 disk image creation\" --zone=${ZONE} \
     --boot-disk-size 200 --boot-disk-type pd-ssd --machine-type n1-highcpu-4 --image-project=${image_project} \
     --image-family=${image_family} --scopes=default,cloud-source-repos-ro

--- a/cluster/images/private_resource_checkout.sh
+++ b/cluster/images/private_resource_checkout.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+[[ $# -ne 1 ]] && echo "Provide the project hosting the private resources repository" && exit 1
+mkdir /tmp/resources
+gcloud source repos clone common-resources-private /tmp/resources --project=${1}
+rm -r /tmp/resources/.git
+cd /tmp/resources
+find . -type f | while read f; do
+    dirname $(echo "$f" | sed 's#^\./##')
+done | sort -u | while read d; do
+    [[ $d != "." ]] && rm -r /opt/resources/$d
+done
+tar -cf - * | tar -C /opt/resources -xv


### PR DESCRIPTION
This changes the behaviour of the private resources override such that
rather than simply ovewriting files from the public repository with
those from the private that have the same path, the parent directories
will be cleared out too.

This means that rather than relying on filenames to be identical to
avoid having public resources bleed through to the private image, we
will now avoid that problem altogether. However the private resources
need to always have complete self-contained resource sets.

Note that this implementation assumes there will not be complex
multi-level overrides: all resources should be in a "leaf" directory or
imaging is likely to fail.