### PR TITLE
DEV-2382 Fix some bugs in the private imager

### DIFF
--- a/cluster/images/create_private_image.sh
+++ b/cluster/images/create_private_image.sh
@@ -17,7 +17,7 @@ source_image="$1"
 json="$(gcloud compute images describe $source_image --project=$IMAGE_SOURCE_PROJECT --format=json)"
 [[ $? -ne 0 ]] && echo "Unable to find image $source_image in $IMAGE_SOURCE_PROJECT" && exit 1
 
-dest_image="${source_image}_$(date +%Y%m%d%H%M)-private"
+dest_image="${source_image}-$(date +%Y%m%d%H%M)-private"
 gcloud compute images describe $dest_image --project=$DEST_PROJECT >/dev/null 2>&1
 [[ $? -eq 0 ]] && echo "$dest_image exists in project $DEST_PROJECT!" && exit 1
 
@@ -49,6 +49,7 @@ echo "Instance running, continuing with imaging"
 
 set -e
 gcloud compute scp $(dirname $0)/private_resource_checkout.sh ${imager_vm}:/tmp/ --zone=$ZONE --project=$DEST_PROJECT --tunnel-through-iap 
+sleep 60
 $ssh --command="sudo /tmp/private_resource_checkout.sh $dest_image $SOURCE_REPO_PROJECT"
 
 gcloud compute instances stop $imager_vm --zone=${ZONE} --project=$DEST_PROJECT


### PR DESCRIPTION
There was an underscore in the name of the private image, which isn't
allowed under the naming rules for GCP images.

Also there was what appears to be a timing issue with the `git` checkout
from the private image VM, which was failing repeatedly from multiple
machines for us today. A simple `sleep 60` seems to have at least
allowed a single operation to succeed so let's wait and see whether that
lasts.