### PR TITLE
DEV-2573 Add panel bed to common resources

### DIFF
--- a/cluster/images/create_public_image.sh
+++ b/cluster/images/create_public_image.sh
@@ -3,7 +3,7 @@
 LOCATION="europe-west4"
 ZONE="${LOCATION}-a"
 PROJECT="hmf-pipeline-development"
-VERSION=5-27
+VERSION=5-28
 
 TOOLS_ONLY=false
 while getopts ':tf:' flag; do

--- a/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
@@ -81,6 +81,7 @@ public class CommandLineOptions {
     private static final String CONTEXT_FLAG = "context";
     private static final String COST_CENTER_LABEL_FLAG = "cost_center_label";
     private static final String USER_LABEL_FLAG = "user_label";
+    private static final String PANEL_BED_FLAG = "panel_bed_location";
 
     private static Options options() {
         return new Options().addOption(profile())
@@ -146,7 +147,13 @@ public class CommandLineOptions {
                 .addOption(anonymize())
                 .addOption(context())
                 .addOption(costCenterLabel())
-                .addOption(userLabel());
+                .addOption(userLabel())
+                .addOption(panelBedLocation());
+    }
+
+    private static Option panelBedLocation() {
+        return optionWithArg(PANEL_BED_FLAG,
+                "Specify the location of the panel bed to enable panel mode. Both within image and gs:// urls are supported.");
     }
 
     private static Option userLabel() {
@@ -379,6 +386,7 @@ public class CommandLineOptions {
                     .context(context(commandLine, defaults))
                     .costCenterLabel(costCenterLabel(commandLine, defaults))
                     .userLabel(userLabel(commandLine, defaults))
+                    .panelBedLocation(panelBedLocation(commandLine, defaults))
                     .build();
         } catch (ParseException e) {
             LOGGER.error("Could not parse command line args", e);
@@ -386,6 +394,13 @@ public class CommandLineOptions {
             formatter.printHelp("pipeline5", options());
             throw e;
         }
+    }
+
+    public static Optional<String> panelBedLocation(final CommandLine commandLine, final Arguments defaults) {
+        if (commandLine.hasOption(PANEL_BED_FLAG)) {
+            return Optional.of(commandLine.getOptionValue(PANEL_BED_FLAG));
+        }
+        return defaults.panelBedLocation();
     }
 
     public static Optional<String> userLabel(final CommandLine commandLine, final Arguments defaults) {

--- a/cluster/src/main/java/com/hartwig/pipeline/CommonArguments.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/CommonArguments.java
@@ -77,6 +77,8 @@ public interface CommonArguments {
 
     Optional<String> userLabel();
 
+    Optional<String> panelBedLocation();
+
     static Optional<String> privateKey(CommandLine commandLine) {
         if (commandLine.hasOption(PRIVATE_KEY_PATH)) {
             return Optional.of(commandLine.getOptionValue(PRIVATE_KEY_PATH));

--- a/cluster/src/main/java/com/hartwig/pipeline/resource/OverridePanelCommand.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/resource/OverridePanelCommand.java
@@ -1,0 +1,23 @@
+package com.hartwig.pipeline.resource;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.hartwig.pipeline.Arguments;
+import com.hartwig.pipeline.execution.vm.BashCommand;
+import com.hartwig.pipeline.execution.vm.unix.MkDirCommand;
+
+public class OverridePanelCommand {
+
+    static final String RESOURCES_OVERRIDE = "/opt/resources/" + ResourceNames.PANEL + "/override";
+
+    public static List<BashCommand> overrides(final Arguments arguments) {
+        return arguments.panelBedLocation()
+                .map(p -> List.of(new MkDirCommand(RESOURCES_OVERRIDE), copyDownPanelBed(p)))
+                .orElse(Collections.emptyList());
+    }
+
+    private static BashCommand copyDownPanelBed(final String p) {
+        return () -> String.format("gsutil -qm cp -n %s %s", p, RESOURCES_OVERRIDE);
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/resource/PanelEnabled.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/resource/PanelEnabled.java
@@ -1,0 +1,192 @@
+package com.hartwig.pipeline.resource;
+
+import java.util.Optional;
+
+import com.hartwig.pipeline.execution.vm.VmDirectories;
+
+public class PanelEnabled implements ResourceFiles {
+
+    private final ResourceFiles decorated;
+    private final String panelBed;
+
+    public PanelEnabled(final ResourceFiles decorated, final String panelBedLocation) {
+        this.decorated = decorated;
+        this.panelBed = panelBedLocation.startsWith("gs://") ? OverridePanelCommand.RESOURCES_OVERRIDE + panelBedLocation.substring(
+                panelBedLocation.lastIndexOf("/")) : VmDirectories.RESOURCES + "/" + ResourceNames.PANEL + "/" + panelBedLocation;
+    }
+
+    @Override
+    public String refGenomeFile() {
+        return decorated.refGenomeFile();
+    }
+
+    @Override
+    public RefGenomeVersion version() {
+        return decorated.version();
+    }
+
+    @Override
+    public String versionDirectory() {
+        return decorated.versionDirectory();
+    }
+
+    @Override
+    public String gcProfileFile() {
+        return decorated.gcProfileFile();
+    }
+
+    @Override
+    public String diploidRegionsBed() {
+        return decorated.diploidRegionsBed();
+    }
+
+    @Override
+    public String amberHeterozygousLoci() {
+        return decorated.amberHeterozygousLoci();
+    }
+
+    @Override
+    public String amberSnpcheck() {
+        return decorated.amberSnpcheck();
+    }
+
+    @Override
+    public String gridssRepeatMaskerDb() {
+        return decorated.gridssRepeatMaskerDb();
+    }
+
+    @Override
+    public String gridssBlacklistBed() {
+        return decorated.gridssBlacklistBed();
+    }
+
+    @Override
+    public String gridssBreakendPon() {
+        return decorated.gridssBreakendPon();
+    }
+
+    @Override
+    public String gridssBreakpointPon() {
+        return decorated.gridssBreakpointPon();
+    }
+
+    @Override
+    public String sageSomaticHotspots() {
+        return decorated.sageSomaticHotspots();
+    }
+
+    @Override
+    public String sageSomaticCodingPanel() {
+        return decorated.sageSomaticCodingPanel();
+    }
+
+    @Override
+    public String sageGermlineHotspots() {
+        return decorated.sageGermlineHotspots();
+    }
+
+    @Override
+    public String sageGermlineCodingPanel() {
+        return decorated.sageGermlineCodingPanel();
+    }
+
+    @Override
+    public String sageGermlineCoveragePanel() {
+        return decorated.sageGermlineCoveragePanel();
+    }
+
+    @Override
+    public String sageGermlineSlicePanel() {
+        return decorated.sageGermlineSlicePanel();
+    }
+
+    @Override
+    public String sageGermlineBlacklistVcf() {
+        return decorated.sageGermlineBlacklistVcf();
+    }
+
+    @Override
+    public String sageGermlineBlacklistBed() {
+        return decorated.sageGermlineBlacklistBed();
+    }
+
+    @Override
+    public String clinvarVcf() {
+        return decorated.clinvarVcf();
+    }
+
+    @Override
+    public String out150Mappability() {
+        return decorated.out150Mappability();
+    }
+
+    @Override
+    public String sageGermlinePon() {
+        return decorated.sageGermlinePon();
+    }
+
+    @Override
+    public String giabHighConfidenceBed() {
+        return decorated.giabHighConfidenceBed();
+    }
+
+    @Override
+    public String knownFusionPairBedpe() {
+        return decorated.knownFusionPairBedpe();
+    }
+
+    @Override
+    public String ensemblDataCache() {
+        return decorated.ensemblDataCache();
+    }
+
+    @Override
+    public String fragileSites() {
+        return decorated.fragileSites();
+    }
+
+    @Override
+    public String lineElements() {
+        return decorated.lineElements();
+    }
+
+    @Override
+    public String knownFusionData() {
+        return decorated.knownFusionData();
+    }
+
+    @Override
+    public String genotypeSnpsDB() {
+        return decorated.genotypeSnpsDB();
+    }
+
+    @Override
+    public String driverGenePanel() {
+        return decorated.driverGenePanel();
+    }
+
+    @Override
+    public String actionabilityDir() {
+        return decorated.actionabilityDir();
+    }
+
+    @Override
+    public String hlaRegionBed() {
+        return decorated.hlaRegionBed();
+    }
+
+    @Override
+    public String peachFilterBed() {
+        return decorated.peachFilterBed();
+    }
+
+    @Override
+    public String purpleCohortGermlineDeletions() {
+        return decorated.purpleCohortGermlineDeletions();
+    }
+
+    @Override
+    public Optional<String> panelBed() {
+        return Optional.of(panelBed);
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/resource/RefGenome37ResourceFiles.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/resource/RefGenome37ResourceFiles.java
@@ -19,6 +19,8 @@ import static com.hartwig.pipeline.resource.ResourceNames.REFERENCE_GENOME;
 import static com.hartwig.pipeline.resource.ResourceNames.SAGE;
 import static com.hartwig.pipeline.resource.ResourceNames.SERVE;
 
+import java.util.Optional;
+
 public class RefGenome37ResourceFiles implements ResourceFiles {
 
     private static final String REF_GENOME_FASTA_37_FILE = "Homo_sapiens.GRCh37.GATK.illumina.fasta";
@@ -189,6 +191,7 @@ public class RefGenome37ResourceFiles implements ResourceFiles {
     }
 
     @Override
-    public String purpleCohortGermlineDeletions() { return formPath(PURPLE, "cohort_germline_del_freq.37.csv"); }
-
+    public String purpleCohortGermlineDeletions() {
+        return formPath(PURPLE, "cohort_germline_del_freq.37.csv");
+    }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/resource/ResourceFiles.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/resource/ResourceFiles.java
@@ -11,6 +11,8 @@ import static com.hartwig.pipeline.resource.ResourceNames.VIRUS_INTERPRETER;
 import static com.hartwig.pipeline.resource.ResourceNames.VIRUS_REFERENCE_GENOME;
 import static com.hartwig.pipeline.resource.ResourceNames.PURPLE;
 
+import java.util.Optional;
+
 import com.hartwig.pipeline.execution.vm.VmDirectories;
 
 public interface ResourceFiles {
@@ -106,6 +108,10 @@ public interface ResourceFiles {
     String peachFilterBed();
 
     String purpleCohortGermlineDeletions();
+
+    default Optional<String> panelBed() {
+        return Optional.empty();
+    }
 
     default String cuppaRefData() {
         return of(CUPPA);

--- a/cluster/src/main/java/com/hartwig/pipeline/resource/ResourceFilesFactory.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/resource/ResourceFilesFactory.java
@@ -10,6 +10,12 @@ public class ResourceFilesFactory {
 
     public static ResourceFiles buildResourceFiles(final CommonArguments arguments) {
         ResourceFiles resourceFiles = buildResourceFiles(arguments.refGenomeVersion());
-        return arguments.refGenomeUrl().<ResourceFiles>map(p -> new OverriddenReferenceGenome(resourceFiles, p)).orElse(resourceFiles);
+        if (arguments.refGenomeUrl().isPresent()) {
+            resourceFiles = new OverriddenReferenceGenome(resourceFiles, arguments.refGenomeUrl().get());
+        }
+        if (arguments.panelBedLocation().isPresent()) {
+            resourceFiles = new PanelEnabled(resourceFiles, arguments.panelBedLocation().get());
+        }
+        return resourceFiles;
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/resource/ResourceNames.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/resource/ResourceNames.java
@@ -28,4 +28,5 @@ public interface ResourceNames {
     String ORANGE = "orange";
     String PURPLE = "purple";
     String LILAC = "lilac";
+    String PANEL = "panel";
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/stages/StageRunner.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/stages/StageRunner.java
@@ -17,6 +17,7 @@ import com.hartwig.pipeline.failsafe.DefaultBackoffPolicy;
 import com.hartwig.pipeline.labels.Labels;
 import com.hartwig.pipeline.metadata.RunMetadata;
 import com.hartwig.pipeline.reruns.StartingPoint;
+import com.hartwig.pipeline.resource.OverridePanelCommand;
 import com.hartwig.pipeline.resource.OverrideReferenceGenomeCommand;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
@@ -52,6 +53,7 @@ public class StageRunner<M extends RunMetadata> {
                 BashStartupScript bash = BashStartupScript.of(bucket.name());
                 bash.addCommands(stage.inputs())
                         .addCommands(OverrideReferenceGenomeCommand.overrides(arguments))
+                        .addCommands(OverridePanelCommand.overrides(arguments))
                         .addCommands(commands)
                         .addCommand(new OutputUpload(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path()),
                                 RuntimeFiles.typical()));

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/HmfToolCommandBuilder.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/HmfToolCommandBuilder.java
@@ -3,6 +3,9 @@ package com.hartwig.pipeline.tertiary;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.hartwig.pipeline.execution.vm.BashCommand;
 import com.hartwig.pipeline.execution.vm.VmDirectories;
@@ -33,6 +36,12 @@ public class HmfToolCommandBuilder {
 
     public HmfToolCommandBuilder reference(final String referenceSample, final String referenceBamPath) {
         arguments.addAll(List.of("-reference", referenceSample, "-reference_bam", referenceBamPath));
+        return this;
+    }
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    public HmfToolCommandBuilder panelBed(final Optional<String> panelBedLocation) {
+      //  arguments.addAll(panelBedLocation.stream().flatMap(l -> Stream.of("-panel_bed", l)).collect(Collectors.toList()));
         return this;
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/amber/Amber.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/amber/Amber.java
@@ -48,6 +48,7 @@ public class Amber extends TertiaryStage<AmberOutput> {
         return List.of(AmberCommandBuilder.newBuilder(resourceFiles)
                 .tumor(metadata.tumor().sampleName(), getTumorBamDownload().getLocalTargetPath())
                 .reference(metadata.reference().sampleName(), getReferenceBamDownload().getLocalTargetPath())
+                .panelBed(resourceFiles.panelBed())
                 .build(), new CopyResourceToOutput(resourceFiles.amberSnpcheck()));
     }
 

--- a/cluster/src/test/java/com/hartwig/pipeline/resource/OverridePanelCommandTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/resource/OverridePanelCommandTest.java
@@ -1,0 +1,29 @@
+package com.hartwig.pipeline.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.hartwig.pipeline.Arguments;
+import com.hartwig.pipeline.execution.vm.BashCommand;
+
+import org.junit.Test;
+
+public class OverridePanelCommandTest {
+
+    @Test
+    public void createsEmptyListIfNoReferenceGenomeUrl() {
+        assertThat(OverridePanelCommand.overrides(Arguments.testDefaultsBuilder().panelBedLocation(Optional.empty()).build())).isEmpty();
+    }
+
+    @Test
+    public void mksDirAndCopiesDownReferenceGenome() {
+        List<BashCommand> commands = OverridePanelCommand.overrides(Arguments.testDefaultsBuilder()
+                .panelBedLocation(Optional.of("gs://bucket/path/panel.bed"))
+                .build());
+        assertThat(commands).hasSize(2);
+        assertThat(commands.stream().map(BashCommand::asBash)).containsExactly("mkdir -p /opt/resources/panel/override",
+                "gsutil -qm cp -n gs://bucket/path/panel.bed /opt/resources/panel/override");
+    }
+}

--- a/cluster/src/test/java/com/hartwig/pipeline/resource/PanelEnabledTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/resource/PanelEnabledTest.java
@@ -1,0 +1,23 @@
+package com.hartwig.pipeline.resource;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+
+public class PanelEnabledTest {
+
+    @Test
+    public void returnsLocalPathToOverridenBedFileGCS() {
+        ResourceFiles decorated = mock(ResourceFiles.class);
+        PanelEnabled victim = new PanelEnabled(decorated, "gs://bucket/panel/panel.bed");
+        assertThat(victim.panelBed()).hasValue("/opt/resources/panel/override/panel.bed");
+    }
+
+    @Test
+    public void returnsLocalPathToBedFileInImage() {
+        ResourceFiles decorated = mock(ResourceFiles.class);
+        PanelEnabled victim = new PanelEnabled(decorated, "panel.bed");
+        assertThat(victim.panelBed()).hasValue("/opt/resources/panel/panel.bed");
+    }
+}


### PR DESCRIPTION
The panel bed is configured as an optional arg and can be either a location within the
image or a location in google cloud storage

The bed is integrated with the resource files in a similar manner to the reference genome
where the GCS based bed is auto-downloaded by the stage runner prior to stage start.

Stages can then decide whether to use the panel bed via ResourceFiles