### PR TITLE
DEV-2523 Upgrade GRIDSS to 2.13.2

### DIFF
--- a/cluster/images/tools.cmds
+++ b/cluster/images/tools.cmds
@@ -68,9 +68,16 @@ sudo chmod a+x /opt/tools/gridss/2.11.1/gridsstools
 sudo chmod a+x /opt/tools/gridss/2.11.1/virusbreakend.sh
 sudo chmod a+x /opt/tools/gridss/2.11.1/gridss_annotate_vcf_kraken2.sh
 sudo chmod a+x /opt/tools/gridss/2.11.1/gridss_annotate_vcf_repeatmasker.sh
+sudo chmod a+x /opt/tools/gridss/2.13.2/gridss
+sudo chmod a+x /opt/tools/gridss/2.13.2/gridsstools
+sudo chmod a+x /opt/tools/gridss/2.13.2/virusbreakend
+sudo chmod a+x /opt/tools/gridss/2.13.2/gridss_annotate_vcf_kraken2
+sudo chmod a+x /opt/tools/gridss/2.13.2/gridss_annotate_vcf_repeatmasker
+
 
 sudo chmod a+x /opt/tools/samtools/1.9/samtools
 sudo chmod a+x /opt/tools/samtools/1.10/samtools
+sudo chmod a+x /opt/tools/samtools/1.14/samtools
 sudo chmod a+x /opt/tools/bcl2fastq/2.20.0.422/bcl2fastq
 sudo chmod a+x /opt/tools/star/2.7.3a/STAR
 sudo chmod a+x /opt/tools/rmblast/2.10.0/rmblastn

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/structural/gridss/stage/Driver.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/structural/gridss/stage/Driver.java
@@ -36,7 +36,7 @@ public class Driver extends SubStage {
     @Override
     public List<BashCommand> bash(final OutputFile input, final OutputFile output) {
         return Lists.newArrayList(new VersionedToolCommand(GRIDSS,
-                "gridss.sh",
+                "gridss",
                 Versions.GRIDSS,
                 "--output",
                 output.path(),

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/structural/gridss/stage/RepeatMasker.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/structural/gridss/stage/RepeatMasker.java
@@ -20,7 +20,7 @@ public class RepeatMasker extends SubStage {
     public List<BashCommand> bash(final OutputFile input, final OutputFile output) {
         String repeatMasker = VmDirectories.TOOLS + "/repeatmasker/" + Versions.REPEAT_MASKER + "/RepeatMasker";
         return List.of(new VersionedToolCommand("gridss",
-                "gridss_annotate_vcf_repeatmasker.sh",
+                "gridss_annotate_vcf_repeatmasker",
                 Versions.GRIDSS,
                 "--output",
                 output.path(),

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/virus/VirusBreakendCommand.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/virus/VirusBreakendCommand.java
@@ -11,7 +11,7 @@ public class VirusBreakendCommand extends VersionedToolCommand {
 
     public VirusBreakendCommand(ResourceFiles resourceFiles, String tumorSample, String tumorBamPath) {
         super("gridss",
-                "virusbreakend.sh",
+                "virusbreakend",
                 Versions.GRIDSS,
                 "--output",
                 VmDirectories.outputFile(tumorSample + ".virusbreakend.vcf"),

--- a/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
@@ -21,13 +21,13 @@ public interface Versions {
     String HEALTH_CHECKER = "3.3";
     String PURPLE = "3.2";
     String CIRCOS = "0.69.6";
-    String GRIDSS = "2.11.1";
-    String VIRUSBREAKEND_GRIDSS = "2.11.1";
+    String GRIDSS = "2.13.2";
+    String VIRUSBREAKEND_GRIDSS = "2.13.2";
     String VIRUS_INTERPRETER = "1.2";
     String GRIPSS = "2.0";
     String LINX = "1.17";
     String CHORD = "2.00_1.14";
-    String SAMTOOLS = "1.10";
+    String SAMTOOLS = "1.14";
     String BAMCOMP = "1.3";
     String PROTECT = "2.0";
     String REPEAT_MASKER = "4.1.1";

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageCommandBuilderTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageCommandBuilderTest.java
@@ -41,11 +41,13 @@ public class SageCommandBuilderTest {
         assertEquals(5, bash.size());
 
         assertEquals(bash.get(0),
-                "/opt/tools/samtools/1.10/samtools view -T /opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta -L /opt/resources/sage/37/SlicePanel.germline.37.bed.gz -o /data/input/COLO829v003T.bam -u -@ $(grep -c '^processor' /proc/cpuinfo) -M /data/input/COLO829v003T.cram");
-        assertEquals(bash.get(1), "/opt/tools/samtools/1.10/samtools index /data/input/COLO829v003T.bam");
+                "/opt/tools/samtools/1.14/samtools view -T /opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta -L "
+                        + "/opt/resources/sage/37/SlicePanel.germline.37.bed.gz -o /data/input/COLO829v003T.bam -u -@ $(grep -c '^processor' /proc/cpuinfo) -M /data/input/COLO829v003T.cram");
+        assertEquals(bash.get(1), "/opt/tools/samtools/1.14/samtools index /data/input/COLO829v003T.bam");
         assertEquals(bash.get(2),
-                "/opt/tools/samtools/1.10/samtools view -T /opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta -L /opt/resources/sage/37/SlicePanel.germline.37.bed.gz -o /data/input/COLO829v003R.bam -u -@ $(grep -c '^processor' /proc/cpuinfo) -M /data/input/COLO829v003R.cram");
-        assertEquals(bash.get(3), "/opt/tools/samtools/1.10/samtools index /data/input/COLO829v003R.bam");
+                "/opt/tools/samtools/1.14/samtools view -T /opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta -L "
+                        + "/opt/resources/sage/37/SlicePanel.germline.37.bed.gz -o /data/input/COLO829v003R.bam -u -@ $(grep -c '^processor' /proc/cpuinfo) -M /data/input/COLO829v003R.cram");
+        assertEquals(bash.get(3), "/opt/tools/samtools/1.14/samtools index /data/input/COLO829v003R.bam");
         assertEquals(bash.get(4), REFERENCE_SAGE_COMMAND);
     }
 

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/structural/StructuralCallerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/structural/StructuralCallerTest.java
@@ -60,11 +60,17 @@ public class StructuralCallerTest extends StageTest<StructuralCallerOutput, Soma
     @Override
     protected List<String> expectedCommands() {
         return ImmutableList.of("export PATH=\"${PATH}:/opt/tools/bwa/0.7.17\"",
-                "export PATH=\"${PATH}:/opt/tools/samtools/1.10\"",
-                "/opt/tools/gridss/2.11.1/gridss.sh --output /data/output/tumor.gridss.driver.vcf.gz --assembly /data/output/tumor"
-                        + ".assembly.bam --workingdir /data/output --reference /opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta --jar /opt/tools/gridss/2.11.1/gridss.jar --blacklist /opt/resources/gridss_repeatmasker_db/37/ENCFF001TDO.37.bed --configuration /opt/resources/gridss_config/gridss.properties --labels reference,tumor --jvmheap 31G --externalaligner /data/input/reference.bam /data/input/tumor.bam",
-                "/opt/tools/gridss/2.11.1/gridss_annotate_vcf_repeatmasker.sh --output /data/output/tumor.gridss.repeatmasker.vcf.gz --jar /opt/tools/gridss/2.11.1/gridss.jar -w /data/output --rm /opt/tools/repeatmasker/4.1.1/RepeatMasker /data/output/tumor.gridss.driver.vcf.gz",
-                "java -Xmx8G -Dsamjdk.create_index=true -Dsamjdk.use_async_io_read_samtools=true -Dsamjdk.use_async_io_write_samtools=true -Dsamjdk.use_async_io_write_tribble=true -Dsamjdk.buffer_size=4194304 -cp /opt/tools/gridss/2.11.1/gridss.jar gridss.AnnotateInsertedSequence REFERENCE_SEQUENCE=/opt/resources/virus_reference_genome/human_virus.fa INPUT=/data/output/tumor.gridss.repeatmasker.vcf.gz OUTPUT=/data/output/tumor.gridss.unfiltered.vcf.gz ALIGNMENT=APPEND WORKER_THREADS=$(grep -c '^processor' /proc/cpuinfo)");
+                "export PATH=\"${PATH}:/opt/tools/samtools/1.14\"",
+                "/opt/tools/gridss/2.13.2/gridss --output /data/output/tumor.gridss.driver.vcf.gz --assembly /data/output/tumor"
+                        + ".assembly.bam --workingdir /data/output --reference /opt/resources/reference_genome/37/Homo_sapiens.GRCh37"
+                        + ".GATK.illumina.fasta --jar /opt/tools/gridss/2.13.2/gridss.jar --blacklist "
+                        + "/opt/resources/gridss_repeatmasker_db/37/ENCFF001TDO.37.bed --configuration /opt/resources/gridss_config/gridss.properties --labels reference,tumor --jvmheap 31G --externalaligner /data/input/reference.bam /data/input/tumor.bam",
+                "/opt/tools/gridss/2.13.2/gridss_annotate_vcf_repeatmasker --output /data/output/tumor.gridss.repeatmasker.vcf.gz "
+                        + "--jar /opt/tools/gridss/2.13.2/gridss.jar -w /data/output --rm /opt/tools/repeatmasker/4.1.1/RepeatMasker "
+                        + "/data/output/tumor.gridss.driver.vcf.gz",
+                "java -Xmx8G -Dsamjdk.create_index=true -Dsamjdk.use_async_io_read_samtools=true -Dsamjdk"
+                        + ".use_async_io_write_samtools=true -Dsamjdk.use_async_io_write_tribble=true -Dsamjdk.buffer_size=4194304 -cp "
+                        + "/opt/tools/gridss/2.13.2/gridss.jar gridss.AnnotateInsertedSequence REFERENCE_SEQUENCE=/opt/resources/virus_reference_genome/human_virus.fa INPUT=/data/output/tumor.gridss.repeatmasker.vcf.gz OUTPUT=/data/output/tumor.gridss.unfiltered.vcf.gz ALIGNMENT=APPEND WORKER_THREADS=$(grep -c '^processor' /proc/cpuinfo)");
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/cram/CramConversionTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/cram/CramConversionTest.java
@@ -59,7 +59,7 @@ public class CramConversionTest extends StageTest<CramOutput, SingleSampleRunMet
 
     @Override
     protected List<String> expectedCommands() {
-        String samtools = "/opt/tools/samtools/1.10/samtools";
+        String samtools = "/opt/tools/samtools/1.14/samtools";
         String input = "/data/input/reference.bam";
         String output = "/data/output/reference.cram";
         return ImmutableList.of(format("%s view -T %s -o %s -O cram,embed_ref=1 -@ $(grep -c '^processor' /proc/cpuinfo) %s",
@@ -70,7 +70,8 @@ public class CramConversionTest extends StageTest<CramOutput, SingleSampleRunMet
                 format("%s index %s", samtools, output),
                 format("java -Xmx4G -cp /opt/tools/bamcomp/1.3/bamcomp.jar com.hartwig.bamcomp.BamCompMain "
                                 + "-r /opt/resources/reference_genome/38/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna -1 %s -2 %s -n 6 "
-                                + "--samtools-binary /opt/tools/samtools/1.10/samtools --sambamba-binary /opt/tools/sambamba/0.6.8/sambamba",
+                                + "--samtools-binary /opt/tools/samtools/1.14/samtools --sambamba-binary /opt/tools/sambamba/0.6"
+                                + ".8/sambamba",
                         input,
                         output));
     }

--- a/cluster/src/test/java/com/hartwig/pipeline/cram2bam/Cram2BamTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/cram2bam/Cram2BamTest.java
@@ -48,8 +48,8 @@ public class Cram2BamTest extends StageTest<AlignmentOutput, SingleSampleRunMeta
 
     @Override
     protected List<String> expectedCommands() {
-        return List.of("/opt/tools/samtools/1.10/samtools view -O bam -o /data/output/tumor.bam -@ $(grep -c '^processor' /proc/cpuinfo) "
-                + "/data/input/tumor.bam", "/opt/tools/samtools/1.10/samtools index /data/output/tumor.bam");
+        return List.of("/opt/tools/samtools/1.14/samtools view -O bam -o /data/output/tumor.bam -@ $(grep -c '^processor' /proc/cpuinfo) "
+                + "/data/input/tumor.bam", "/opt/tools/samtools/1.14/samtools index /data/output/tumor.bam");
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/metrics/BamMetricsCommandTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/metrics/BamMetricsCommandTest.java
@@ -40,7 +40,7 @@ public class BamMetricsCommandTest {
     @Test
     public void shouldStartCommandLineWithJarAndOperation() {
         assertThat(actual).startsWith("java -Xmx24G -Dsamjdk.use_async_io_read_samtools=true -Dsamjdk.use_async_io_write_samtools=true "
-                + "-Dsamjdk.use_async_io_write_tribble=true -Dsamjdk.buffer_size=4194304 -cp /opt/tools/gridss/2.11.1/gridss.jar "
+                + "-Dsamjdk.use_async_io_write_tribble=true -Dsamjdk.buffer_size=4194304 -cp /opt/tools/gridss/2.13.2/gridss.jar "
                 + "picard.cmdline.PicardCommandLine " + OPERATION);
     }
 

--- a/cluster/src/test/java/com/hartwig/pipeline/metrics/BamMetricsTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/metrics/BamMetricsTest.java
@@ -59,7 +59,7 @@ public class BamMetricsTest extends StageTest<BamMetricsOutput, SingleSampleRunM
     @Override
     protected List<String> expectedCommands() {
         return ImmutableList.of("java -Xmx24G -Dsamjdk.use_async_io_read_samtools=true -Dsamjdk.use_async_io_write_samtools=true "
-                + "-Dsamjdk.use_async_io_write_tribble=true -Dsamjdk.buffer_size=4194304 -cp /opt/tools/gridss/2.11.1/gridss.jar "
+                + "-Dsamjdk.use_async_io_write_tribble=true -Dsamjdk.buffer_size=4194304 -cp /opt/tools/gridss/2.13.2/gridss.jar "
                 + "picard.cmdline.PicardCommandLine CollectWgsMetrics "
                 + "REFERENCE_SEQUENCE=/opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta "
                 + "INPUT=/data/input/reference.bam OUTPUT=/data/output/" + REFERENCE_WGSMETRICS + " MINIMUM_MAPPING_QUALITY=20 "

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/virus/VirusAnalysisTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/virus/VirusAnalysisTest.java
@@ -87,16 +87,17 @@ public class VirusAnalysisTest extends TertiaryStageTest<VirusOutput> {
 
     @Override
     protected List<String> expectedCommands() {
-        return List.of("export PATH=\"${PATH}:/opt/tools/gridss/2.11.1\"",
+        return List.of("export PATH=\"${PATH}:/opt/tools/gridss/2.13.2\"",
                 "export PATH=\"${PATH}:/opt/tools/repeatmasker/4.1.1\"",
                 "export PATH=\"${PATH}:/opt/tools/kraken2/2.1.0\"",
-                "export PATH=\"${PATH}:/opt/tools/samtools/1.10\"",
+                "export PATH=\"${PATH}:/opt/tools/samtools/1.14\"",
                 "export PATH=\"${PATH}:/opt/tools/bcftools/1.9\"",
                 "export PATH=\"${PATH}:/opt/tools/bwa/0.7.17\"",
-                "/opt/tools/gridss/2.11.1/virusbreakend.sh " + "--output /data/output/tumor.virusbreakend.vcf "
+                "/opt/tools/gridss/2.13.2/virusbreakend --output /data/output/tumor.virusbreakend.vcf "
                         + "--workingdir /data/output "
                         + "--reference /opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta "
-                        + "--db /opt/resources/virusbreakend_db --jar /opt/tools/gridss/2.11.1/gridss.jar --gridssargs \"--jvmheap 60G\" /data/input/tumor.bam",
+                        + "--db /opt/resources/virusbreakend_db --jar /opt/tools/gridss/2.13.2/gridss.jar --gridssargs \"--jvmheap 60G\" "
+                        + "/data/input/tumor.bam",
                 "java -Xmx2G -jar /opt/tools/virus-interpreter/1.2/virus-interpreter.jar -sample_id tumor "
                         + "-purple_purity_tsv /data/input/tumor.purple.purity.tsv -purple_qc_file /data/input/tumor.purple.qc "
                         + "-tumor_sample_wgs_metrics_file /data/input/tumor.wgsmetrics "


### PR DESCRIPTION
Version bump plus samtools upgrade to 1.14 and removal of sh
suffix from all gridss script invocations.