### PR TITLE
DEV-2358 Orange upgrade to 1.4

### DIFF
--- a/cluster/Dockerfile
+++ b/cluster/Dockerfile
@@ -9,6 +9,6 @@ RUN dpkg -i rclone-current-linux-amd64.deb
 ADD bin/pipeline5.sh pipeline5.sh
 ADD target/lib /usr/share/pipeline5/lib
 ARG VERSION
-ADD target/cluster-$VERSION.jar /usr/share/pipeline5/bootstrap.jar
+ADD target/cluster-local-SNAPSHOT.jar /usr/share/pipeline5/bootstrap.jar
 
 ENTRYPOINT ["./pipeline5.sh"]

--- a/cluster/Dockerfile
+++ b/cluster/Dockerfile
@@ -9,6 +9,6 @@ RUN dpkg -i rclone-current-linux-amd64.deb
 ADD bin/pipeline5.sh pipeline5.sh
 ADD target/lib /usr/share/pipeline5/lib
 ARG VERSION
-ADD target/cluster-local-SNAPSHOT.jar /usr/share/pipeline5/bootstrap.jar
+ADD target/cluster-$VERSION.jar /usr/share/pipeline5/bootstrap.jar
 
 ENTRYPOINT ["./pipeline5.sh"]

--- a/cluster/images/base.cmds
+++ b/cluster/images/base.cmds
@@ -4,7 +4,7 @@ echo 'tmpfs /root/.gsutil tmpfs size=128m 0 0' | sudo tee -a /etc/fstab
 sudo apt -y upgrade
 sudo apt -y update
 sudo apt -y install dirmngr apt-transport-https ca-certificates software-properties-common gnupg2
-sudo apt-key add /tmp/jranke.asc
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7'
 sudo add-apt-repository 'deb https://cloud.r-project.org/bin/linux/debian stretch-cran35/'
 sudo apt -y update
 sudo apt -y install perl-modules make time python3-pip python3-venv r-base vcftools

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/InputDownloadIfBlobExists.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/InputDownloadIfBlobExists.java
@@ -1,0 +1,26 @@
+package com.hartwig.pipeline.execution.vm;
+
+import com.hartwig.pipeline.storage.GoogleStorageLocation;
+
+public class InputDownloadIfBlobExists implements BashCommand {
+
+    private final InputDownload download;
+    private final GoogleStorageLocation googleStorageLocation;
+
+    public InputDownloadIfBlobExists(final GoogleStorageLocation googleStorageLocation) {
+        this.download = new InputDownload(googleStorageLocation);
+        this.googleStorageLocation = googleStorageLocation;
+    }
+
+    @Override
+    public String asBash() {
+        return String.format("gsutil  -q stat  gs://%s/%s; if [ $? == 0 ]; then  %s ; fi",
+                googleStorageLocation.bucket(),
+                googleStorageLocation.path(),
+                download.asBash());
+    }
+
+    public String getLocalTargetPath() {
+        return download.getLocalTargetPath();
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/resource/ResourceFiles.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/resource/ResourceFiles.java
@@ -5,6 +5,7 @@ import static com.hartwig.pipeline.resource.ResourceNames.DISEASE_ONTOLOGY;
 import static com.hartwig.pipeline.resource.ResourceNames.GRIDSS_CONFIG;
 import static com.hartwig.pipeline.resource.ResourceNames.LINX;
 import static com.hartwig.pipeline.resource.ResourceNames.MAPPABILITY;
+import static com.hartwig.pipeline.resource.ResourceNames.ORANGE;
 import static com.hartwig.pipeline.resource.ResourceNames.SIGS;
 import static com.hartwig.pipeline.resource.ResourceNames.SNPEFF;
 import static com.hartwig.pipeline.resource.ResourceNames.VIRUS_INTERPRETER;
@@ -134,6 +135,14 @@ public interface ResourceFiles {
 
     default String virusReportingDb() {
         return of(VIRUS_INTERPRETER, "virus_reporting_db.tsv");
+    }
+
+    default String orangeCohortMapping() {
+        return of(ORANGE, "cohort_mapping.tsv");
+    }
+
+    default String orangeCohortPercentiles() {
+        return of(ORANGE, "cohort_percentiles.tsv");
     }
 
     default String formPath(String name, String file) {

--- a/cluster/src/main/java/com/hartwig/pipeline/resource/ResourceNames.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/resource/ResourceNames.java
@@ -26,4 +26,5 @@ public interface ResourceNames {
     String CUPPA = "cuppa";
     String PEACH = "peach";
     String SIGS = "sigs";
+    String ORANGE = "orange";
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/cuppa/Cuppa.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/cuppa/Cuppa.java
@@ -37,7 +37,7 @@ import com.hartwig.pipeline.tools.Versions;
 public class Cuppa implements Stage<CuppaOutput, SomaticRunMetadata> {
     public static final String CUP_REPORT_SUMMARY_PNG = ".cup.report.summary.png";
     public static final String CUP_DATA_CSV = ".cup.data.csv";
-    public static final String CUPPA_CHART_PNG = ".cuppa.chart.png";
+    public static final String CUPPA_FEATURE_PLOT = ".cup.report.features.png";
     public static final String CUPPA_CONCLUSION_TXT = ".cuppa.conclusion.txt";
     public static String NAMESPACE = "cuppa";
     private final InputDownload purpleSomaticVcfDownload;
@@ -123,7 +123,7 @@ public class Cuppa implements Stage<CuppaOutput, SomaticRunMetadata> {
         final String conclusionTxt = cuppaConclusionTxt(metadata);
         final String cuppaSummaryChartPng = cupReportSummaryPng(metadata);
         final String resultsCsv = cupDataCsv(metadata);
-        final String featurePlot = cuppaChartPng(metadata);
+        final String featurePlot = cuppaFeaturePlot(metadata);
         return CuppaOutput.builder()
                 .status(jobStatus)
                 .maybeCuppaOutputLocations(CuppaOutputLocations.builder()
@@ -157,8 +157,8 @@ public class Cuppa implements Stage<CuppaOutput, SomaticRunMetadata> {
         return metadata.tumor().sampleName() + CUP_DATA_CSV;
     }
 
-    private String cuppaChartPng(final SomaticRunMetadata metadata) {
-        return metadata.tumor().sampleName() + CUPPA_CHART_PNG;
+    private String cuppaFeaturePlot(final SomaticRunMetadata metadata) {
+        return metadata.tumor().sampleName() + CUPPA_FEATURE_PLOT;
     }
 
     private String cuppaConclusionTxt(final SomaticRunMetadata metadata) {
@@ -175,7 +175,7 @@ public class Cuppa implements Stage<CuppaOutput, SomaticRunMetadata> {
         final String conclusionTxt = cuppaConclusionTxt(metadata);
         final String cuppaChart = cupReportSummaryPng(metadata);
         final String resultsCsv = cupDataCsv(metadata);
-        final String featurePlot = cuppaChartPng(metadata);
+        final String featurePlot = cuppaFeaturePlot(metadata);
         return CuppaOutput.builder()
                 .status(PipelineStatus.PERSISTED)
                 .maybeCuppaOutputLocations(CuppaOutputLocations.builder()

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/orange/Orange.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/orange/Orange.java
@@ -11,6 +11,7 @@ import com.hartwig.pipeline.execution.PipelineStatus;
 import com.hartwig.pipeline.execution.vm.BashCommand;
 import com.hartwig.pipeline.execution.vm.BashStartupScript;
 import com.hartwig.pipeline.execution.vm.InputDownload;
+import com.hartwig.pipeline.execution.vm.InputDownloadIfBlobExists;
 import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
 import com.hartwig.pipeline.execution.vm.VirtualMachinePerformanceProfile;
 import com.hartwig.pipeline.execution.vm.VmDirectories;
@@ -72,10 +73,9 @@ public class Orange implements Stage<OrangeOutput, SomaticRunMetadata> {
     private final InputDownload linxDriverCatalogTsv;
     private final InputDownload linxDriverTsv;
     private final InputDownload chordPredictionTxt;
-    private final InputDownload cuppaConclusionTxt;
     private final InputDownload cuppaSummaryPlot;
     private final InputDownload cuppaResultCsv;
-    private final InputDownload cuppaFeaturePlot;
+    private final InputDownloadIfBlobExists cuppaFeaturePlot;
     private final InputDownload peachGenotypeTsv;
     private final InputDownload protectEvidenceTsv;
     private final InputDownload annotatedVirusTsv;
@@ -108,10 +108,9 @@ public class Orange implements Stage<OrangeOutput, SomaticRunMetadata> {
         this.linxDriverCatalogTsv = new InputDownload(linxOrEmpty(linxOutput, LinxOutputLocations::driverCatalog));
         this.linxDriverTsv = new InputDownload(linxOrEmpty(linxOutput, LinxOutputLocations::drivers));
         this.chordPredictionTxt = new InputDownload(chordOutput.maybePredictions().orElse(GoogleStorageLocation.empty()));
-        this.cuppaConclusionTxt = new InputDownload(cuppaOrEmpty(cuppaOutput, CuppaOutputLocations::conclusionTxt));
         this.cuppaResultCsv = new InputDownload(cuppaOrEmpty(cuppaOutput, CuppaOutputLocations::resultCsv));
         this.cuppaSummaryPlot = new InputDownload(cuppaOrEmpty(cuppaOutput, CuppaOutputLocations::summaryChartPng));
-        this.cuppaFeaturePlot = new InputDownload(cuppaOrEmpty(cuppaOutput, CuppaOutputLocations::featurePlot));
+        this.cuppaFeaturePlot = new InputDownloadIfBlobExists(cuppaOrEmpty(cuppaOutput, CuppaOutputLocations::featurePlot));
         this.peachGenotypeTsv = new InputDownload(peachOutput.maybeGenotypeTsv().orElse(GoogleStorageLocation.empty()));
         this.protectEvidenceTsv = new InputDownload(protectOutput.maybeEvidenceTsv().orElse(GoogleStorageLocation.empty()));
         this.annotatedVirusTsv = new InputDownload(virusOutput.maybeAnnotatedVirusFile().orElse(GoogleStorageLocation.empty()));
@@ -151,10 +150,9 @@ public class Orange implements Stage<OrangeOutput, SomaticRunMetadata> {
                 linxBreakEndTsv,
                 linxDriverCatalogTsv,
                 linxDriverTsv,
-                cuppaConclusionTxt,
+                cuppaFeaturePlot,
                 cuppaResultCsv,
                 cuppaSummaryPlot,
-                cuppaFeaturePlot,
                 chordPredictionTxt,
                 protectEvidenceTsv,
                 annotatedVirusTsv,
@@ -230,12 +228,12 @@ public class Orange implements Stage<OrangeOutput, SomaticRunMetadata> {
                                 linxDriverTsv.getLocalTargetPath(),
                                 "-linx_plot_directory",
                                 linxPlotDir,
-                                "-cuppa_conclusion_txt",
-                                cuppaConclusionTxt.getLocalTargetPath(),
                                 "-cuppa_result_csv",
                                 cuppaResultCsv.getLocalTargetPath(),
                                 "-cuppa_summary_plot",
                                 cuppaSummaryPlot.getLocalTargetPath(),
+                                "-cuppa_feature_plot",
+                                cuppaFeaturePlot.getLocalTargetPath(),
                                 "-chord_prediction_txt",
                                 chordPredictionTxt.getLocalTargetPath(),
                                 "-peach_genotype_tsv",
@@ -245,7 +243,12 @@ public class Orange implements Stage<OrangeOutput, SomaticRunMetadata> {
                                 "-annotated_virus_tsv",
                                 annotatedVirusTsv.getLocalTargetPath(),
                                 "-pipeline_version_file",
-                                pipelineVersionFilePath)));
+                                pipelineVersionFilePath,
+                                "",
+                                "-cohort_mapping_tsv",
+                                resourceFiles.orangeCohortMapping(),
+                                "-cohort_percentiles_tsv",
+                                resourceFiles.orangeCohortPercentiles())));
     }
 
     @Override

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/orange/Orange.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/orange/Orange.java
@@ -244,7 +244,6 @@ public class Orange implements Stage<OrangeOutput, SomaticRunMetadata> {
                                 annotatedVirusTsv.getLocalTargetPath(),
                                 "-pipeline_version_file",
                                 pipelineVersionFilePath,
-                                "",
                                 "-cohort_mapping_tsv",
                                 resourceFiles.orangeCohortMapping(),
                                 "-cohort_percentiles_tsv",

--- a/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
@@ -36,7 +36,7 @@ public interface Versions {
     String CUPPA = "1.5";
     String PEACH = "1.4";
     String SIGS = "1.0";
-    String ORANGE = "1.2";
+    String ORANGE = "1.3";
 
     static void printAll() {
         Logger logger = LoggerFactory.getLogger(Versions.class);

--- a/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
@@ -36,7 +36,7 @@ public interface Versions {
     String CUPPA = "1.5";
     String PEACH = "1.4";
     String SIGS = "1.0";
-    String ORANGE = "1.1";
+    String ORANGE = "1.2";
 
     static void printAll() {
         Logger logger = LoggerFactory.getLogger(Versions.class);

--- a/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
@@ -36,7 +36,7 @@ public interface Versions {
     String CUPPA = "1.5";
     String PEACH = "1.4";
     String SIGS = "1.0";
-    String ORANGE = "1.3";
+    String ORANGE = "1.4";
 
     static void printAll() {
         Logger logger = LoggerFactory.getLogger(Versions.class);

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/cuppa/CuppaTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/cuppa/CuppaTest.java
@@ -23,7 +23,7 @@ import com.hartwig.pipeline.testsupport.TestInputs;
 public class CuppaTest extends TertiaryStageTest<CuppaOutput> {
 
     private static final String TUMOR_CUPPA_CONCLUSION_TXT = "tumor.cuppa.conclusion.txt";
-    private static final String TUMOR_CUPPA_CHART_PNG = "tumor.cuppa.chart.png";
+    private static final String TUMOR_CUP_REPORT_FEATURE_PNG = "tumor.cup.report.features.png";
     private static final String TUMOR_CUP_DATA_CSV = "tumor.cup.data.csv";
     private static final String TUMOR_CUP_REPORT_SUMMARY_PNG = "tumor.cup.report.summary.png";
 
@@ -50,7 +50,7 @@ public class CuppaTest extends TertiaryStageTest<CuppaOutput> {
                         new ArchivePath(Folder.root(), Cuppa.NAMESPACE, TUMOR_CUP_DATA_CSV)),
                 new AddDatatype(DataType.CUPPA_FEATURE_PLOT,
                         TestInputs.defaultSomaticRunMetadata().barcode(),
-                        new ArchivePath(Folder.root(), Cuppa.NAMESPACE, TUMOR_CUPPA_CHART_PNG)));
+                        new ArchivePath(Folder.root(), Cuppa.NAMESPACE, TUMOR_CUP_REPORT_FEATURE_PNG)));
     }
 
     @Override
@@ -77,7 +77,7 @@ public class CuppaTest extends TertiaryStageTest<CuppaOutput> {
         assertThat(output.cuppaOutputLocations().resultCsv()).isEqualTo(GoogleStorageLocation.of(SOMATIC_BUCKET + "/cuppa",
                 ResultsDirectory.defaultDirectory().path(TUMOR_CUP_DATA_CSV)));
         assertThat(output.cuppaOutputLocations().featurePlot()).isEqualTo(GoogleStorageLocation.of(SOMATIC_BUCKET + "/cuppa",
-                ResultsDirectory.defaultDirectory().path(TUMOR_CUPPA_CHART_PNG)));
+                ResultsDirectory.defaultDirectory().path(TUMOR_CUP_REPORT_FEATURE_PNG)));
     }
 
     @Override
@@ -89,7 +89,7 @@ public class CuppaTest extends TertiaryStageTest<CuppaOutput> {
         assertThat(output.cuppaOutputLocations().resultCsv()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
                 "set/cuppa/" + TUMOR_CUP_DATA_CSV));
         assertThat(output.cuppaOutputLocations().featurePlot()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
-                "set/cuppa/" + TUMOR_CUPPA_CHART_PNG));
+                "set/cuppa/" + TUMOR_CUP_REPORT_FEATURE_PNG));
     }
 
     @Override
@@ -97,7 +97,7 @@ public class CuppaTest extends TertiaryStageTest<CuppaOutput> {
         persistedDataset.addPath(DataType.CUPPA_CONCLUSION, "cuppa/" + TUMOR_CUPPA_CONCLUSION_TXT);
         persistedDataset.addPath(DataType.CUPPA_CHART, "cuppa/" + TUMOR_CUP_REPORT_SUMMARY_PNG);
         persistedDataset.addPath(DataType.CUPPA_RESULTS, "cuppa/" + TUMOR_CUP_DATA_CSV);
-        persistedDataset.addPath(DataType.CUPPA_FEATURE_PLOT, "cuppa/" + TUMOR_CUPPA_CHART_PNG);
+        persistedDataset.addPath(DataType.CUPPA_FEATURE_PLOT, "cuppa/" + TUMOR_CUP_REPORT_FEATURE_PNG);
     }
 
     @Override
@@ -109,7 +109,7 @@ public class CuppaTest extends TertiaryStageTest<CuppaOutput> {
         assertThat(output.cuppaOutputLocations().resultCsv()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
                 "cuppa/" + TUMOR_CUP_DATA_CSV));
         assertThat(output.cuppaOutputLocations().featurePlot()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
-                "cuppa/" + TUMOR_CUPPA_CHART_PNG));
+                "cuppa/" + TUMOR_CUP_REPORT_FEATURE_PNG));
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/orange/OrangeTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/orange/OrangeTest.java
@@ -59,9 +59,10 @@ public class OrangeTest extends TertiaryStageTest<OrangeOutput> {
                 input(expectedRuntimeBucketName() + "/purple/results/", "purple"),
                 input(expectedRuntimeBucketName() + "/linx/results/", "linx"),
                 input(expectedRuntimeBucketName() + "/linx/tumor.linx.drivers.tsv", "tumor.linx.drivers.tsv"),
-                input(expectedRuntimeBucketName() + "/cuppa/tumor.cuppa.conclusion.txt", "tumor.cuppa.conclusion.txt"),
+                "gsutil  -q stat  gs://run-reference-tumor-test/cuppa/tumor.cup.report.features.png; if [ $? == 0 ]; then  gsutil -o "
+                        + "'GSUtil:parallel_thread_count=1' -o GSUtil:sliced_object_download_max_components=$(nproc) -qm cp -r -n "
+                        + "gs://run-reference-tumor-test/cuppa/tumor.cup.report.features.png /data/input/tumor.cup.report.features.png ; fi",
                 input(expectedRuntimeBucketName() + "/cuppa/tumor.cup.data.csv", "tumor.cup.data.csv"),
-                input(expectedRuntimeBucketName() + "/cuppa/tumor.cuppa.chart.png", "tumor.cuppa.chart.png"),
                 input(expectedRuntimeBucketName() + "/cuppa/tumor.cup.report.summary.png", "tumor.cup.report.summary.png"),
                 input(expectedRuntimeBucketName() + "/protect/tumor.protect.tsv", "tumor.protect.tsv"),
                 input(expectedRuntimeBucketName() + "/peach/tumor.peach.genotype.tsv", "tumor.peach.genotype.tsv"));
@@ -71,7 +72,7 @@ public class OrangeTest extends TertiaryStageTest<OrangeOutput> {
     protected List<String> expectedCommands() {
         return Arrays.asList("mkdir -p /data/input/linx/plot",
                 "echo '5.25' | tee /data/input/orange_pipeline.version.txt",
-                "java -Xmx8G -jar /opt/tools/orange/1.1/orange.jar -output_dir /data/output -doid_json /opt/resources/disease_ontology/201015_doid.json "
+                "java -Xmx8G -jar /opt/tools/orange/1.2/orange.jar -output_dir /data/output -doid_json /opt/resources/disease_ontology/201015_doid.json "
                         + "-primary_tumor_doids \"01;02\" -max_evidence_level C -tumor_sample_id tumor -reference_sample_id reference "
                         + "-ref_sample_wgs_metrics_file /data/input/reference.wgsmetrics -tumor_sample_wgs_metrics_file /data/input/tumor.wgsmetrics "
                         + "-ref_sample_flagstat_file /data/input/reference.flagstat -tumor_sample_flagstat_file /data/input/tumor.flagstat "
@@ -82,11 +83,12 @@ public class OrangeTest extends TertiaryStageTest<OrangeOutput> {
                         + "-purple_somatic_driver_catalog_tsv /data/input/tumor.driver.catalog.somatic.tsv -purple_somatic_variant_vcf /data/input/tumor.purple.somatic.vcf.gz "
                         + "-linx_fusion_tsv /data/input/tumor.linx.fusion.tsv -linx_breakend_tsv /data/input/tumor.linx.breakend.tsv "
                         + "-linx_driver_catalog_tsv /data/input/tumor.linx.driver.catalog.tsv -linx_driver_tsv /data/input/tumor.linx.drivers.tsv "
-                        + "-linx_plot_directory /data/input/linx/plot -cuppa_conclusion_txt /data/input/tumor.cuppa.conclusion.txt "
+                        + "-linx_plot_directory /data/input/linx/plot "
                         + "-cuppa_result_csv /data/input/tumor.cup.data.csv -cuppa_summary_plot /data/input/tumor.cup.report.summary.png "
-                        + "-chord_prediction_txt /data/input/tumor_chord_prediction.txt "
+                        + "-cuppa_feature_plot /data/input/tumor.cup.report.features.png -chord_prediction_txt /data/input/tumor_chord_prediction.txt "
                         + "-peach_genotype_tsv /data/input/tumor.peach.genotype.tsv -protect_evidence_tsv /data/input/tumor.protect.tsv "
-                        + "-annotated_virus_tsv /data/input/tumor.virus.annotated.tsv -pipeline_version_file /data/input/orange_pipeline.version.txt");
+                        + "-annotated_virus_tsv /data/input/tumor.virus.annotated.tsv -pipeline_version_file /data/input/orange_pipeline.version.txt  "
+                        + "-cohort_mapping_tsv /opt/resources/orange/cohort_mapping.tsv -cohort_percentiles_tsv /opt/resources/orange/cohort_percentiles.tsv");
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/orange/OrangeTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/orange/OrangeTest.java
@@ -72,7 +72,7 @@ public class OrangeTest extends TertiaryStageTest<OrangeOutput> {
     protected List<String> expectedCommands() {
         return Arrays.asList("mkdir -p /data/input/linx/plot",
                 "echo '5.25' | tee /data/input/orange_pipeline.version.txt",
-                "java -Xmx8G -jar /opt/tools/orange/1.2/orange.jar -output_dir /data/output -doid_json /opt/resources/disease_ontology/201015_doid.json "
+                "java -Xmx8G -jar /opt/tools/orange/1.3/orange.jar -output_dir /data/output -doid_json /opt/resources/disease_ontology/201015_doid.json "
                         + "-primary_tumor_doids \"01;02\" -max_evidence_level C -tumor_sample_id tumor -reference_sample_id reference "
                         + "-ref_sample_wgs_metrics_file /data/input/reference.wgsmetrics -tumor_sample_wgs_metrics_file /data/input/tumor.wgsmetrics "
                         + "-ref_sample_flagstat_file /data/input/reference.flagstat -tumor_sample_flagstat_file /data/input/tumor.flagstat "
@@ -87,7 +87,7 @@ public class OrangeTest extends TertiaryStageTest<OrangeOutput> {
                         + "-cuppa_result_csv /data/input/tumor.cup.data.csv -cuppa_summary_plot /data/input/tumor.cup.report.summary.png "
                         + "-cuppa_feature_plot /data/input/tumor.cup.report.features.png -chord_prediction_txt /data/input/tumor_chord_prediction.txt "
                         + "-peach_genotype_tsv /data/input/tumor.peach.genotype.tsv -protect_evidence_tsv /data/input/tumor.protect.tsv "
-                        + "-annotated_virus_tsv /data/input/tumor.virus.annotated.tsv -pipeline_version_file /data/input/orange_pipeline.version.txt  "
+                        + "-annotated_virus_tsv /data/input/tumor.virus.annotated.tsv -pipeline_version_file /data/input/orange_pipeline.version.txt "
                         + "-cohort_mapping_tsv /opt/resources/orange/cohort_mapping.tsv -cohort_percentiles_tsv /opt/resources/orange/cohort_percentiles.tsv");
     }
 

--- a/cluster/src/test/java/com/hartwig/pipeline/testsupport/TestInputs.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/testsupport/TestInputs.java
@@ -307,7 +307,7 @@ public class TestInputs {
                         .conclusionTxt(GoogleStorageLocation.of(somaticBucket(Cuppa.NAMESPACE), TUMOR_SAMPLE + Cuppa.CUPPA_CONCLUSION_TXT))
                         .resultCsv(GoogleStorageLocation.of(somaticBucket(Cuppa.NAMESPACE), TUMOR_SAMPLE + Cuppa.CUP_DATA_CSV))
                         .summaryChartPng(GoogleStorageLocation.of(somaticBucket(Cuppa.NAMESPACE), TUMOR_SAMPLE + Cuppa.CUP_REPORT_SUMMARY_PNG))
-                        .featurePlot(GoogleStorageLocation.of(somaticBucket(Cuppa.NAMESPACE), TUMOR_SAMPLE + Cuppa.CUPPA_CHART_PNG))
+                        .featurePlot(GoogleStorageLocation.of(somaticBucket(Cuppa.NAMESPACE), TUMOR_SAMPLE + Cuppa.CUPPA_FEATURE_PLOT))
                         .build())
                 .build();
     }


### PR DESCRIPTION
Version bump plus a couple new resources.

Also implemented a fix here to check for the existence in GCS of the feature plot. This enables use
of the Orange 1.2 feature to pass a non-existent cuppa feature plot as an argument (the feature plot
is not always used).