### PR TITLE
DEV-2634 Disable "release" (aka docker) profile by default

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -15,6 +15,7 @@ steps:
     timeout: 2400s
     args:
       - 'deploy'
+      - '-Drelease'
       - '--batch-mode'
     env:
       - RCLONE_CONFIG=/workspace/cluster/src/test/resources/smoke_test/rclone.conf

--- a/cluster/pom.xml
+++ b/cluster/pom.xml
@@ -139,10 +139,10 @@
 
     <profiles>
         <profile>
-            <id>docker</id>
+            <id>release</id>
             <activation>
                 <property>
-                    <name>!skipDocker</name>
+                    <name>release</name>
                 </property>
             </activation>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -75,11 +75,6 @@
                 <version>${java-client.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.hartwig</groupId>
-                <artifactId>compar</artifactId>
-                <version>${compar.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>google-cloud-bom</artifactId>
                 <version>0.145.0</version>
@@ -207,6 +202,12 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.hartwig</groupId>
+                <artifactId>compar</artifactId>
+                <version>${compar.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
The release profile no longer creates a docker container, but still creates the runnable
jar and copies the dependencies to the correct locations for the containerization. So we
call it release and not "smoke test".