### PR TITLE
DEV-2394 Download overridden reference FASTA to alignment VM's

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/bwa/BwaAligner.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/bwa/BwaAligner.java
@@ -40,6 +40,7 @@ import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.report.ReportComponent;
 import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.report.SingleFileComponent;
+import com.hartwig.pipeline.resource.OverrideReferenceGenomeCommand;
 import com.hartwig.pipeline.resource.ResourceFiles;
 import com.hartwig.pipeline.stages.SubStageInputOutput;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
@@ -106,6 +107,8 @@ public class BwaAligner implements Aligner {
             InputDownload second =
                     new InputDownload(GoogleStorageLocation.of(rootBucket.name(), fastQFileName(sample.name(), lane.secondOfPairPath())));
             bash.addCommand(first).addCommand(second);
+            
+            bash.addCommands(OverrideReferenceGenomeCommand.overrides(arguments));
 
             SubStageInputOutput alignment = new LaneAlignment(arguments.sbpApiRunId().isPresent(),
                     resourceFiles.refGenomeFile(),


### PR DESCRIPTION
Download the FASTA file specified by the 'reference_genome_url'
command line option and the associated index files
to the VM's used for FASTQ alignment.