### PR TITLE
DEV-2573 Move defaulting of empty output locations

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/SingleSamplePipeline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/SingleSamplePipeline.java
@@ -110,8 +110,8 @@ public class SingleSamplePipeline {
             final PipelineState state) throws Exception {
         AlignmentOutput alignmentOutput = report.add(state.add(aligner.run(metadata)));
         alignmentOutput =
-                state.shouldProceed() && !arguments.useCrams() && alignmentOutput.finalBamLocation().path().endsWith(FileTypes.CRAM)
-                        ? state.add(stageRunner.run(metadata, new Cram2Bam(alignmentOutput.finalBamLocation(), metadata.type())))
+                state.shouldProceed() && !arguments.useCrams() && alignmentOutput.alignments().path().endsWith(FileTypes.CRAM)
+                        ? state.add(stageRunner.run(metadata, new Cram2Bam(alignmentOutput.alignments(), metadata.type())))
                         : alignmentOutput;
         return alignmentOutput;
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/AlignmentOutput.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/AlignmentOutput.java
@@ -18,24 +18,10 @@ public interface AlignmentOutput extends StageOutput {
         return Aligner.NAMESPACE;
     }
 
-    Optional<GoogleStorageLocation> maybeFinalBamLocation();
+    Optional<GoogleStorageLocation> maybeAlignments();
 
-    Optional<GoogleStorageLocation> maybeFinalBaiLocation();
-
-    default GoogleStorageLocation finalBamLocation() {
-        return maybeFinalBamLocation().orElseThrow(noBamAvailable());
-    }
-
-    default GoogleStorageLocation finalBaiLocation() {
-        return maybeFinalBaiLocation().orElseThrow(noBaiAvailable());
-    }
-
-    static Supplier<IllegalStateException> noBamAvailable() {
-        return () -> new IllegalStateException("No BAM available");
-    }
-
-    static Supplier<IllegalStateException> noBaiAvailable() {
-        return () -> new IllegalStateException("No BAI available");
+    default GoogleStorageLocation alignments() {
+        return maybeAlignments().orElse(GoogleStorageLocation.empty());
     }
 
     static ImmutableAlignmentOutput.Builder builder() {

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/AlignmentPair.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/AlignmentPair.java
@@ -2,6 +2,8 @@ package com.hartwig.pipeline.alignment;
 
 import java.util.Optional;
 
+import com.hartwig.pipeline.storage.GoogleStorageLocation;
+
 import org.immutables.value.Value;
 
 @Value.Immutable

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/bwa/BwaAligner.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/bwa/BwaAligner.java
@@ -89,8 +89,7 @@ public class BwaAligner implements Aligner {
             return AlignmentOutput.builder()
                     .sample(metadata.sampleName())
                     .status(PipelineStatus.PROVIDED)
-                    .maybeFinalBamLocation(GoogleStorageLocation.of(bucket, path))
-                    .maybeFinalBaiLocation(GoogleStorageLocation.of(bucket, FileTypes.bai(path)))
+                    .maybeAlignments(GoogleStorageLocation.of(bucket, path))
                     .build();
         }
         final ResourceFiles resourceFiles = buildResourceFiles(arguments);
@@ -156,10 +155,7 @@ public class BwaAligner implements Aligner {
             ImmutableAlignmentOutput.Builder outputBuilder = AlignmentOutput.builder()
                     .sample(metadata.sampleName())
                     .status(status)
-                    .maybeFinalBamLocation(GoogleStorageLocation.of(rootBucket.name(),
-                            resultsDirectory.path(merged.outputFile().fileName())))
-                    .maybeFinalBaiLocation(GoogleStorageLocation.of(rootBucket.name(),
-                            resultsDirectory.path(bai(merged.outputFile().fileName()))))
+                    .maybeAlignments(GoogleStorageLocation.of(rootBucket.name(), resultsDirectory.path(merged.outputFile().fileName())))
                     .addAllReportComponents(laneLogComponents)
                     .addAllFailedLogLocations(laneFailedLogs)
                     .addFailedLogLocations(GoogleStorageLocation.of(rootBucket.name(), RunLogComponent.LOG_FILE))

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/persisted/PersistedAlignment.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/persisted/PersistedAlignment.java
@@ -31,10 +31,7 @@ public class PersistedAlignment implements Aligner {
         return AlignmentOutput.builder()
                 .sample(metadata.sampleName())
                 .status(PipelineStatus.PERSISTED)
-                .maybeFinalBamLocation(alignmentMapLocation)
-                .maybeFinalBaiLocation(alignmentMapLocation.path().endsWith("bam")
-                        ? alignmentMapLocation.transform(FileTypes::bai)
-                        : alignmentMapLocation.transform(FileTypes::crai))
+                .maybeAlignments(alignmentMapLocation)
                 .build();
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/germline/GermlineCaller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/germline/GermlineCaller.java
@@ -62,8 +62,8 @@ public class GermlineCaller implements Stage<GermlineCallerOutput, SingleSampleR
     public GermlineCaller(final AlignmentOutput alignmentOutput, final ResourceFiles resourceFiles,
             final PersistedDataset persistedDataset) {
         this.resourceFiles = resourceFiles;
-        this.bamDownload = new InputDownload(alignmentOutput.finalBamLocation());
-        this.baiDownload = new InputDownload(alignmentOutput.finalBaiLocation());
+        this.bamDownload = new InputDownload(alignmentOutput.alignments());
+        this.baiDownload = new InputDownload(alignmentOutput.alignments().transform(FileTypes::toAlignmentIndex));
         this.outputFile = GermlineCallerOutput.outputFile(alignmentOutput.sample());
         this.persistedDataset = persistedDataset;
     }
@@ -101,8 +101,7 @@ public class GermlineCaller implements Stage<GermlineCallerOutput, SingleSampleR
         SubStageInputOutput combinedFilters = snpFilterOutput.combine(indelFilterOutput);
 
         SubStageInputOutput finalOutput =
-                new CombineFilteredVariants(indelFilterOutput.outputFile().path(), referenceFasta)
-                        .andThen(new GermlineZipIndex())
+                new CombineFilteredVariants(indelFilterOutput.outputFile().path(), referenceFasta).andThen(new GermlineZipIndex())
                         .apply(combinedFilters);
 
         return ImmutableList.<BashCommand>builder()

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageCaller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageCaller.java
@@ -72,10 +72,10 @@ public abstract class SageCaller extends TertiaryStage<SageOutput> {
         return SageOutput.builder(namespace())
                 .status(jobStatus)
                 .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
-                .maybeGermlineGeneCoverageTsv(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(geneCoverageFile)))
+                .maybeGermlineGeneCoverage(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(geneCoverageFile)))
                 .maybeSomaticRefSampleBqrPlot(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(somaticRefSampleBqrPlot)))
                 .maybeSomaticTumorSampleBqrPlot(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(somaticTumorSampleBqrPlot)))
-                .maybeFinalVcf(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(filteredOutputFile)))
+                .maybeVariants(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(filteredOutputFile)))
                 .addReportComponents(bqrComponent(metadata.tumor(), "png", bucket, resultsDirectory))
                 .addReportComponents(bqrComponent(metadata.tumor(), "tsv", bucket, resultsDirectory))
                 .addReportComponents(bqrComponent(metadata.reference(), "png", bucket, resultsDirectory))
@@ -124,10 +124,10 @@ public abstract class SageCaller extends TertiaryStage<SageOutput> {
 
         return SageOutput.builder(namespace())
                 .status(PipelineStatus.PERSISTED)
-                .maybeFinalVcf(persistedDataset.path(metadata.tumor().sampleName(), vcfDatatype)
+                .maybeVariants(persistedDataset.path(metadata.tumor().sampleName(), vcfDatatype)
                         .orElse(GoogleStorageLocation.of(metadata.bucket(),
                                 PersistedLocations.blobForSet(metadata.set(), namespace(), filteredOutputFile))))
-                .maybeGermlineGeneCoverageTsv(persistedDataset.path(metadata.tumor().sampleName(), geneCoverageDatatype)
+                .maybeGermlineGeneCoverage(persistedDataset.path(metadata.tumor().sampleName(), geneCoverageDatatype)
                         .orElse(GoogleStorageLocation.of(metadata.bucket(),
                                 PersistedLocations.blobForSet(metadata.set(), namespace(), geneCoverageFile))))
                 .maybeSomaticRefSampleBqrPlot(persistedDataset.path(metadata.tumor().sampleName(), refSampleBqrPlot)

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageOutput.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageOutput.java
@@ -13,28 +13,28 @@ public interface SageOutput extends StageOutput {
 
     PipelineStatus status();
 
-    Optional<GoogleStorageLocation> maybeFinalVcf();
+    Optional<GoogleStorageLocation> maybeVariants();
 
-    Optional<GoogleStorageLocation> maybeGermlineGeneCoverageTsv();
+    Optional<GoogleStorageLocation> maybeGermlineGeneCoverage();
 
     Optional<GoogleStorageLocation> maybeSomaticRefSampleBqrPlot();
 
     Optional<GoogleStorageLocation> maybeSomaticTumorSampleBqrPlot();
 
-    default GoogleStorageLocation finalVcf() {
-        return maybeFinalVcf().orElseThrow(() -> new IllegalStateException("No final vcf available"));
+    default GoogleStorageLocation variants() {
+        return maybeVariants().orElse(GoogleStorageLocation.empty());
     }
 
-    default GoogleStorageLocation germlineGeneCoverageTsv() {
-        return maybeGermlineGeneCoverageTsv().orElseThrow(() -> new IllegalStateException("No germline gene coverage tsv available"));
+    default GoogleStorageLocation germlineGeneCoverage() {
+        return maybeGermlineGeneCoverage().orElse(GoogleStorageLocation.empty());
     }
 
     default GoogleStorageLocation somaticRefSampleBqrPlot() {
-        return maybeSomaticRefSampleBqrPlot().orElseThrow(() -> new IllegalStateException("No somatic ref sample bqr plot available"));
+        return maybeSomaticRefSampleBqrPlot().orElse(GoogleStorageLocation.empty());
     }
 
     default GoogleStorageLocation somaticTumorSampleBqrPlot() {
-        return maybeSomaticTumorSampleBqrPlot().orElseThrow(() -> new IllegalStateException("No somatic tumor sample bqr plot available"));
+        return maybeSomaticTumorSampleBqrPlot().orElse(GoogleStorageLocation.empty());
     }
 
     static ImmutableSageOutput.Builder builder(String nameSpace) {

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/structural/StructuralCallerOutput.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/structural/StructuralCallerOutput.java
@@ -19,12 +19,8 @@ public interface StructuralCallerOutput extends StageOutput {
 
     Optional<GoogleStorageLocation> maybeUnfilteredVcfIndex();
 
-    default GoogleStorageLocation unfilteredVcf() {
-        return maybeUnfilteredVcf().orElseThrow(() -> new IllegalStateException("No unfiltered VCF available"));
-    }
-
-    default GoogleStorageLocation unfilteredVcfIndex() {
-        return maybeUnfilteredVcfIndex().orElseThrow(() -> new IllegalStateException("No unfiltered VCF index available"));
+    default GoogleStorageLocation unfilteredVariants() {
+        return maybeUnfilteredVcf().orElse(GoogleStorageLocation.empty());
     }
 
     static ImmutableStructuralCallerOutput.Builder builder() {

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/structural/gripss/GripssGermline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/structural/gripss/GripssGermline.java
@@ -46,8 +46,8 @@ public class GripssGermline implements Stage<GripssGermlineOutput, SomaticRunMet
     public GripssGermline(final ResourceFiles resourceFiles, StructuralCallerOutput structuralCallerOutput,
             final PersistedDataset persistedDataset) {
         this.resourceFiles = resourceFiles;
-        gridssVcf = new InputDownload(structuralCallerOutput.unfilteredVcf());
-        gridssVcfIndex = new InputDownload(structuralCallerOutput.unfilteredVcfIndex());
+        gridssVcf = new InputDownload(structuralCallerOutput.unfilteredVariants());
+        gridssVcfIndex = new InputDownload(structuralCallerOutput.unfilteredVariants().transform(FileTypes::tabixIndex));
         this.persistedDataset = persistedDataset;
     }
 
@@ -91,11 +91,8 @@ public class GripssGermline implements Stage<GripssGermlineOutput, SomaticRunMet
             final ResultsDirectory resultsDirectory) {
         return GripssGermlineOutput.builder()
                 .status(jobStatus)
-                .maybeFilteredVcf(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(basename(germlineFilteredVcf))))
-                .maybeFilteredVcfIndex(GoogleStorageLocation.of(bucket.name(),
-                        FileTypes.tabixIndex(resultsDirectory.path(basename(germlineFilteredVcf)))))
-                .maybeFullVcf(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(basename(germlineUnfilteredVcf))))
-                .maybeFullVcfIndex(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(basename(germlineUnfilteredVcf + ".tbi"))))
+                .maybeFilteredVariants(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(basename(germlineFilteredVcf))))
+                .maybeUnfilteredVariants(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(basename(germlineUnfilteredVcf))))
                 .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .addReportComponents(new ZippedVcfAndIndexComponent(bucket,
                         NAMESPACE,
@@ -143,10 +140,8 @@ public class GripssGermline implements Stage<GripssGermlineOutput, SomaticRunMet
 
         return GripssGermlineOutput.builder()
                 .status(PipelineStatus.PERSISTED)
-                .maybeFilteredVcf(filteredLocation)
-                .maybeFilteredVcfIndex(filteredLocation.transform(FileTypes::tabixIndex))
-                .maybeFullVcf(unfilteredLocation)
-                .maybeFullVcfIndex(unfilteredLocation.transform(FileTypes::tabixIndex))
+                .maybeFilteredVariants(filteredLocation)
+                .maybeUnfilteredVariants(unfilteredLocation)
                 .build();
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/structural/gripss/GripssOutput.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/structural/gripss/GripssOutput.java
@@ -5,31 +5,17 @@ import java.util.Optional;
 import com.hartwig.pipeline.StageOutput;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 
-import org.immutables.value.Value;
-
 public interface GripssOutput extends StageOutput {
 
-    Optional<GoogleStorageLocation> maybeFilteredVcf();
+    Optional<GoogleStorageLocation> maybeFilteredVariants();
 
-    Optional<GoogleStorageLocation> maybeFilteredVcfIndex();
+    Optional<GoogleStorageLocation> maybeUnfilteredVariants();
 
-    Optional<GoogleStorageLocation> maybeFullVcf();
-
-    Optional<GoogleStorageLocation> maybeFullVcfIndex();
-
-    default GoogleStorageLocation filteredVcf() {
-        return maybeFilteredVcf().orElseThrow(() -> new IllegalStateException("No filtered VCF available"));
+    default GoogleStorageLocation filteredVariants() {
+        return maybeFilteredVariants().orElse(GoogleStorageLocation.empty());
     }
 
-    default GoogleStorageLocation fullVcf() {
-        return maybeFullVcf().orElseThrow(() -> new IllegalStateException("No full VCF available"));
-    }
-
-    default GoogleStorageLocation filteredVcfIndex() {
-        return maybeFilteredVcfIndex().orElseThrow(() -> new IllegalStateException("No filtered VCF index available"));
-    }
-
-    default GoogleStorageLocation fullVcfIndex() {
-        return maybeFullVcfIndex().orElseThrow(() -> new IllegalStateException("No full VCF index available"));
+    default GoogleStorageLocation unfilteredVariants() {
+        return maybeUnfilteredVariants().orElse(GoogleStorageLocation.empty());
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/structural/gripss/GripssSomatic.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/structural/gripss/GripssSomatic.java
@@ -48,8 +48,8 @@ public class GripssSomatic implements Stage<GripssSomaticOutput, SomaticRunMetad
     public GripssSomatic(final ResourceFiles resourceFiles, StructuralCallerOutput structuralCallerOutput,
             final PersistedDataset persistedDataset) {
         this.resourceFiles = resourceFiles;
-        gridssVcf = new InputDownload(structuralCallerOutput.unfilteredVcf());
-        gridssVcfIndex = new InputDownload(structuralCallerOutput.unfilteredVcfIndex());
+        gridssVcf = new InputDownload(structuralCallerOutput.unfilteredVariants());
+        gridssVcfIndex = new InputDownload(structuralCallerOutput.unfilteredVariants().transform(FileTypes::tabixIndex));
         this.persistedDataset = persistedDataset;
     }
 
@@ -97,11 +97,8 @@ public class GripssSomatic implements Stage<GripssSomaticOutput, SomaticRunMetad
             final ResultsDirectory resultsDirectory) {
         return GripssSomaticOutput.builder()
                 .status(jobStatus)
-                .maybeFilteredVcf(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(basename(somaticFilteredVcf))))
-                .maybeFilteredVcfIndex(GoogleStorageLocation.of(bucket.name(),
-                        FileTypes.tabixIndex(resultsDirectory.path(basename(somaticFilteredVcf)))))
-                .maybeFullVcf(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(basename(somaticUnfilteredVcf))))
-                .maybeFullVcfIndex(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(basename(somaticUnfilteredVcf + ".tbi"))))
+                .maybeFilteredVariants(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(basename(somaticFilteredVcf))))
+                .maybeUnfilteredVariants(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(basename(somaticUnfilteredVcf))))
                 .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .addReportComponents(new ZippedVcfAndIndexComponent(bucket,
                         NAMESPACE,
@@ -145,10 +142,8 @@ public class GripssSomatic implements Stage<GripssSomaticOutput, SomaticRunMetad
 
         return GripssSomaticOutput.builder()
                 .status(PipelineStatus.PERSISTED)
-                .maybeFilteredVcf(somaticFilteredLocation)
-                .maybeFilteredVcfIndex(somaticFilteredLocation.transform(FileTypes::tabixIndex))
-                .maybeFullVcf(somaticLocation)
-                .maybeFullVcfIndex(somaticLocation.transform(FileTypes::tabixIndex))
+                .maybeFilteredVariants(somaticFilteredLocation)
+                .maybeUnfilteredVariants(somaticLocation)
                 .build();
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/cram/CramConversion.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/cram/CramConversion.java
@@ -40,7 +40,7 @@ public class CramConversion implements Stage<CramOutput, SingleSampleRunMetadata
     private final ResourceFiles resourceFiles;
 
     public CramConversion(final AlignmentOutput alignmentOutput, final SampleType sampleType, ResourceFiles resourceFiles) {
-        bamDownload = new InputDownload(alignmentOutput.finalBamLocation());
+        bamDownload = new InputDownload(alignmentOutput.alignments());
         outputCram = VmDirectories.outputFile(FileTypes.cram(alignmentOutput.sample()));
         this.sampleType = sampleType;
         this.resourceFiles = resourceFiles;

--- a/cluster/src/main/java/com/hartwig/pipeline/cram2bam/Cram2Bam.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/cram2bam/Cram2Bam.java
@@ -68,8 +68,7 @@ public class Cram2Bam implements Stage<AlignmentOutput, SingleSampleRunMetadata>
                 .status(jobStatus)
                 .sample(metadata.sampleName())
                 .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
-                .maybeFinalBamLocation(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(bam)))
-                .maybeFinalBaiLocation(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(FileTypes.bai(bam))))
+                .maybeAlignments(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(bam)))
                 .build();
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/datatypes/FileTypes.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/datatypes/FileTypes.java
@@ -1,5 +1,9 @@
 package com.hartwig.pipeline.datatypes;
 
+import java.util.function.Function;
+
+import com.hartwig.pipeline.storage.GoogleStorageLocation;
+
 public class FileTypes {
 
     public static final String BAM = "bam";
@@ -50,5 +54,14 @@ public class FileTypes {
 
     public static boolean isVcf(final String filename) {
         return filename.endsWith(VCF);
+    }
+
+    public static String toAlignmentIndex(final String filename) {
+        if (isBam(filename)) {
+            return bai(filename);
+        } else if (isCram(filename)) {
+            return crai(filename);
+        }
+        throw new IllegalArgumentException();
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/flagstat/Flagstat.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/flagstat/Flagstat.java
@@ -34,7 +34,7 @@ public class Flagstat implements Stage<FlagstatOutput, SingleSampleRunMetadata> 
     private final PersistedDataset persistedDataset;
 
     public Flagstat(final AlignmentOutput alignmentOutput, final PersistedDataset persistedDataset) {
-        bamDownload = new InputDownload(alignmentOutput.finalBamLocation());
+        bamDownload = new InputDownload(alignmentOutput.alignments());
         this.persistedDataset = persistedDataset;
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/metrics/BamMetrics.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metrics/BamMetrics.java
@@ -37,7 +37,7 @@ public class BamMetrics implements Stage<BamMetricsOutput, SingleSampleRunMetada
 
     public BamMetrics(final ResourceFiles resourceFiles, final AlignmentOutput alignmentOutput, final PersistedDataset persistedDataset) {
         this.resourceFiles = resourceFiles;
-        bamDownload = new InputDownload(alignmentOutput.finalBamLocation());
+        bamDownload = new InputDownload(alignmentOutput.alignments());
         this.persistedDataset = persistedDataset;
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/metrics/BamMetricsOutput.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metrics/BamMetricsOutput.java
@@ -23,7 +23,7 @@ public interface BamMetricsOutput extends StageOutput {
     Optional<GoogleStorageLocation> maybeMetricsOutputFile();
 
     default GoogleStorageLocation metricsOutputFile() {
-        return maybeMetricsOutputFile().orElseThrow(() -> new IllegalStateException("No metrics file available"));
+        return maybeMetricsOutputFile().orElse(GoogleStorageLocation.empty());
     }
 
     static String outputFile(String sample) {

--- a/cluster/src/main/java/com/hartwig/pipeline/snpgenotype/SnpGenotype.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/snpgenotype/SnpGenotype.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableList;
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.ResultsDirectory;
 import com.hartwig.pipeline.alignment.AlignmentOutput;
+import com.hartwig.pipeline.datatypes.FileTypes;
 import com.hartwig.pipeline.execution.PipelineStatus;
 import com.hartwig.pipeline.execution.vm.BashCommand;
 import com.hartwig.pipeline.execution.vm.BashStartupScript;
@@ -38,8 +39,8 @@ public class SnpGenotype implements Stage<SnpGenotypeOutput, SingleSampleRunMeta
 
     public SnpGenotype(final ResourceFiles resourceFiles, final AlignmentOutput alignmentOutput) {
         this.resourceFiles = resourceFiles;
-        this.bamDownload = new InputDownload(alignmentOutput.finalBamLocation());
-        this.baiDownload = new InputDownload(alignmentOutput.finalBaiLocation());
+        this.bamDownload = new InputDownload(alignmentOutput.alignments());
+        this.baiDownload = new InputDownload(alignmentOutput.alignments().transform(FileTypes::toAlignmentIndex));
     }
 
     @Override

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/TertiaryStage.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/TertiaryStage.java
@@ -7,6 +7,7 @@ import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.StageOutput;
 import com.hartwig.pipeline.alignment.AlignmentOutput;
 import com.hartwig.pipeline.alignment.AlignmentPair;
+import com.hartwig.pipeline.datatypes.FileTypes;
 import com.hartwig.pipeline.execution.vm.BashCommand;
 import com.hartwig.pipeline.execution.vm.InputDownload;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
@@ -21,16 +22,10 @@ public abstract class TertiaryStage<S extends StageOutput> implements Stage<S, S
     private final InputDownload referenceBaiDownload;
 
     public TertiaryStage(final AlignmentPair alignmentPair) {
-        tumorBamDownload =
-                new InputDownload(alignmentPair.maybeTumor().map(AlignmentOutput::finalBamLocation).orElse(GoogleStorageLocation.empty()));
-        tumorBaiDownload =
-                new InputDownload(alignmentPair.maybeTumor().map(AlignmentOutput::finalBaiLocation).orElse(GoogleStorageLocation.empty()));
-        referenceBamDownload = new InputDownload(alignmentPair.maybeReference()
-                .map(AlignmentOutput::finalBamLocation)
-                .orElse(GoogleStorageLocation.empty()));
-        referenceBaiDownload = new InputDownload(alignmentPair.maybeReference()
-                .map(AlignmentOutput::finalBaiLocation)
-                .orElse(GoogleStorageLocation.empty()));
+        tumorBamDownload = new InputDownload(alignmentPair.tumor().alignments());
+        tumorBaiDownload = new InputDownload(alignmentPair.tumor().alignments().transform(FileTypes::toAlignmentIndex));
+        referenceBamDownload = new InputDownload(alignmentPair.reference().alignments());
+        referenceBaiDownload = new InputDownload(alignmentPair.reference().alignments().transform(FileTypes::toAlignmentIndex));
     }
 
     @Override

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/amber/Amber.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/amber/Amber.java
@@ -1,24 +1,17 @@
 package com.hartwig.pipeline.tertiary.amber;
 
-import static java.util.Collections.singletonList;
-
 import java.io.File;
 import java.util.List;
 
-import com.google.common.collect.Lists;
 import com.hartwig.pipeline.Arguments;
-import com.hartwig.pipeline.GermlineOnlyCommand;
 import com.hartwig.pipeline.ResultsDirectory;
 import com.hartwig.pipeline.alignment.AlignmentPair;
 import com.hartwig.pipeline.datatypes.DataType;
 import com.hartwig.pipeline.execution.PipelineStatus;
-import com.hartwig.pipeline.execution.vm.Bash;
 import com.hartwig.pipeline.execution.vm.BashCommand;
 import com.hartwig.pipeline.execution.vm.BashStartupScript;
 import com.hartwig.pipeline.execution.vm.CopyResourceToOutput;
 import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
-import com.hartwig.pipeline.execution.vm.VmDirectories;
-import com.hartwig.pipeline.execution.vm.java.JavaClassCommand;
 import com.hartwig.pipeline.metadata.AddDatatype;
 import com.hartwig.pipeline.metadata.ArchivePath;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
@@ -31,10 +24,6 @@ import com.hartwig.pipeline.resource.ResourceFiles;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 import com.hartwig.pipeline.tertiary.TertiaryStage;
-import com.hartwig.pipeline.tertiary.TumorNormalCommand;
-import com.hartwig.pipeline.tertiary.TumorOnlyCommand;
-import com.hartwig.pipeline.tertiary.cobalt.CobaltCommandBuilder;
-import com.hartwig.pipeline.tools.Versions;
 
 public class Amber extends TertiaryStage<AmberOutput> {
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/amber/AmberOutput.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/amber/AmberOutput.java
@@ -18,7 +18,7 @@ public interface AmberOutput extends StageOutput {
     Optional<GoogleStorageLocation> maybeOutputDirectory();
 
     default GoogleStorageLocation outputDirectory() {
-        return maybeOutputDirectory().orElseThrow(() -> new IllegalStateException("No output directory available"));
+        return maybeOutputDirectory().orElse(GoogleStorageLocation.empty());
     }
 
     static ImmutableAmberOutput.Builder builder() {

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/chord/Chord.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/chord/Chord.java
@@ -39,10 +39,10 @@ public class Chord implements Stage<ChordOutput, SomaticRunMetadata> {
     public Chord(final RefGenomeVersion refGenomeVersion, final PurpleOutput purpleOutput, final PersistedDataset persistedDataset) {
         this.refGenomeVersion = refGenomeVersion;
         purpleStructuralVcfDownload = new InputDownload(purpleOutput.maybeOutputLocations()
-                .map(PurpleOutputLocations::structuralVcf)
+                .map(PurpleOutputLocations::structuralVariants)
                 .orElse(GoogleStorageLocation.empty()));
         purpleSomaticVcfDownload = new InputDownload(purpleOutput.maybeOutputLocations()
-                .map(PurpleOutputLocations::somaticVcf)
+                .map(PurpleOutputLocations::somaticVariants)
                 .orElse(GoogleStorageLocation.empty()));
         this.persistedDataset = persistedDataset;
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/chord/ChordOutput.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/chord/ChordOutput.java
@@ -8,7 +8,7 @@ import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public interface ChordOutput extends StageOutput{
+public interface ChordOutput extends StageOutput {
 
     @Override
     default String name() {
@@ -21,7 +21,7 @@ public interface ChordOutput extends StageOutput{
 
     Optional<GoogleStorageLocation> maybePredictions();
 
-    default GoogleStorageLocation predictions(){
-        return maybePredictions().orElseThrow();
+    default GoogleStorageLocation predictions() {
+        return maybePredictions().orElse(GoogleStorageLocation.empty());
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/cobalt/CobaltOutput.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/cobalt/CobaltOutput.java
@@ -18,7 +18,7 @@ public interface CobaltOutput extends StageOutput {
     Optional<GoogleStorageLocation> maybeOutputDirectory();
 
     default GoogleStorageLocation outputDirectory() {
-        return maybeOutputDirectory().orElseThrow(() -> new IllegalStateException("No output directory available"));
+        return maybeOutputDirectory().orElse(GoogleStorageLocation.empty());
     }
 
     static ImmutableCobaltOutput.Builder builder() {

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/cuppa/Cuppa.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/cuppa/Cuppa.java
@@ -42,8 +42,8 @@ public class Cuppa implements Stage<CuppaOutput, SomaticRunMetadata> {
     public static final String CUPPA_CONCLUSION_TXT = ".cuppa.conclusion.txt";
     public static final String CUPPA_CONCLUSION_CHART = ".cuppa.chart.png";
     public static String NAMESPACE = "cuppa";
-    private final InputDownload purpleSomaticVcfDownload;
-    private final InputDownload purpleStructuralVcfDownload;
+    private final InputDownload purpleSomaticVariantsDownload;
+    private final InputDownload purpleStructuralVariantsDownload;
     private final InputDownload purpleOutputDirectory;
     private final LinxSomaticOutput linxOutput;
 
@@ -53,15 +53,10 @@ public class Cuppa implements Stage<CuppaOutput, SomaticRunMetadata> {
 
     public Cuppa(final PurpleOutput purpleOutput, final LinxSomaticOutput linxOutput, final ResourceFiles resourceFiles,
             final PersistedDataset persistedDataset) {
-        this.purpleSomaticVcfDownload = new InputDownload(purpleOutput.maybeOutputLocations()
-                .map(PurpleOutputLocations::somaticVcf)
-                .orElse(GoogleStorageLocation.empty()));
-        this.purpleStructuralVcfDownload = new InputDownload(purpleOutput.maybeOutputLocations()
-                .map(PurpleOutputLocations::structuralVcf)
-                .orElse(GoogleStorageLocation.empty()));
-        this.purpleOutputDirectory = new InputDownload(purpleOutput.maybeOutputLocations()
-                .map(PurpleOutputLocations::outputDirectory)
-                .orElse(GoogleStorageLocation.empty()));
+        PurpleOutputLocations purpleOutputLocations = purpleOutput.outputLocations();
+        this.purpleSomaticVariantsDownload = new InputDownload(purpleOutputLocations.somaticVariants());
+        this.purpleStructuralVariantsDownload = new InputDownload(purpleOutputLocations.structuralVariants());
+        this.purpleOutputDirectory = new InputDownload(purpleOutputLocations.outputDirectory());
         this.linxOutput = linxOutput;
         this.resourceFiles = resourceFiles;
         this.persistedDataset = persistedDataset;
@@ -69,7 +64,7 @@ public class Cuppa implements Stage<CuppaOutput, SomaticRunMetadata> {
 
     @Override
     public List<BashCommand> inputs() {
-        return List.of(purpleSomaticVcfDownload, purpleStructuralVcfDownload, purpleOutputDirectory, linxOutputDownload());
+        return List.of(purpleSomaticVariantsDownload, purpleStructuralVariantsDownload, purpleOutputDirectory, linxOutputDownload());
     }
 
     @Override
@@ -93,9 +88,9 @@ public class Cuppa implements Stage<CuppaOutput, SomaticRunMetadata> {
                                 "-sample_data_dir",
                                 linxOutputDownload().getLocalTargetPath(),
                                 "-sample_sv_file",
-                                purpleStructuralVcfDownload.getLocalTargetPath(),
+                                purpleStructuralVariantsDownload.getLocalTargetPath(),
                                 "-sample_somatic_vcf",
-                                purpleSomaticVcfDownload.getLocalTargetPath(),
+                                purpleSomaticVariantsDownload.getLocalTargetPath(),
                                 "-output_dir",
                                 VmDirectories.OUTPUT)),
                 new Python3Command("cuppa-chart",

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/cuppa/CuppaOutput.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/cuppa/CuppaOutput.java
@@ -3,6 +3,7 @@ package com.hartwig.pipeline.tertiary.cuppa;
 import java.util.Optional;
 
 import com.hartwig.pipeline.StageOutput;
+import com.hartwig.pipeline.storage.GoogleStorageLocation;
 
 import org.immutables.value.Value;
 
@@ -20,6 +21,11 @@ public interface CuppaOutput extends StageOutput {
     Optional<CuppaOutputLocations> maybeCuppaOutputLocations();
 
     default CuppaOutputLocations cuppaOutputLocations() {
-        return maybeCuppaOutputLocations().orElseThrow();
+        return maybeCuppaOutputLocations().orElse(CuppaOutputLocations.builder()
+                .conclusionTxt(GoogleStorageLocation.empty())
+                .featurePlot(GoogleStorageLocation.empty())
+                .resultCsv(GoogleStorageLocation.empty())
+                .summaryChartPng(GoogleStorageLocation.empty())
+                .build());
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/healthcheck/HealthChecker.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/healthcheck/HealthChecker.java
@@ -45,18 +45,12 @@ public class HealthChecker implements Stage<HealthCheckOutput, SomaticRunMetadat
 
     public HealthChecker(BamMetricsOutput referenceMetricsOutput, BamMetricsOutput tumorMetricsOutput,
             FlagstatOutput referenceFlagstatOutput, FlagstatOutput tumorFlagstatOutput, PurpleOutput purpleOutput) {
-        referenceMetricsDownload = new InputDownload(referenceMetricsOutput.maybeMetricsOutputFile().orElse(GoogleStorageLocation.empty()),
-                localMetricsPath(referenceMetricsOutput));
-        tumorMetricsDownload = new InputDownload(tumorMetricsOutput.maybeMetricsOutputFile().orElse(GoogleStorageLocation.empty()),
-                localMetricsPath(tumorMetricsOutput));
+        referenceMetricsDownload = new InputDownload(referenceMetricsOutput.metricsOutputFile(), localMetricsPath(referenceMetricsOutput));
+        tumorMetricsDownload = new InputDownload(tumorMetricsOutput.metricsOutputFile(), localMetricsPath(tumorMetricsOutput));
         referenceFlagstatDownload =
-                new InputDownload(referenceFlagstatOutput.maybeFlagstatOutputFile().orElse(GoogleStorageLocation.empty()),
-                        localFlagstatPath(referenceFlagstatOutput));
-        tumorFlagstatDownload = new InputDownload(tumorFlagstatOutput.maybeFlagstatOutputFile().orElse(GoogleStorageLocation.empty()),
-                localFlagstatPath(tumorFlagstatOutput));
-        purpleDownload = new InputDownload(purpleOutput.maybeOutputLocations()
-                .map(PurpleOutputLocations::outputDirectory)
-                .orElse(GoogleStorageLocation.empty()), LOCAL_PURPLE_DIR);
+                new InputDownload(referenceFlagstatOutput.flagstatOutputFile(), localFlagstatPath(referenceFlagstatOutput));
+        tumorFlagstatDownload = new InputDownload(tumorFlagstatOutput.flagstatOutputFile(), localFlagstatPath(tumorFlagstatOutput));
+        purpleDownload = new InputDownload(purpleOutput.outputLocations().outputDirectory(), LOCAL_PURPLE_DIR);
     }
 
     @Override

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/LinxGermline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/LinxGermline.java
@@ -35,19 +35,19 @@ public class LinxGermline implements Stage<LinxGermlineOutput, SomaticRunMetadat
     public static final String GERMLINE_DRIVER_CATALOG_TSV = ".linx.germline.driver.catalog.tsv";
     public static final String GERMLINE_DISRUPTION_TSV = ".linx.germline.disruption.tsv";
 
-    private final InputDownload gripssGermlineVcfDownload;
+    private final InputDownload gripssGermlineVariantsDownload;
     private final ResourceFiles resourceFiles;
     private final PersistedDataset persistedDataset;
 
     public LinxGermline(GripssOutput gripssOutput, final ResourceFiles resourceFiles, final PersistedDataset persistedDataset) {
-        gripssGermlineVcfDownload = new InputDownload(gripssOutput.filteredVariants());
+        gripssGermlineVariantsDownload = new InputDownload(gripssOutput.filteredVariants());
         this.resourceFiles = resourceFiles;
         this.persistedDataset = persistedDataset;
     }
 
     @Override
     public List<BashCommand> inputs() {
-        return Collections.singletonList(gripssGermlineVcfDownload);
+        return Collections.singletonList(gripssGermlineVariantsDownload);
     }
 
     @Override
@@ -58,7 +58,7 @@ public class LinxGermline implements Stage<LinxGermlineOutput, SomaticRunMetadat
     @Override
     public List<BashCommand> commands(final SomaticRunMetadata metadata) {
         return Collections.singletonList(new LinxCommand(metadata.tumor().sampleName(),
-                gripssGermlineVcfDownload.getLocalTargetPath(),
+                gripssGermlineVariantsDownload.getLocalTargetPath(),
                 resourceFiles.version(),
                 VmDirectories.OUTPUT,
                 resourceFiles.lineElements(),

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/LinxGermline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/LinxGermline.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.util.Collections;
 import java.util.List;
 
-import com.google.api.client.util.Lists;
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.ResultsDirectory;
 import com.hartwig.pipeline.calling.structural.gripss.GripssOutput;
@@ -41,7 +40,7 @@ public class LinxGermline implements Stage<LinxGermlineOutput, SomaticRunMetadat
     private final PersistedDataset persistedDataset;
 
     public LinxGermline(GripssOutput gripssOutput, final ResourceFiles resourceFiles, final PersistedDataset persistedDataset) {
-        gripssGermlineVcfDownload = new InputDownload(gripssOutput.filteredVcf());
+        gripssGermlineVcfDownload = new InputDownload(gripssOutput.filteredVariants());
         this.resourceFiles = resourceFiles;
         this.persistedDataset = persistedDataset;
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/LinxSomatic.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/LinxSomatic.java
@@ -1,19 +1,15 @@
 package com.hartwig.pipeline.tertiary.linx;
 
-import static com.hartwig.pipeline.execution.vm.VirtualMachinePerformanceProfile.custom;
-
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
 
-import com.google.api.client.util.Lists;
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.ResultsDirectory;
 import com.hartwig.pipeline.datatypes.DataType;
 import com.hartwig.pipeline.execution.PipelineStatus;
 import com.hartwig.pipeline.execution.vm.BashCommand;
 import com.hartwig.pipeline.execution.vm.BashStartupScript;
-import com.hartwig.pipeline.execution.vm.ImmutableVirtualMachineJobDefinition;
 import com.hartwig.pipeline.execution.vm.InputDownload;
 import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
 import com.hartwig.pipeline.execution.vm.VmDirectories;
@@ -45,17 +41,14 @@ public class LinxSomatic implements Stage<LinxSomaticOutput, SomaticRunMetadata>
     public static final String DRIVERS_TSV = ".linx.drivers.tsv";
 
     private final InputDownload purpleOutputDirDownload;
-    private final InputDownload purpleStructuralVcfDownload;
+    private final InputDownload purpleStructuralVariantsDownload;
     private final ResourceFiles resourceFiles;
     private final PersistedDataset persistedDataset;
 
     public LinxSomatic(PurpleOutput purpleOutput, final ResourceFiles resourceFiles, final PersistedDataset persistedDataset) {
-        purpleOutputDirDownload = new InputDownload(purpleOutput.maybeOutputLocations()
-                .map(PurpleOutputLocations::outputDirectory)
-                .orElse(GoogleStorageLocation.empty()));
-        purpleStructuralVcfDownload = new InputDownload(purpleOutput.maybeOutputLocations()
-                .map(PurpleOutputLocations::structuralVcf)
-                .orElse(GoogleStorageLocation.empty()));
+        PurpleOutputLocations purpleOutputLocations = purpleOutput.outputLocations();
+        purpleOutputDirDownload = new InputDownload(purpleOutputLocations.outputDirectory());
+        purpleStructuralVariantsDownload = new InputDownload(purpleOutputLocations.structuralVariants());
         this.resourceFiles = resourceFiles;
         this.persistedDataset = persistedDataset;
     }
@@ -73,7 +66,7 @@ public class LinxSomatic implements Stage<LinxSomaticOutput, SomaticRunMetadata>
     @Override
     public List<BashCommand> commands(final SomaticRunMetadata metadata) {
         return List.of(new LinxCommand(metadata.tumor().sampleName(),
-                        purpleStructuralVcfDownload.getLocalTargetPath(),
+                        purpleStructuralVariantsDownload.getLocalTargetPath(),
                         purpleOutputDirDownload.getLocalTargetPath(),
                         resourceFiles.version(),
                         VmDirectories.OUTPUT,

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/LinxSomaticOutput.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/LinxSomaticOutput.java
@@ -3,6 +3,7 @@ package com.hartwig.pipeline.tertiary.linx;
 import java.util.Optional;
 
 import com.hartwig.pipeline.StageOutput;
+import com.hartwig.pipeline.storage.GoogleStorageLocation;
 
 import org.immutables.value.Value;
 
@@ -21,6 +22,14 @@ public interface LinxSomaticOutput extends StageOutput {
     Optional<LinxSomaticOutputLocations> maybeLinxOutputLocations();
 
     default LinxSomaticOutputLocations linxOutputLocations() {
-        return maybeLinxOutputLocations().orElseThrow();
+        return maybeLinxOutputLocations().orElse(LinxSomaticOutputLocations.builder()
+                .drivers(GoogleStorageLocation.empty())
+                .breakends(GoogleStorageLocation.empty())
+                .outputDirectory(GoogleStorageLocation.empty())
+                .clusters(GoogleStorageLocation.empty())
+                .driverCatalog(GoogleStorageLocation.empty())
+                .svAnnotations(GoogleStorageLocation.empty())
+                .fusions(GoogleStorageLocation.empty())
+                .build());
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/orange/Orange.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/orange/Orange.java
@@ -1,7 +1,6 @@
 package com.hartwig.pipeline.tertiary.orange;
 
 import java.util.List;
-import java.util.function.Function;
 
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.ResultsDirectory;
@@ -35,12 +34,10 @@ import com.hartwig.pipeline.tertiary.cuppa.CuppaOutputLocations;
 import com.hartwig.pipeline.tertiary.linx.LinxSomatic;
 import com.hartwig.pipeline.tertiary.linx.LinxSomaticOutput;
 import com.hartwig.pipeline.tertiary.linx.LinxSomaticOutputLocations;
-import com.hartwig.pipeline.tertiary.linx.LinxSomatic;
 import com.hartwig.pipeline.tertiary.peach.PeachOutput;
 import com.hartwig.pipeline.tertiary.protect.ProtectOutput;
 import com.hartwig.pipeline.tertiary.purple.Purple;
 import com.hartwig.pipeline.tertiary.purple.PurpleOutput;
-import com.hartwig.pipeline.tertiary.purple.PurpleOutputLocations;
 import com.hartwig.pipeline.tertiary.purple.PurpleOutputLocations;
 import com.hartwig.pipeline.tertiary.virus.VirusOutput;
 import com.hartwig.pipeline.tools.Versions;
@@ -90,51 +87,36 @@ public class Orange implements Stage<OrangeOutput, SomaticRunMetadata> {
             final ResourceFiles resourceFiles) {
 
         this.resourceFiles = resourceFiles;
-        this.refMetrics = new InputDownload(referenceMetrics.maybeMetricsOutputFile().orElse(GoogleStorageLocation.empty()));
-        this.tumMetrics = new InputDownload(tumorMetrics.maybeMetricsOutputFile().orElse(GoogleStorageLocation.empty()));
-        this.refFlagstat = new InputDownload(referenceFlagstat.maybeFlagstatOutputFile().orElse(GoogleStorageLocation.empty()));
-        this.tumFlagstat = new InputDownload(tumorFlagstat.maybeFlagstatOutputFile().orElse(GoogleStorageLocation.empty()));
-        this.purpleGermlineVcf = new InputDownload(purpleOrEmpty(purpleOutput, PurpleOutputLocations::germlineVcf));
-        this.purpleSomaticVcf = new InputDownload(purpleOrEmpty(purpleOutput, PurpleOutputLocations::somaticVcf));
-        this.purplePurityTsv = new InputDownload(purpleOrEmpty(purpleOutput, PurpleOutputLocations::purityTsv));
-        this.purpleQCFile = new InputDownload(purpleOrEmpty(purpleOutput, PurpleOutputLocations::qcFile));
-        this.purpleGeneCopyNumberTsv = new InputDownload(purpleOrEmpty(purpleOutput, PurpleOutputLocations::geneCopyNumberTsv));
-        this.purpleSomaticDriverCatalog = new InputDownload(purpleOrEmpty(purpleOutput, PurpleOutputLocations::somaticDriverCatalog));
-        this.purpleGermlineDriverCatalog = new InputDownload(purpleOrEmpty(purpleOutput, PurpleOutputLocations::germlineDriverCatalog));
-        this.purpleOutputDir = new InputDownload(purpleOrEmpty(purpleOutput, PurpleOutputLocations::outputDirectory), LOCAL_PURPLE_DIR);
-        this.sageGermlineGeneCoverageTsv =
-                new InputDownload(sageGermlineOutput.maybeGermlineGeneCoverageTsv().orElse(GoogleStorageLocation.empty()));
-        this.sageSomaticRefSampleBqrPlot =
-                new InputDownload(sageSomaticOutput.maybeSomaticRefSampleBqrPlot().orElse(GoogleStorageLocation.empty()));
-        this.sageSomaticTumorSampleBqrPlot =
-                new InputDownload(sageSomaticOutput.maybeSomaticTumorSampleBqrPlot().orElse(GoogleStorageLocation.empty()));
-        this.linxOutputDir = new InputDownload(linxOrEmpty(linxOutput, LinxSomaticOutputLocations::outputDirectory), LOCAL_LINX_DIR);
-        this.linxFusionTsv = new InputDownload(linxOrEmpty(linxOutput, LinxSomaticOutputLocations::fusions));
-        this.linxBreakEndTsv = new InputDownload(linxOrEmpty(linxOutput, LinxSomaticOutputLocations::breakends));
-        this.linxDriverCatalogTsv = new InputDownload(linxOrEmpty(linxOutput, LinxSomaticOutputLocations::driverCatalog));
-        this.linxDriverTsv = new InputDownload(linxOrEmpty(linxOutput, LinxSomaticOutputLocations::drivers));
-        this.chordPredictionTxt = new InputDownload(chordOutput.maybePredictions().orElse(GoogleStorageLocation.empty()));
-        this.cuppaResultCsv = new InputDownload(cuppaOrEmpty(cuppaOutput, CuppaOutputLocations::resultCsv));
-        this.cuppaSummaryPlot = new InputDownload(cuppaOrEmpty(cuppaOutput, CuppaOutputLocations::summaryChartPng));
-        this.cuppaFeaturePlot = new InputDownloadIfBlobExists(cuppaOrEmpty(cuppaOutput, CuppaOutputLocations::featurePlot));
-        this.peachGenotypeTsv = new InputDownload(peachOutput.maybeGenotypeTsv().orElse(GoogleStorageLocation.empty()));
-        this.protectEvidenceTsv = new InputDownload(protectOutput.maybeEvidenceTsv().orElse(GoogleStorageLocation.empty()));
-        this.annotatedVirusTsv = new InputDownload(virusOutput.maybeAnnotatedVirusFile().orElse(GoogleStorageLocation.empty()));
-    }
-
-    public GoogleStorageLocation purpleOrEmpty(final PurpleOutput purpleOutput,
-            final Function<PurpleOutputLocations, GoogleStorageLocation> extractor) {
-        return purpleOutput.maybeOutputLocations().map(extractor).orElse(GoogleStorageLocation.empty());
-    }
-
-    public GoogleStorageLocation linxOrEmpty(final LinxSomaticOutput linxOutput,
-            final Function<LinxSomaticOutputLocations, GoogleStorageLocation> extractor) {
-        return linxOutput.maybeLinxOutputLocations().map(extractor).orElse(GoogleStorageLocation.empty());
-    }
-
-    public GoogleStorageLocation cuppaOrEmpty(final CuppaOutput cuppaOutput,
-            final Function<CuppaOutputLocations, GoogleStorageLocation> extractor) {
-        return cuppaOutput.maybeCuppaOutputLocations().map(extractor).orElse(GoogleStorageLocation.empty());
+        this.refMetrics = new InputDownload(referenceMetrics.metricsOutputFile());
+        this.tumMetrics = new InputDownload(tumorMetrics.metricsOutputFile());
+        this.refFlagstat = new InputDownload(referenceFlagstat.flagstatOutputFile());
+        this.tumFlagstat = new InputDownload(tumorFlagstat.flagstatOutputFile());
+        PurpleOutputLocations purpleOutputLocations = purpleOutput.outputLocations();
+        this.purpleGermlineVcf = new InputDownload(purpleOutputLocations.germlineVariants());
+        this.purpleSomaticVcf = new InputDownload(purpleOutputLocations.somaticVariants());
+        this.purplePurityTsv = new InputDownload(purpleOutputLocations.purity());
+        this.purpleQCFile = new InputDownload(purpleOutputLocations.qcFile());
+        this.purpleGeneCopyNumberTsv = new InputDownload(purpleOutputLocations.geneCopyNumber());
+        this.purpleSomaticDriverCatalog = new InputDownload(purpleOutputLocations.somaticDriverCatalog());
+        this.purpleGermlineDriverCatalog = new InputDownload(purpleOutputLocations.germlineDriverCatalog());
+        this.purpleOutputDir = new InputDownload(purpleOutputLocations.outputDirectory(), LOCAL_PURPLE_DIR);
+        this.sageGermlineGeneCoverageTsv = new InputDownload(sageGermlineOutput.germlineGeneCoverage());
+        this.sageSomaticRefSampleBqrPlot = new InputDownload(sageSomaticOutput.somaticRefSampleBqrPlot());
+        this.sageSomaticTumorSampleBqrPlot = new InputDownload(sageSomaticOutput.somaticTumorSampleBqrPlot());
+        LinxSomaticOutputLocations linxSomaticOutputLocations = linxOutput.linxOutputLocations();
+        this.linxOutputDir = new InputDownload(linxSomaticOutputLocations.outputDirectory(), LOCAL_LINX_DIR);
+        this.linxFusionTsv = new InputDownload(linxSomaticOutputLocations.fusions());
+        this.linxBreakEndTsv = new InputDownload(linxSomaticOutputLocations.breakends());
+        this.linxDriverCatalogTsv = new InputDownload(linxSomaticOutputLocations.driverCatalog());
+        this.linxDriverTsv = new InputDownload(linxSomaticOutputLocations.drivers());
+        this.chordPredictionTxt = new InputDownload(chordOutput.predictions());
+        CuppaOutputLocations cuppaOutputLocations = cuppaOutput.cuppaOutputLocations();
+        this.cuppaResultCsv = new InputDownload(cuppaOutputLocations.resultCsv());
+        this.cuppaSummaryPlot = new InputDownload(cuppaOutputLocations.summaryChartPng());
+        this.cuppaFeaturePlot = new InputDownloadIfBlobExists(cuppaOutputLocations.featurePlot());
+        this.peachGenotypeTsv = new InputDownload(peachOutput.genotypes());
+        this.protectEvidenceTsv = new InputDownload(protectOutput.evidence());
+        this.annotatedVirusTsv = new InputDownload(virusOutput.virusAnnotations());
     }
 
     @Override

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/pave/Pave.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/pave/Pave.java
@@ -41,7 +41,7 @@ public abstract class Pave implements Stage<PaveOutput, SomaticRunMetadata> {
     public Pave(final ResourceFiles resourceFiles, SageOutput sageOutput, final PersistedDataset persistedDataset,
             final DataType vcfDatatype) {
         this.resourceFiles = resourceFiles;
-        this.vcfDownload = new InputDownload(sageOutput.maybeFinalVcf().orElse(GoogleStorageLocation.empty()));
+        this.vcfDownload = new InputDownload(sageOutput.variants());
         this.persistedDataset = persistedDataset;
         this.vcfDatatype = vcfDatatype;
     }
@@ -86,7 +86,7 @@ public abstract class Pave implements Stage<PaveOutput, SomaticRunMetadata> {
         return PaveOutput.builder(namespace())
                 .status(jobStatus)
                 .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
-                .maybeFinalVcf(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(outputFile)))
+                .maybeAnnotatedVariants(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(outputFile)))
                 .addReportComponents(vcfComponent(outputFile, bucket, resultsDirectory))
                 .addDatatypes(new AddDatatype(vcfDatatype, metadata.barcode(), new ArchivePath(Folder.root(), namespace(), outputFile)))
                 .build();
@@ -97,7 +97,7 @@ public abstract class Pave implements Stage<PaveOutput, SomaticRunMetadata> {
         final String outputFile = outputFile(metadata);
         return PaveOutput.builder(namespace())
                 .status(PipelineStatus.PERSISTED)
-                .maybeFinalVcf(persistedDataset.path(metadata.tumor().sampleName(), vcfDatatype)
+                .maybeAnnotatedVariants(persistedDataset.path(metadata.tumor().sampleName(), vcfDatatype)
                         .orElse(GoogleStorageLocation.of(metadata.bucket(),
                                 PersistedLocations.blobForSet(metadata.set(), namespace(), outputFile))))
                 .build();

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/pave/PaveOutput.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/pave/PaveOutput.java
@@ -3,7 +3,6 @@ package com.hartwig.pipeline.tertiary.pave;
 import java.util.Optional;
 
 import com.hartwig.pipeline.StageOutput;
-import com.hartwig.pipeline.calling.sage.ImmutableSageOutput;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 
 import org.immutables.value.Value;
@@ -11,10 +10,10 @@ import org.immutables.value.Value;
 @Value.Immutable
 public interface PaveOutput extends StageOutput {
 
-    Optional<GoogleStorageLocation> maybeFinalVcf();
+    Optional<GoogleStorageLocation> maybeAnnotatedVariants();
 
-    default GoogleStorageLocation finalVcf() {
-        return maybeFinalVcf().orElseThrow(() -> new IllegalStateException("No final vcf available"));
+    default GoogleStorageLocation annotatedVariants() {
+        return maybeAnnotatedVariants().orElseThrow(() -> new IllegalStateException("No final vcf available"));
     }
 
     static ImmutablePaveOutput.Builder builder(final String namespace) {

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/peach/PeachOutput.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/peach/PeachOutput.java
@@ -18,9 +18,9 @@ public interface PeachOutput extends StageOutput {
         return Peach.NAMESPACE;
     }
 
-    Optional<GoogleStorageLocation> maybeGenotypeTsv();
+    Optional<GoogleStorageLocation> maybeGenotypes();
 
-    default GoogleStorageLocation genotypeTsv() {
-        return maybeGenotypeTsv().orElseThrow();
+    default GoogleStorageLocation genotypes() {
+        return maybeGenotypes().orElse(GoogleStorageLocation.empty());
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/protect/Protect.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/protect/Protect.java
@@ -42,45 +42,37 @@ public class Protect implements Stage<ProtectOutput, SomaticRunMetadata> {
 
     private final InputDownload purplePurity;
     private final InputDownload purpleQCFile;
-    private final InputDownload purpleGeneCopyNumberTsv;
+    private final InputDownload purpleGeneCopyNumber;
     private final InputDownload purpleSomaticDriverCatalog;
     private final InputDownload purpleGermlineDriverCatalog;
     private final InputDownload purpleSomaticVariants;
     private final InputDownload purpleGermlineVariants;
-    private final InputDownload linxFusionTsv;
-    private final InputDownload linxBreakendTsv;
-    private final InputDownload linxDriverCatalogTsv;
-    private final InputDownload annotatedVirusTsv;
+    private final InputDownload linxFusions;
+    private final InputDownload linxBreakends;
+    private final InputDownload linxDriverCatalog;
+    private final InputDownload virusAnnotations;
     private final InputDownload chordPrediction;
     private final ResourceFiles resourceFiles;
     private final PersistedDataset persistedDataset;
 
     public Protect(final PurpleOutput purpleOutput, final LinxSomaticOutput linxOutput, final VirusOutput virusOutput,
             final ChordOutput chordOutput, final ResourceFiles resourceFiles, final PersistedDataset persistedDataset) {
-        this.purplePurity = new InputDownload(purpleOrEmpty(purpleOutput, PurpleOutputLocations::purityTsv));
-        this.purpleQCFile = new InputDownload(purpleOrEmpty(purpleOutput, PurpleOutputLocations::qcFile));
-        this.purpleGeneCopyNumberTsv = new InputDownload(purpleOrEmpty(purpleOutput, PurpleOutputLocations::geneCopyNumberTsv));
-        this.purpleSomaticDriverCatalog = new InputDownload(purpleOrEmpty(purpleOutput, PurpleOutputLocations::somaticDriverCatalog));
-        this.purpleGermlineDriverCatalog = new InputDownload(purpleOrEmpty(purpleOutput, PurpleOutputLocations::germlineDriverCatalog));
-        this.purpleSomaticVariants = new InputDownload(purpleOrEmpty(purpleOutput, PurpleOutputLocations::somaticVcf));
-        this.purpleGermlineVariants = new InputDownload(purpleOrEmpty(purpleOutput, PurpleOutputLocations::germlineVcf));
-        this.linxFusionTsv = new InputDownload(linxOrEmpty(linxOutput, LinxSomaticOutputLocations::fusions));
-        this.linxBreakendTsv = new InputDownload(linxOrEmpty(linxOutput, LinxSomaticOutputLocations::breakends));
-        this.linxDriverCatalogTsv = new InputDownload(linxOrEmpty(linxOutput, LinxSomaticOutputLocations::driverCatalog));
-        this.annotatedVirusTsv = new InputDownload(virusOutput.maybeAnnotatedVirusFile().orElse(GoogleStorageLocation.empty()));
-        this.chordPrediction = new InputDownload(chordOutput.maybePredictions().orElse(GoogleStorageLocation.empty()));
+        PurpleOutputLocations purpleOutputLocations = purpleOutput.outputLocations();
+        this.purplePurity = new InputDownload(purpleOutputLocations.purity());
+        this.purpleQCFile = new InputDownload(purpleOutputLocations.qcFile());
+        this.purpleGeneCopyNumber = new InputDownload(purpleOutputLocations.geneCopyNumber());
+        this.purpleSomaticDriverCatalog = new InputDownload(purpleOutputLocations.somaticDriverCatalog());
+        this.purpleGermlineDriverCatalog = new InputDownload(purpleOutputLocations.germlineDriverCatalog());
+        this.purpleSomaticVariants = new InputDownload(purpleOutputLocations.somaticVariants());
+        this.purpleGermlineVariants = new InputDownload(purpleOutputLocations.germlineVariants());
+        LinxSomaticOutputLocations linxSomaticOutputLocations = linxOutput.linxOutputLocations();
+        this.linxFusions = new InputDownload(linxSomaticOutputLocations.fusions());
+        this.linxBreakends = new InputDownload(linxSomaticOutputLocations.breakends());
+        this.linxDriverCatalog = new InputDownload(linxSomaticOutputLocations.driverCatalog());
+        this.virusAnnotations = new InputDownload(virusOutput.virusAnnotations());
+        this.chordPrediction = new InputDownload(chordOutput.predictions());
         this.resourceFiles = resourceFiles;
         this.persistedDataset = persistedDataset;
-    }
-
-    private GoogleStorageLocation purpleOrEmpty(final PurpleOutput purpleOutput,
-            final Function<PurpleOutputLocations, GoogleStorageLocation> extractor) {
-        return purpleOutput.maybeOutputLocations().map(extractor).orElse(GoogleStorageLocation.empty());
-    }
-
-    private GoogleStorageLocation linxOrEmpty(final LinxSomaticOutput linxOutput,
-            final Function<LinxSomaticOutputLocations, GoogleStorageLocation> extractor) {
-        return linxOutput.maybeLinxOutputLocations().map(extractor).orElse(GoogleStorageLocation.empty());
     }
 
     @Override
@@ -92,15 +84,15 @@ public class Protect implements Stage<ProtectOutput, SomaticRunMetadata> {
     public List<BashCommand> inputs() {
         return List.of(purplePurity,
                 purpleQCFile,
-                purpleGeneCopyNumberTsv,
+                purpleGeneCopyNumber,
                 purpleSomaticDriverCatalog,
                 purpleGermlineDriverCatalog,
                 purpleSomaticVariants,
                 purpleGermlineVariants,
-                linxFusionTsv,
-                linxBreakendTsv,
-                linxDriverCatalogTsv,
-                annotatedVirusTsv,
+                linxFusions,
+                linxBreakends,
+                linxDriverCatalog,
+                virusAnnotations,
                 chordPrediction);
     }
 
@@ -115,15 +107,15 @@ public class Protect implements Stage<ProtectOutput, SomaticRunMetadata> {
                 resourceFiles.doidJson(),
                 purplePurity.getLocalTargetPath(),
                 purpleQCFile.getLocalTargetPath(),
-                purpleGeneCopyNumberTsv.getLocalTargetPath(),
+                purpleGeneCopyNumber.getLocalTargetPath(),
                 purpleSomaticDriverCatalog.getLocalTargetPath(),
                 purpleGermlineDriverCatalog.getLocalTargetPath(),
                 purpleSomaticVariants.getLocalTargetPath(),
                 purpleGermlineVariants.getLocalTargetPath(),
-                linxFusionTsv.getLocalTargetPath(),
-                linxBreakendTsv.getLocalTargetPath(),
-                linxDriverCatalogTsv.getLocalTargetPath(),
-                annotatedVirusTsv.getLocalTargetPath(),
+                linxFusions.getLocalTargetPath(),
+                linxBreakends.getLocalTargetPath(),
+                linxDriverCatalog.getLocalTargetPath(),
+                virusAnnotations.getLocalTargetPath(),
                 chordPrediction.getLocalTargetPath()));
     }
 
@@ -144,7 +136,7 @@ public class Protect implements Stage<ProtectOutput, SomaticRunMetadata> {
         final String evidenceTsv = evidenceTsv(metadata);
         return ProtectOutput.builder()
                 .status(jobStatus)
-                .maybeEvidenceTsv(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(evidenceTsv)))
+                .maybeEvidence(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(evidenceTsv)))
                 .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .addReportComponents(new EntireOutputComponent(bucket, Folder.root(), namespace(), resultsDirectory))
                 .addDatatypes(new AddDatatype(DataType.PROTECT_EVIDENCE,
@@ -160,7 +152,7 @@ public class Protect implements Stage<ProtectOutput, SomaticRunMetadata> {
 
     @Override
     public ProtectOutput skippedOutput(final SomaticRunMetadata metadata) {
-        return ProtectOutput.builder().status(PipelineStatus.SKIPPED).maybeEvidenceTsv(GoogleStorageLocation.empty()).build();
+        return ProtectOutput.builder().status(PipelineStatus.SKIPPED).build();
     }
 
     @Override
@@ -168,7 +160,7 @@ public class Protect implements Stage<ProtectOutput, SomaticRunMetadata> {
         String evidenceTsv = evidenceTsv(metadata);
         return ProtectOutput.builder()
                 .status(PipelineStatus.PERSISTED)
-                .maybeEvidenceTsv(persistedDataset.path(metadata.tumor().sampleName(), DataType.PROTECT_EVIDENCE)
+                .maybeEvidence(persistedDataset.path(metadata.tumor().sampleName(), DataType.PROTECT_EVIDENCE)
                         .orElse(GoogleStorageLocation.of(metadata.bucket(),
                                 PersistedLocations.blobForSet(metadata.set(), namespace(), evidenceTsv))))
                 .addDatatypes(new AddDatatype(DataType.PROTECT_EVIDENCE,

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/protect/ProtectOutput.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/protect/ProtectOutput.java
@@ -15,10 +15,10 @@ public interface ProtectOutput extends StageOutput {
         return Protect.NAMESPACE;
     }
 
-    Optional<GoogleStorageLocation> maybeEvidenceTsv();
+    Optional<GoogleStorageLocation> maybeEvidence();
 
-    default GoogleStorageLocation evidenceTsv() {
-        return maybeEvidenceTsv().orElseThrow();
+    default GoogleStorageLocation evidence() {
+        return maybeEvidence().orElse(GoogleStorageLocation.empty());
     }
 
     static ImmutableProtectOutput.Builder builder() {

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/purple/Purple.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/purple/Purple.java
@@ -52,12 +52,12 @@ public class Purple implements Stage<PurpleOutput, SomaticRunMetadata> {
     public static final String PURPLE_CIRCOS_PLOT = ".circos.png";
 
     private final ResourceFiles resourceFiles;
-    private final InputDownload somaticVcfDownload;
-    private final InputDownload germlineVcfDownload;
-    private final InputDownload structuralVcfDownload;
-    private final InputDownload structuralVcfIndexDownload;
-    private final InputDownload svRecoveryVcfDownload;
-    private final InputDownload svRecoveryVcfIndexDownload;
+    private final InputDownload somaticVariantsDownload;
+    private final InputDownload germlineVariantsDownload;
+    private final InputDownload structuralVariantsDownload;
+    private final InputDownload structuralVariantsIndexDownload;
+    private final InputDownload svRecoveryVariantsDownload;
+    private final InputDownload svRecoveryVariantsIndexDownload;
     private final InputDownload amberOutputDownload;
     private final InputDownload cobaltOutputDownload;
     private final PersistedDataset persistedDataset;
@@ -68,12 +68,12 @@ public class Purple implements Stage<PurpleOutput, SomaticRunMetadata> {
             GripssSomaticOutput structuralCallerOutput, AmberOutput amberOutput, CobaltOutput cobaltOutput,
             final PersistedDataset persistedDataset, final boolean shallow, final boolean sageGermlineEnabled) {
         this.resourceFiles = resourceFiles;
-        this.somaticVcfDownload = new InputDownload(paveSomaticOutput.annotatedVariants());
-        this.germlineVcfDownload = new InputDownload(germlineCallerOutput.annotatedVariants());
-        this.structuralVcfDownload = new InputDownload(structuralCallerOutput.filteredVariants());
-        this.structuralVcfIndexDownload = new InputDownload(structuralCallerOutput.filteredVariants().transform(FileTypes::tabixIndex));
-        this.svRecoveryVcfDownload = new InputDownload(structuralCallerOutput.unfilteredVariants());
-        this.svRecoveryVcfIndexDownload = new InputDownload(structuralCallerOutput.unfilteredVariants().transform(FileTypes::tabixIndex));
+        this.somaticVariantsDownload = new InputDownload(paveSomaticOutput.annotatedVariants());
+        this.germlineVariantsDownload = new InputDownload(germlineCallerOutput.annotatedVariants());
+        this.structuralVariantsDownload = new InputDownload(structuralCallerOutput.filteredVariants());
+        this.structuralVariantsIndexDownload = new InputDownload(structuralCallerOutput.filteredVariants().transform(FileTypes::tabixIndex));
+        this.svRecoveryVariantsDownload = new InputDownload(structuralCallerOutput.unfilteredVariants());
+        this.svRecoveryVariantsIndexDownload = new InputDownload(structuralCallerOutput.unfilteredVariants().transform(FileTypes::tabixIndex));
         this.amberOutputDownload = new InputDownload(amberOutput.outputDirectory());
         this.cobaltOutputDownload = new InputDownload(cobaltOutput.outputDirectory());
         this.persistedDataset = persistedDataset;
@@ -92,26 +92,23 @@ public class Purple implements Stage<PurpleOutput, SomaticRunMetadata> {
                 amberOutputDownload.getLocalTargetPath(),
                 cobaltOutputDownload.getLocalTargetPath(),
                 metadata.tumor().sampleName(),
-                structuralVcfDownload.getLocalTargetPath(),
-                svRecoveryVcfDownload.getLocalTargetPath(),
-                somaticVcfDownload.getLocalTargetPath()).setShallow(shallow).setReferenceSample(metadata.reference().sampleName());
+                structuralVariantsDownload.getLocalTargetPath(),
+                svRecoveryVariantsDownload.getLocalTargetPath(),
+                somaticVariantsDownload.getLocalTargetPath()).setShallow(shallow).setReferenceSample(metadata.reference().sampleName());
         if (sageGermlineEnabled) {
-            builder.addGermline(germlineVcfDownload.getLocalTargetPath());
+            builder.addGermline(germlineVariantsDownload.getLocalTargetPath());
         }
         return Collections.singletonList(builder.build());
     }
 
     @Override
     public List<BashCommand> inputs() {
-        List<BashCommand> inputs = new ArrayList<>(ImmutableList.of(somaticVcfDownload,
-                structuralVcfDownload,
-                structuralVcfIndexDownload,
-                svRecoveryVcfDownload,
-                svRecoveryVcfIndexDownload,
+        List<BashCommand> inputs = new ArrayList<>(ImmutableList.of(somaticVariantsDownload, structuralVariantsDownload,
+                structuralVariantsIndexDownload, svRecoveryVariantsDownload, svRecoveryVariantsIndexDownload,
                 amberOutputDownload,
                 cobaltOutputDownload));
         if (sageGermlineEnabled) {
-            inputs.add(germlineVcfDownload);
+            inputs.add(germlineVariantsDownload);
         }
         return inputs;
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/purple/PurpleOutput.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/purple/PurpleOutput.java
@@ -3,6 +3,7 @@ package com.hartwig.pipeline.tertiary.purple;
 import java.util.Optional;
 
 import com.hartwig.pipeline.StageOutput;
+import com.hartwig.pipeline.storage.GoogleStorageLocation;
 
 import org.immutables.value.Value;
 
@@ -17,7 +18,19 @@ public interface PurpleOutput extends StageOutput {
     Optional<PurpleOutputLocations> maybeOutputLocations();
 
     default PurpleOutputLocations outputLocations() {
-        return maybeOutputLocations().orElseThrow();
+        return maybeOutputLocations().orElse(PurpleOutputLocations.builder()
+                .structuralVariants(GoogleStorageLocation.empty())
+                .somaticVariants(GoogleStorageLocation.empty())
+                .germlineVariants(GoogleStorageLocation.empty())
+                .qcFile(GoogleStorageLocation.empty())
+                .purity(GoogleStorageLocation.empty())
+                .germlineDriverCatalog(GoogleStorageLocation.empty())
+                .circosPlot(GoogleStorageLocation.empty())
+                .somaticCopyNumber(GoogleStorageLocation.empty())
+                .geneCopyNumber(GoogleStorageLocation.empty())
+                .outputDirectory(GoogleStorageLocation.empty())
+                .somaticDriverCatalog(GoogleStorageLocation.empty())
+                .build());
     }
 
     static ImmutablePurpleOutput.Builder builder() {

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/purple/PurpleOutputLocations.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/purple/PurpleOutputLocations.java
@@ -10,21 +10,21 @@ public interface PurpleOutputLocations {
 
     GoogleStorageLocation outputDirectory();
 
-    GoogleStorageLocation somaticVcf();
+    GoogleStorageLocation somaticVariants();
 
-    GoogleStorageLocation germlineVcf();
+    GoogleStorageLocation germlineVariants();
 
-    GoogleStorageLocation structuralVcf();
+    GoogleStorageLocation structuralVariants();
 
-    GoogleStorageLocation purityTsv();
+    GoogleStorageLocation purity();
 
     GoogleStorageLocation qcFile();
 
-    GoogleStorageLocation geneCopyNumberTsv();
+    GoogleStorageLocation geneCopyNumber();
 
     GoogleStorageLocation somaticDriverCatalog();
 
-    GoogleStorageLocation somaticCopyNumberTsv();
+    GoogleStorageLocation somaticCopyNumber();
 
     GoogleStorageLocation germlineDriverCatalog();
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/sigs/Sigs.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/sigs/Sigs.java
@@ -24,26 +24,23 @@ import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 import com.hartwig.pipeline.tertiary.purple.PurpleOutput;
-import com.hartwig.pipeline.tertiary.purple.PurpleOutputLocations;
 import com.hartwig.pipeline.tools.Versions;
 
 public class Sigs implements Stage<SigsOutput, SomaticRunMetadata> {
     public static String NAMESPACE = "sigs";
 
-    private final InputDownload purpleSomaticVcfDownload;
+    private final InputDownload purpleSomaticVariantsDownload;
 
     private final ResourceFiles resourceFiles;
 
     public Sigs(final PurpleOutput purpleOutput, final ResourceFiles resourceFiles) {
-        purpleSomaticVcfDownload = new InputDownload(purpleOutput.maybeOutputLocations()
-                .map(PurpleOutputLocations::somaticVcf)
-                .orElse(GoogleStorageLocation.empty()));
+        purpleSomaticVariantsDownload = new InputDownload(purpleOutput.outputLocations().somaticVariants());
         this.resourceFiles = resourceFiles;
     }
 
     @Override
     public List<BashCommand> inputs() {
-        return List.of(purpleSomaticVcfDownload);
+        return List.of(purpleSomaticVariantsDownload);
     }
 
     @Override
@@ -62,7 +59,7 @@ public class Sigs implements Stage<SigsOutput, SomaticRunMetadata> {
                         "-signatures_file",
                         resourceFiles.snvSignatures(),
                         "-somatic_vcf_file",
-                        purpleSomaticVcfDownload.getLocalTargetPath(),
+                        purpleSomaticVariantsDownload.getLocalTargetPath(),
                         "-output_dir",
                         VmDirectories.OUTPUT)));
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/virus/VirusAnalysis.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/virus/VirusAnalysis.java
@@ -40,7 +40,7 @@ public class VirusAnalysis extends TertiaryStage<VirusOutput> {
 
     private final ResourceFiles resourceFiles;
     private final PersistedDataset persistedDataset;
-    private final InputDownload purplePurityTsv;
+    private final InputDownload purplePurity;
     private final InputDownload purpleQcFile;
     private final InputDownload tumorBamMetrics;
 
@@ -49,20 +49,17 @@ public class VirusAnalysis extends TertiaryStage<VirusOutput> {
         super(alignmentPair);
         this.resourceFiles = resourceFiles;
         this.persistedDataset = persistedDataset;
-        this.purpleQcFile = new InputDownload(purpleOutput.maybeOutputLocations()
-                .map(PurpleOutputLocations::qcFile)
-                .orElse(GoogleStorageLocation.empty()));
-        this.purplePurityTsv = new InputDownload(purpleOutput.maybeOutputLocations()
-                .map(PurpleOutputLocations::purityTsv)
-                .orElse(GoogleStorageLocation.empty()));
-        this.tumorBamMetrics = new InputDownload(tumorBamMetricsOutput.maybeMetricsOutputFile().orElse(GoogleStorageLocation.empty()));
+        final PurpleOutputLocations purpleOutputLocations = purpleOutput.outputLocations();
+        this.purpleQcFile = new InputDownload(purpleOutputLocations.qcFile());
+        this.purplePurity = new InputDownload(purpleOutputLocations.purity());
+        this.tumorBamMetrics = new InputDownload(tumorBamMetricsOutput.metricsOutputFile());
     }
 
     @Override
     public List<BashCommand> inputs() {
         List<BashCommand> inputs = new ArrayList<>(super.inputs());
         inputs.add(purpleQcFile);
-        inputs.add(purplePurityTsv);
+        inputs.add(purplePurity);
         inputs.add(tumorBamMetrics);
         return inputs;
     }
@@ -78,7 +75,7 @@ public class VirusAnalysis extends TertiaryStage<VirusOutput> {
         return new VirusBreakend(tumorSample, getTumorBamDownload().getLocalTargetPath(), resourceFiles).andThen(new VirusInterpreter(
                 tumorSample,
                 resourceFiles,
-                purplePurityTsv.getLocalTargetPath(),
+                purplePurity.getLocalTargetPath(),
                 purpleQcFile.getLocalTargetPath(),
                 tumorBamMetrics.getLocalTargetPath())).apply(SubStageInputOutput.empty(tumorSample)).bash();
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/virus/VirusOutput.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/virus/VirusOutput.java
@@ -17,8 +17,8 @@ public interface VirusOutput extends StageOutput {
 
     Optional<GoogleStorageLocation> maybeAnnotatedVirusFile();
 
-    default GoogleStorageLocation annotatedVirusFile() {
-        return maybeAnnotatedVirusFile().orElseThrow();
+    default GoogleStorageLocation virusAnnotations() {
+        return maybeAnnotatedVirusFile().orElse(GoogleStorageLocation.empty());
     }
 
     static ImmutableVirusOutput.Builder builder() {

--- a/cluster/src/test/java/com/hartwig/pipeline/SingleSamplePipelineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/SingleSamplePipelineTest.java
@@ -239,10 +239,10 @@ public class SingleSamplePipelineTest {
                 AlignmentOutput.builder().from(referenceAlignmentOutput()).addReportComponents(alignerComponent).build();
         when(aligner.run(referenceRunMetadata())).thenReturn(alignmentWithReportComponents);
         when(stageRunner.run(eq(referenceRunMetadata()), any())).thenReturn(BamMetricsOutput.builder()
-                .from(alignmentWithReportComponents)
-                .addReportComponents(metricsComponent)
-                .sample(referenceSample())
-                .build())
+                        .from(alignmentWithReportComponents)
+                        .addReportComponents(metricsComponent)
+                        .sample(referenceSample())
+                        .build())
                 .thenReturn(SnpGenotypeOutput.builder().from(snpGenotypeOutput()).addReportComponents(snpgenotypeComponent).build())
                 .thenReturn(FlagstatOutput.builder().from(flagstatOutput()).addReportComponents(flagstatComponent).build())
                 .thenReturn(CramOutput.builder().from(cramOutput()).addReportComponents(cramComponent).build())
@@ -328,7 +328,7 @@ public class SingleSamplePipelineTest {
         AlignmentOutput alignmentOutput = AlignmentOutput.builder()
                 .status(PipelineStatus.SUCCESS)
                 .sample(referenceSample())
-                .maybeFinalBamLocation(GoogleStorageLocation.of("run-reference-test/aligner", "results/reference.cram"))
+                .maybeAlignments(GoogleStorageLocation.of("run-reference-test/aligner", "results/reference.cram"))
                 .build();
         when(aligner.run(referenceRunMetadata())).thenReturn(alignmentOutput);
         @SuppressWarnings("unchecked")
@@ -336,8 +336,7 @@ public class SingleSamplePipelineTest {
         AlignmentOutput cram2Bam = AlignmentOutput.builder()
                 .status(PipelineStatus.FAILED)
                 .sample(referenceSample())
-                .maybeFinalBamLocation(GoogleStorageLocation.of("run-reference-test/cram2bam", "results/reference.bam"))
-                .maybeFinalBaiLocation(GoogleStorageLocation.of("run-reference-test/cram2bam", "results/reference.bam.bai"))
+                .maybeAlignments(GoogleStorageLocation.of("run-reference-test/cram2bam", "results/reference.bam"))
                 .build();
         when(stageRunner.run(eq(referenceRunMetadata()), stageArgumentCaptor.capture())).thenReturn(cram2Bam);
         PipelineState runOutput = victim.run(referenceRunMetadata());

--- a/cluster/src/test/java/com/hartwig/pipeline/alignment/bwa/BwaAlignerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/alignment/bwa/BwaAlignerTest.java
@@ -55,7 +55,8 @@ public class BwaAlignerTest {
                 sampleSource,
                 sampleUpload,
                 ResultsDirectory.defaultDirectory(),
-                Executors.newSingleThreadExecutor(), mock(Labels.class));
+                Executors.newSingleThreadExecutor(),
+                mock(Labels.class));
     }
 
     @Test
@@ -98,8 +99,7 @@ public class BwaAlignerTest {
     public void returnsProvidedBamIfInSample() throws Exception {
         when(sampleSource.sample(METADATA)).thenReturn(Sample.builder(METADATA.sampleName()).bam("gs://bucket/path/reference.bam").build());
         AlignmentOutput output = victim.run(METADATA);
-        assertThat(output.finalBamLocation()).isEqualTo(GoogleStorageLocation.of("bucket", "path/reference.bam"));
-        assertThat(output.finalBaiLocation()).isEqualTo(GoogleStorageLocation.of("bucket", "path/reference.bam.bai"));
+        assertThat(output.alignments()).isEqualTo(GoogleStorageLocation.of("bucket", "path/reference.bam"));
         assertThat(output.sample()).isEqualTo(METADATA.sampleName());
         assertThat(output.status()).isEqualTo(PipelineStatus.PROVIDED);
     }

--- a/cluster/src/test/java/com/hartwig/pipeline/alignment/persisted/PersistedAlignmentTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/alignment/persisted/PersistedAlignmentTest.java
@@ -31,9 +31,7 @@ public class PersistedAlignmentTest {
         AlignmentOutput output = victim.run(TestInputs.referenceRunMetadata());
         assertThat(output.sample()).isEqualTo("reference");
         assertThat(output.status()).isEqualTo(PipelineStatus.PERSISTED);
-        assertThat(output.finalBamLocation()).isEqualTo(PERSISTED_REFERENCE_CRAM);
-        assertThat(output.finalBaiLocation()).isEqualTo(GoogleStorageLocation.of(PERSISTED_REFERENCE_CRAM.bucket(),
-                FileTypes.crai(PERSISTED_REFERENCE_CRAM.path())));
+        assertThat(output.alignments()).isEqualTo(PERSISTED_REFERENCE_CRAM);
     }
 
     @Test
@@ -42,8 +40,7 @@ public class PersistedAlignmentTest {
         AlignmentOutput output = victim.run(TestInputs.referenceRunMetadata());
         assertThat(output.sample()).isEqualTo("reference");
         assertThat(output.status()).isEqualTo(PipelineStatus.PERSISTED);
-        assertThat(output.finalBamLocation()).isEqualTo(GoogleStorageLocation.of("bucket", "set/reference/aligner/reference.bam"));
-        assertThat(output.finalBaiLocation()).isEqualTo(GoogleStorageLocation.of("bucket", "set/reference/aligner/reference.bam.bai"));
+        assertThat(output.alignments()).isEqualTo(GoogleStorageLocation.of("bucket", "set/reference/aligner/reference.bam"));
     }
 
     @Test
@@ -53,7 +50,6 @@ public class PersistedAlignmentTest {
         AlignmentOutput output = victim.run(TestInputs.referenceRunMetadata());
         assertThat(output.sample()).isEqualTo("reference");
         assertThat(output.status()).isEqualTo(PipelineStatus.PERSISTED);
-        assertThat(output.finalBamLocation()).isEqualTo(GoogleStorageLocation.of("bucket", "set/reference/cram/reference.cram"));
-        assertThat(output.finalBaiLocation()).isEqualTo(GoogleStorageLocation.of("bucket", "set/reference/cram/reference.cram.crai"));
+        assertThat(output.alignments()).isEqualTo(GoogleStorageLocation.of("bucket", "set/reference/cram/reference.cram"));
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageGermlineCallerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageGermlineCallerTest.java
@@ -67,7 +67,7 @@ public class SageGermlineCallerTest extends TertiaryStageTest<SageOutput> {
 
     @Override
     protected void validatePersistedOutput(final SageOutput output) {
-        assertThat(output.finalVcf()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
+        assertThat(output.variants()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
                 "set/sage_germline/tumor.sage.germline.filtered.vcf.gz"));
     }
 

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageSomaticCallerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageSomaticCallerTest.java
@@ -71,7 +71,7 @@ public class SageSomaticCallerTest extends TertiaryStageTest<SageOutput> {
 
     @Override
     protected void validatePersistedOutput(final SageOutput output) {
-        assertThat(output.finalVcf()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
+        assertThat(output.variants()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
                 "set/sage_somatic/tumor.sage.somatic.filtered.vcf.gz"));
     }
 

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/structural/GripssGermlineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/structural/GripssGermlineTest.java
@@ -85,11 +85,8 @@ public class GripssGermlineTest extends StageTest<GripssGermlineOutput, SomaticR
     @Override
     protected void validatePersistedOutput(final GripssGermlineOutput output) {
         String outputDir = "set/" + GRIPSS;
-        assertThat(output.filteredVcf()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, outputDir + TUMOR_GRIPSS_FILTERED_VCF_GZ));
-        assertThat(output.filteredVcfIndex()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
-                outputDir + TUMOR_GRIPSS_FILTERED_VCF_GZ + ".tbi"));
-        assertThat(output.fullVcf()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, outputDir + TUMOR_GRIPSS_VCF_GZ));
-        assertThat(output.fullVcfIndex()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, outputDir + TUMOR_GRIPSS_VCF_GZ + ".tbi"));
+        assertThat(output.filteredVariants()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, outputDir + TUMOR_GRIPSS_FILTERED_VCF_GZ));
+        assertThat(output.unfilteredVariants()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, outputDir + TUMOR_GRIPSS_VCF_GZ));
     }
 
     @Override
@@ -100,11 +97,8 @@ public class GripssGermlineTest extends StageTest<GripssGermlineOutput, SomaticR
 
     @Override
     protected void validatePersistedOutputFromPersistedDataset(final GripssGermlineOutput output) {
-        assertThat(output.filteredVcf()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, GRIPSS + TUMOR_GRIPSS_FILTERED_VCF_GZ));
-        assertThat(output.filteredVcfIndex()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
-                GRIPSS + TUMOR_GRIPSS_FILTERED_VCF_GZ + ".tbi"));
-        assertThat(output.fullVcf()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, GRIPSS + TUMOR_GRIPSS_VCF_GZ));
-        assertThat(output.fullVcfIndex()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, GRIPSS + TUMOR_GRIPSS_VCF_GZ + ".tbi"));
+        assertThat(output.filteredVariants()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, GRIPSS + TUMOR_GRIPSS_FILTERED_VCF_GZ));
+        assertThat(output.unfilteredVariants()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, GRIPSS + TUMOR_GRIPSS_VCF_GZ));
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/structural/GripssSomaticTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/structural/GripssSomaticTest.java
@@ -85,11 +85,8 @@ public class GripssSomaticTest extends StageTest<GripssSomaticOutput, SomaticRun
     @Override
     protected void validatePersistedOutput(final GripssSomaticOutput output) {
         String outputDir = "set/" + GRIPSS;
-        assertThat(output.filteredVcf()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, outputDir + TUMOR_GRIPSS_FILTERED_VCF_GZ));
-        assertThat(output.filteredVcfIndex()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
-                outputDir + TUMOR_GRIPSS_FILTERED_VCF_GZ + ".tbi"));
-        assertThat(output.fullVcf()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, outputDir + TUMOR_GRIPSS_VCF_GZ));
-        assertThat(output.fullVcfIndex()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, outputDir + TUMOR_GRIPSS_VCF_GZ + ".tbi"));
+        assertThat(output.filteredVariants()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, outputDir + TUMOR_GRIPSS_FILTERED_VCF_GZ));
+        assertThat(output.unfilteredVariants()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, outputDir + TUMOR_GRIPSS_VCF_GZ));
     }
 
     @Override
@@ -100,11 +97,8 @@ public class GripssSomaticTest extends StageTest<GripssSomaticOutput, SomaticRun
 
     @Override
     protected void validatePersistedOutputFromPersistedDataset(final GripssSomaticOutput output) {
-        assertThat(output.filteredVcf()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, GRIPSS + TUMOR_GRIPSS_FILTERED_VCF_GZ));
-        assertThat(output.filteredVcfIndex()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
-                GRIPSS + TUMOR_GRIPSS_FILTERED_VCF_GZ + ".tbi"));
-        assertThat(output.fullVcf()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, GRIPSS + TUMOR_GRIPSS_VCF_GZ));
-        assertThat(output.fullVcfIndex()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, GRIPSS + TUMOR_GRIPSS_VCF_GZ + ".tbi"));
+        assertThat(output.filteredVariants()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, GRIPSS + TUMOR_GRIPSS_FILTERED_VCF_GZ));
+        assertThat(output.unfilteredVariants()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, GRIPSS + TUMOR_GRIPSS_VCF_GZ));
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/structural/StructuralCallerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/structural/StructuralCallerTest.java
@@ -95,10 +95,8 @@ public class StructuralCallerTest extends StageTest<StructuralCallerOutput, Soma
 
     @Override
     protected void validatePersistedOutput(final StructuralCallerOutput output) {
-        assertThat(output.unfilteredVcf()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
+        assertThat(output.unfilteredVariants()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
                 "set/gridss/" + TUMOR_GRIDSS_UNFILTERED_VCF_GZ));
-        assertThat(output.unfilteredVcfIndex()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
-                "set/gridss/" + TUMOR_GRIDSS_UNFILTERED_VCF_GZ + ".tbi"));
     }
 
     @Override
@@ -108,9 +106,7 @@ public class StructuralCallerTest extends StageTest<StructuralCallerOutput, Soma
 
     @Override
     protected void validatePersistedOutputFromPersistedDataset(final StructuralCallerOutput output) {
-        assertThat(output.unfilteredVcf()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, GRIDSS + TUMOR_GRIDSS_UNFILTERED_VCF_GZ));
-        assertThat(output.unfilteredVcfIndex()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
-                GRIDSS + TUMOR_GRIDSS_UNFILTERED_VCF_GZ + ".tbi"));
+        assertThat(output.unfilteredVariants()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, GRIDSS + TUMOR_GRIDSS_UNFILTERED_VCF_GZ));
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/cram2bam/Cram2BamTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/cram2bam/Cram2BamTest.java
@@ -54,7 +54,6 @@ public class Cram2BamTest extends StageTest<AlignmentOutput, SingleSampleRunMeta
 
     @Override
     protected void validateOutput(final AlignmentOutput output) {
-        assertThat(output.finalBamLocation()).isEqualTo(GoogleStorageLocation.of("run-tumor-test/cram2bam", "results/tumor.bam"));
-        assertThat(output.finalBaiLocation()).isEqualTo(GoogleStorageLocation.of("run-tumor-test/cram2bam", "results/tumor.bam.bai"));
+        assertThat(output.alignments()).isEqualTo(GoogleStorageLocation.of("run-tumor-test/cram2bam", "results/tumor.bam"));
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/pave/PaveGermlineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/pave/PaveGermlineTest.java
@@ -74,7 +74,7 @@ public class PaveGermlineTest extends StageTest<PaveOutput, SomaticRunMetadata> 
 
     @Override
     protected void validatePersistedOutput(final PaveOutput output) {
-        assertThat(output.finalVcf()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
+        assertThat(output.annotatedVariants()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
                 "set/pave_germline/tumor.sage.germline.filtered.pave.vcf.gz"));
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/pave/PaveSomaticTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/pave/PaveSomaticTest.java
@@ -74,7 +74,7 @@ public class PaveSomaticTest extends StageTest<PaveOutput, SomaticRunMetadata> {
 
     @Override
     protected void validatePersistedOutput(final PaveOutput output) {
-        assertThat(output.finalVcf()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
+        assertThat(output.annotatedVariants()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
                 "set/pave_somatic/tumor.sage.somatic.filtered.pave.vcf.gz"));
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/peach/PeachTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/peach/PeachTest.java
@@ -45,13 +45,13 @@ public class PeachTest extends TertiaryStageTest<PeachOutput> {
 
     @Override
     protected void validateOutput(final PeachOutput output) {
-        assertThat(output.genotypeTsv()).isEqualTo(GoogleStorageLocation.of(SOMATIC_BUCKET + "/peach",
+        assertThat(output.genotypes()).isEqualTo(GoogleStorageLocation.of(SOMATIC_BUCKET + "/peach",
                 ResultsDirectory.defaultDirectory().path(TUMOR_PEACH_GENOTYPE_TSV)));
     }
 
     @Override
     protected void validatePersistedOutput(final PeachOutput output) {
-        assertThat(output.genotypeTsv()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, "set/peach/" + TUMOR_PEACH_GENOTYPE_TSV));
+        assertThat(output.genotypes()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, "set/peach/" + TUMOR_PEACH_GENOTYPE_TSV));
     }
 
     @Override
@@ -61,7 +61,7 @@ public class PeachTest extends TertiaryStageTest<PeachOutput> {
 
     @Override
     protected void validatePersistedOutputFromPersistedDataset(final PeachOutput output) {
-        assertThat(output.genotypeTsv()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, "peach/" + TUMOR_PEACH_GENOTYPE_TSV));
+        assertThat(output.genotypes()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, "peach/" + TUMOR_PEACH_GENOTYPE_TSV));
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/protect/ProtectTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/protect/ProtectTest.java
@@ -75,13 +75,13 @@ public class ProtectTest extends TertiaryStageTest<ProtectOutput> {
 
     @Override
     protected void validateOutput(final ProtectOutput output) {
-        assertThat(output.evidenceTsv()).isEqualTo(GoogleStorageLocation.of(SOMATIC_BUCKET + "/protect",
+        assertThat(output.evidence()).isEqualTo(GoogleStorageLocation.of(SOMATIC_BUCKET + "/protect",
                 ResultsDirectory.defaultDirectory().path(TUMOR_PROTECT_TSV)));
     }
 
     @Override
     protected void validatePersistedOutput(final ProtectOutput output) {
-        assertThat(output.evidenceTsv()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, "set/protect/" + TUMOR_PROTECT_TSV));
+        assertThat(output.evidence()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, "set/protect/" + TUMOR_PROTECT_TSV));
     }
 
     @Override
@@ -91,7 +91,7 @@ public class ProtectTest extends TertiaryStageTest<ProtectOutput> {
 
     @Override
     protected void validatePersistedOutputFromPersistedDataset(final ProtectOutput output) {
-        assertThat(output.evidenceTsv()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, "protect/" + TUMOR_PROTECT_TSV));
+        assertThat(output.evidence()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, "protect/" + TUMOR_PROTECT_TSV));
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/purple/PurpleTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/purple/PurpleTest.java
@@ -106,20 +106,20 @@ public class PurpleTest extends TertiaryStageTest<PurpleOutput> {
         assertThat(output.outputLocations().outputDirectory().bucket()).isEqualTo(bucketName);
         assertThat(output.outputLocations().outputDirectory().path()).isEqualTo("results");
         assertThat(output.outputLocations().outputDirectory().isDirectory()).isTrue();
-        assertThat(output.outputLocations().somaticVcf().bucket()).isEqualTo(bucketName);
-        assertThat(output.outputLocations().somaticVcf().path()).isEqualTo("results/" + TUMOR_PURPLE_SOMATIC_VCF_GZ);
-        assertThat(output.outputLocations().somaticVcf().isDirectory()).isFalse();
-        assertThat(output.outputLocations().structuralVcf().bucket()).isEqualTo(bucketName);
-        assertThat(output.outputLocations().structuralVcf().path()).isEqualTo("results/" + TUMOR_PURPLE_SV_VCF_GZ);
-        assertThat(output.outputLocations().structuralVcf().isDirectory()).isFalse();
+        assertThat(output.outputLocations().somaticVariants().bucket()).isEqualTo(bucketName);
+        assertThat(output.outputLocations().somaticVariants().path()).isEqualTo("results/" + TUMOR_PURPLE_SOMATIC_VCF_GZ);
+        assertThat(output.outputLocations().somaticVariants().isDirectory()).isFalse();
+        assertThat(output.outputLocations().structuralVariants().bucket()).isEqualTo(bucketName);
+        assertThat(output.outputLocations().structuralVariants().path()).isEqualTo("results/" + TUMOR_PURPLE_SV_VCF_GZ);
+        assertThat(output.outputLocations().structuralVariants().isDirectory()).isFalse();
     }
 
     @Override
     protected void validatePersistedOutput(final PurpleOutput output) {
         assertThat(output.outputLocations().outputDirectory()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, "set/purple", true));
-        assertThat(output.outputLocations().somaticVcf()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
+        assertThat(output.outputLocations().somaticVariants()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
                 "set/purple/" + TUMOR_PURPLE_SOMATIC_VCF_GZ));
-        assertThat(output.outputLocations().structuralVcf()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
+        assertThat(output.outputLocations().structuralVariants()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
                 "set/purple/" + TUMOR_PURPLE_SV_VCF_GZ));
     }
 
@@ -132,9 +132,9 @@ public class PurpleTest extends TertiaryStageTest<PurpleOutput> {
     @Override
     protected void validatePersistedOutputFromPersistedDataset(final PurpleOutput output) {
         assertThat(output.outputLocations().outputDirectory()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET, "purple", true));
-        assertThat(output.outputLocations().somaticVcf()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
+        assertThat(output.outputLocations().somaticVariants()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
                 "purple/" + TUMOR_PURPLE_SOMATIC_VCF_GZ));
-        assertThat(output.outputLocations().structuralVcf()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
+        assertThat(output.outputLocations().structuralVariants()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
                 "purple/" + TUMOR_PURPLE_SV_VCF_GZ));
     }
 

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/virus/VirusAnalysisTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/virus/VirusAnalysisTest.java
@@ -63,13 +63,13 @@ public class VirusAnalysisTest extends TertiaryStageTest<VirusOutput> {
 
     @Override
     protected void validateOutput(final VirusOutput output) {
-        assertThat(output.annotatedVirusFile()).isEqualTo(GoogleStorageLocation.of(SOMATIC_BUCKET + "/virusbreakend",
+        assertThat(output.virusAnnotations()).isEqualTo(GoogleStorageLocation.of(SOMATIC_BUCKET + "/virusbreakend",
                 ResultsDirectory.defaultDirectory().path(TUMOR_VIRUS_ANNOTATED_TSV)));
     }
 
     @Override
     protected void validatePersistedOutput(final VirusOutput output) {
-        assertThat(output.annotatedVirusFile()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
+        assertThat(output.virusAnnotations()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
                 "set/virusbreakend/" + TUMOR_VIRUS_ANNOTATED_TSV));
     }
 
@@ -81,7 +81,7 @@ public class VirusAnalysisTest extends TertiaryStageTest<VirusOutput> {
 
     @Override
     protected void validatePersistedOutputFromPersistedDataset(final VirusOutput output) {
-        assertThat(output.annotatedVirusFile()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
+        assertThat(output.virusAnnotations()).isEqualTo(GoogleStorageLocation.of(OUTPUT_BUCKET,
                 "virusbreakend/" + TUMOR_VIRUS_ANNOTATED_TSV));
     }
 

--- a/cluster/src/test/java/com/hartwig/pipeline/testsupport/TestInputs.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/testsupport/TestInputs.java
@@ -12,11 +12,10 @@ import com.hartwig.pipeline.calling.germline.GermlineCallerOutput;
 import com.hartwig.pipeline.calling.sage.SageGermlineCaller;
 import com.hartwig.pipeline.calling.sage.SageOutput;
 import com.hartwig.pipeline.calling.sage.SageSomaticCaller;
-import com.hartwig.pipeline.calling.structural.gripss.GripssGermline;
-import com.hartwig.pipeline.calling.structural.gripss.GripssGermlineOutput;
-import com.hartwig.pipeline.calling.structural.gripss.GripssOutput;
 import com.hartwig.pipeline.calling.structural.StructuralCaller;
 import com.hartwig.pipeline.calling.structural.StructuralCallerOutput;
+import com.hartwig.pipeline.calling.structural.gripss.GripssGermline;
+import com.hartwig.pipeline.calling.structural.gripss.GripssGermlineOutput;
 import com.hartwig.pipeline.calling.structural.gripss.GripssSomatic;
 import com.hartwig.pipeline.calling.structural.gripss.GripssSomaticOutput;
 import com.hartwig.pipeline.cram.CramOutput;
@@ -44,13 +43,13 @@ import com.hartwig.pipeline.tertiary.cuppa.CuppaOutput;
 import com.hartwig.pipeline.tertiary.cuppa.CuppaOutputLocations;
 import com.hartwig.pipeline.tertiary.healthcheck.HealthCheckOutput;
 import com.hartwig.pipeline.tertiary.healthcheck.HealthChecker;
-import com.hartwig.pipeline.tertiary.linx.LinxSomatic;
+import com.hartwig.pipeline.tertiary.lilac.LilacOutput;
 import com.hartwig.pipeline.tertiary.linx.LinxGermline;
 import com.hartwig.pipeline.tertiary.linx.LinxGermlineOutput;
 import com.hartwig.pipeline.tertiary.linx.LinxGermlineOutputLocations;
+import com.hartwig.pipeline.tertiary.linx.LinxSomatic;
 import com.hartwig.pipeline.tertiary.linx.LinxSomaticOutput;
 import com.hartwig.pipeline.tertiary.linx.LinxSomaticOutputLocations;
-import com.hartwig.pipeline.tertiary.lilac.LilacOutput;
 import com.hartwig.pipeline.tertiary.orange.OrangeOutput;
 import com.hartwig.pipeline.tertiary.pave.PaveGermline;
 import com.hartwig.pipeline.tertiary.pave.PaveOutput;
@@ -143,8 +142,7 @@ public class TestInputs {
         String bucket = namespacedBucket(sample, Aligner.NAMESPACE);
         return AlignmentOutput.builder()
                 .status(PipelineStatus.SUCCESS)
-                .maybeFinalBamLocation(gsLocation(bucket, RESULTS + sample + ".bam"))
-                .maybeFinalBaiLocation(gsLocation(bucket, RESULTS + sample + ".bam.bai"))
+                .maybeAlignments(gsLocation(bucket, RESULTS + sample + ".bam"))
                 .sample(sample)
                 .build();
     }
@@ -207,9 +205,9 @@ public class TestInputs {
     public static SageOutput sageGermlineOutput() {
         return SageOutput.builder(SageGermlineCaller.NAMESPACE)
                 .status(PipelineStatus.SUCCESS)
-                .maybeFinalVcf(gsLocation(somaticBucket(SageGermlineCaller.NAMESPACE),
+                .maybeVariants(gsLocation(somaticBucket(SageGermlineCaller.NAMESPACE),
                         RESULTS + TUMOR_SAMPLE + ".germline." + FileTypes.GZIPPED_VCF))
-                .maybeGermlineGeneCoverageTsv(gsLocation(somaticBucket(SageGermlineCaller.NAMESPACE),
+                .maybeGermlineGeneCoverage(gsLocation(somaticBucket(SageGermlineCaller.NAMESPACE),
                         RESULTS + TUMOR_SAMPLE + SageGermlineCaller.SAGE_GENE_COVERAGE_TSV))
                 .build();
     }
@@ -217,7 +215,7 @@ public class TestInputs {
     public static SageOutput sageSomaticOutput() {
         return SageOutput.builder(SageSomaticCaller.NAMESPACE)
                 .status(PipelineStatus.SUCCESS)
-                .maybeFinalVcf(gsLocation(somaticBucket(SageSomaticCaller.NAMESPACE),
+                .maybeVariants(gsLocation(somaticBucket(SageSomaticCaller.NAMESPACE),
                         RESULTS + TUMOR_SAMPLE + ".somatic." + FileTypes.GZIPPED_VCF))
                 .maybeSomaticRefSampleBqrPlot(gsLocation(somaticBucket(SageSomaticCaller.NAMESPACE),
                         RESULTS + REFERENCE_SAMPLE + SageGermlineCaller.SAGE_BQR_PNG))
@@ -229,7 +227,7 @@ public class TestInputs {
     public static PaveOutput paveSomaticOutput() {
         return PaveOutput.builder(PaveSomatic.NAMESPACE)
                 .status(PipelineStatus.SUCCESS)
-                .maybeFinalVcf(gsLocation(somaticBucket(PaveSomatic.NAMESPACE), RESULTS + TUMOR_SAMPLE + ".somatic." +
+                .maybeAnnotatedVariants(gsLocation(somaticBucket(PaveSomatic.NAMESPACE), RESULTS + TUMOR_SAMPLE + ".somatic." +
                         // String.format(".%s.%s.", SageSomaticPostProcess.SAGE_SOMATIC_FILTERED, PAVE_FILE_ID) +
                         FileTypes.GZIPPED_VCF))
                 .build();
@@ -238,7 +236,7 @@ public class TestInputs {
     public static PaveOutput paveGermlineOutput() {
         return PaveOutput.builder(PaveGermline.NAMESPACE)
                 .status(PipelineStatus.SUCCESS)
-                .maybeFinalVcf(gsLocation(somaticBucket(PaveGermline.NAMESPACE), RESULTS + TUMOR_SAMPLE + ".germline." +
+                .maybeAnnotatedVariants(gsLocation(somaticBucket(PaveGermline.NAMESPACE), RESULTS + TUMOR_SAMPLE + ".germline." +
                         // String.format(".%s.%s.", SageGermlinePostProcess.SAGE_GERMLINE_FILTERED, PAVE_FILE_ID) +
                         FileTypes.GZIPPED_VCF))
                 .build();
@@ -260,13 +258,10 @@ public class TestInputs {
         String full = ".gripss.full.";
         return GripssSomaticOutput.builder()
                 .status(PipelineStatus.SUCCESS)
-                .maybeFilteredVcf(gsLocation(somaticBucket(GripssSomatic.NAMESPACE),
+                .maybeFilteredVariants(gsLocation(somaticBucket(GripssSomatic.NAMESPACE),
                         RESULTS + TUMOR_SAMPLE + filtered + FileTypes.GZIPPED_VCF))
-                .maybeFilteredVcfIndex(gsLocation(somaticBucket(GripssSomatic.NAMESPACE),
-                        RESULTS + TUMOR_SAMPLE + filtered + FileTypes.GZIPPED_VCF + ".tbi"))
-                .maybeFullVcf(gsLocation(somaticBucket(GripssSomatic.NAMESPACE), RESULTS + TUMOR_SAMPLE + full + FileTypes.GZIPPED_VCF))
-                .maybeFullVcfIndex(gsLocation(somaticBucket(GripssSomatic.NAMESPACE),
-                        RESULTS + TUMOR_SAMPLE + full + FileTypes.GZIPPED_VCF + ".tbi"))
+                .maybeUnfilteredVariants(gsLocation(somaticBucket(GripssSomatic.NAMESPACE),
+                        RESULTS + TUMOR_SAMPLE + full + FileTypes.GZIPPED_VCF))
                 .build();
     }
 
@@ -275,13 +270,10 @@ public class TestInputs {
         String full = ".gripss.full.";
         return GripssGermlineOutput.builder()
                 .status(PipelineStatus.SUCCESS)
-                .maybeFilteredVcf(gsLocation(somaticBucket(GripssGermline.NAMESPACE),
+                .maybeFilteredVariants(gsLocation(somaticBucket(GripssGermline.NAMESPACE),
                         RESULTS + TUMOR_SAMPLE + filtered + FileTypes.GZIPPED_VCF))
-                .maybeFilteredVcfIndex(gsLocation(somaticBucket(GripssGermline.NAMESPACE),
-                        RESULTS + TUMOR_SAMPLE + filtered + FileTypes.GZIPPED_VCF + ".tbi"))
-                .maybeFullVcf(gsLocation(somaticBucket(GripssGermline.NAMESPACE), RESULTS + TUMOR_SAMPLE + full + FileTypes.GZIPPED_VCF))
-                .maybeFullVcfIndex(gsLocation(somaticBucket(GripssGermline.NAMESPACE),
-                        RESULTS + TUMOR_SAMPLE + full + FileTypes.GZIPPED_VCF + ".tbi"))
+                .maybeUnfilteredVariants(gsLocation(somaticBucket(GripssGermline.NAMESPACE),
+                        RESULTS + TUMOR_SAMPLE + full + FileTypes.GZIPPED_VCF))
                 .build();
     }
 
@@ -316,19 +308,19 @@ public class TestInputs {
                 .status(PipelineStatus.SUCCESS)
                 .maybeOutputLocations(PurpleOutputLocations.builder()
                         .outputDirectory(gsLocation(somaticBucket(Purple.NAMESPACE), RESULTS))
-                        .somaticVcf(gsLocation(somaticBucket(Purple.NAMESPACE), TUMOR_SAMPLE + Purple.PURPLE_SOMATIC_VCF))
-                        .germlineVcf(gsLocation(somaticBucket(Purple.NAMESPACE), TUMOR_SAMPLE + Purple.PURPLE_GERMLINE_VCF))
-                        .structuralVcf(gsLocation(somaticBucket(Purple.NAMESPACE), TUMOR_SAMPLE + Purple.PURPLE_SV_VCF))
-                        .purityTsv(gsLocation(somaticBucket(Purple.NAMESPACE), TUMOR_SAMPLE + Purple.PURPLE_PURITY_TSV))
+                        .somaticVariants(gsLocation(somaticBucket(Purple.NAMESPACE), TUMOR_SAMPLE + Purple.PURPLE_SOMATIC_VCF))
+                        .germlineVariants(gsLocation(somaticBucket(Purple.NAMESPACE), TUMOR_SAMPLE + Purple.PURPLE_GERMLINE_VCF))
+                        .structuralVariants(gsLocation(somaticBucket(Purple.NAMESPACE), TUMOR_SAMPLE + Purple.PURPLE_SV_VCF))
+                        .purity(gsLocation(somaticBucket(Purple.NAMESPACE), TUMOR_SAMPLE + Purple.PURPLE_PURITY_TSV))
                         .qcFile(gsLocation(somaticBucket(Purple.NAMESPACE), TUMOR_SAMPLE + Purple.PURPLE_QC))
-                        .geneCopyNumberTsv(gsLocation(somaticBucket(Purple.NAMESPACE), TUMOR_SAMPLE + Purple.PURPLE_GENE_COPY_NUMBER_TSV))
+                        .geneCopyNumber(gsLocation(somaticBucket(Purple.NAMESPACE), TUMOR_SAMPLE + Purple.PURPLE_GENE_COPY_NUMBER_TSV))
                         .somaticDriverCatalog(gsLocation(somaticBucket(Purple.NAMESPACE),
                                 TUMOR_SAMPLE + Purple.PURPLE_SOMATIC_DRIVER_CATALOG))
                         .germlineDriverCatalog(gsLocation(somaticBucket(Purple.NAMESPACE),
                                 TUMOR_SAMPLE + Purple.PURPLE_GERMLINE_DRIVER_CATALOG))
                         .circosPlot(gsLocation(somaticBucket(Purple.NAMESPACE),
                                 format("plot/%s%s", TUMOR_SAMPLE, Purple.PURPLE_CIRCOS_PLOT)))
-                        .somaticCopyNumberTsv(gsLocation(somaticBucket(Purple.NAMESPACE),
+                        .somaticCopyNumber(gsLocation(somaticBucket(Purple.NAMESPACE),
                                 TUMOR_SAMPLE + Purple.PURPLE_SOMATIC_COPY_NUMBER_TSV))
                         .build())
                 .build();
@@ -399,14 +391,14 @@ public class TestInputs {
     public static ProtectOutput protectOutput() {
         return ProtectOutput.builder()
                 .status(PipelineStatus.SUCCESS)
-                .maybeEvidenceTsv(GoogleStorageLocation.of(somaticBucket(Protect.NAMESPACE), TUMOR_SAMPLE + Protect.PROTECT_EVIDENCE_TSV))
+                .maybeEvidence(GoogleStorageLocation.of(somaticBucket(Protect.NAMESPACE), TUMOR_SAMPLE + Protect.PROTECT_EVIDENCE_TSV))
                 .build();
     }
 
     public static PeachOutput peachOutput() {
         return PeachOutput.builder()
                 .status(PipelineStatus.SUCCESS)
-                .maybeGenotypeTsv(GoogleStorageLocation.of(somaticBucket(Peach.NAMESPACE), TUMOR_SAMPLE + Peach.PEACH_GENOTYPE_TSV))
+                .maybeGenotypes(GoogleStorageLocation.of(somaticBucket(Peach.NAMESPACE), TUMOR_SAMPLE + Peach.PEACH_GENOTYPE_TSV))
                 .build();
     }
 


### PR DESCRIPTION
Into the output classes themselves, simplifying the client code and
reducing duplication.

Also reduce inconsistency in naming and remove file types from output
property names. There are legitimate cases where the same property is
used with two different file types (ie bam/cram) so this seemed the
most "correct".