### PR TITLE
DEV-2593 Fix incorrect references to tumor in reference-only

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageCaller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageCaller.java
@@ -2,7 +2,6 @@ package com.hartwig.pipeline.calling.sage;
 
 import static java.lang.String.format;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -15,7 +14,6 @@ import com.hartwig.pipeline.execution.vm.BashStartupScript;
 import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
 import com.hartwig.pipeline.metadata.AddDatatype;
 import com.hartwig.pipeline.metadata.ArchivePath;
-import com.hartwig.pipeline.metadata.SingleSampleRunMetadata;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.report.ReportComponent;
@@ -82,19 +80,19 @@ public class SageCaller extends TertiaryStage<SageOutput> {
         final ImmutableSageOutput.Builder builder = SageOutput.builder(namespace()).status(jobStatus);
         somaticRefSampleBqrPlot.ifPresent(s -> builder.maybeSomaticRefSampleBqrPlot(GoogleStorageLocation.of(bucket.name(),
                         resultsDirectory.path(s)))
-                .addReportComponents(bqrComponent(metadata.reference(), "png", bucket, resultsDirectory))
-                .addReportComponents(bqrComponent(metadata.reference(), "tsv", bucket, resultsDirectory)));
+                .addReportComponents(bqrComponent("png", bucket, resultsDirectory, metadata.reference().sampleName()))
+                .addReportComponents(bqrComponent("tsv", bucket, resultsDirectory, metadata.reference().sampleName())));
         somaticTumorSampleBqrPlot.ifPresent(s -> builder.maybeSomaticTumorSampleBqrPlot(GoogleStorageLocation.of(bucket.name(),
                         resultsDirectory.path(s)))
-                .addReportComponents(bqrComponent(metadata.tumor(), "png", bucket, resultsDirectory))
-                .addReportComponents(bqrComponent(metadata.tumor(), "tsv", bucket, resultsDirectory)));
+                .addReportComponents(bqrComponent("png", bucket, resultsDirectory, metadata.tumor().sampleName()))
+                .addReportComponents(bqrComponent("tsv", bucket, resultsDirectory, metadata.tumor().sampleName())));
         return builder.addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .maybeGermlineGeneCoverage(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(geneCoverageFile)))
                 .maybeSomaticTumorSampleBqrPlot(somaticTumorSampleBqrPlot.map(t -> GoogleStorageLocation.of(bucket.name(),
                         resultsDirectory.path(t))))
                 .maybeVariants(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(filteredOutputFile)))
-                .addReportComponents(bqrComponent(metadata.tumor(), "png", bucket, resultsDirectory))
-                .addReportComponents(bqrComponent(metadata.tumor(), "tsv", bucket, resultsDirectory))
+                .addReportComponents(bqrComponent("png", bucket, resultsDirectory, metadata.sampleName()))
+                .addReportComponents(bqrComponent("tsv", bucket, resultsDirectory, metadata.sampleName()))
                 .addReportComponents(vcfComponent(unfilteredOutputFile, bucket, resultsDirectory))
                 .addReportComponents(vcfComponent(filteredOutputFile, bucket, resultsDirectory))
                 .addReportComponents(singleFileComponent(geneCoverageFile, bucket, resultsDirectory))
@@ -162,9 +160,9 @@ public class SageCaller extends TertiaryStage<SageOutput> {
         return new SingleFileComponent(bucket, namespace(), Folder.root(), filename, filename, resultsDirectory);
     }
 
-    private ReportComponent bqrComponent(final SingleSampleRunMetadata metadata, final String extension, final RuntimeBucket bucket,
-            final ResultsDirectory resultsDirectory) {
-        String filename = format("%s.sage.bqr.%s", metadata.sampleName(), extension);
+    private ReportComponent bqrComponent(final String extension, final RuntimeBucket bucket, final ResultsDirectory resultsDirectory,
+            final String sampleName) {
+        String filename = format("%s.sage.bqr.%s", sampleName, extension);
         return singleFileComponent(filename, bucket, resultsDirectory);
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageCommandBuilder.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageCommandBuilder.java
@@ -77,10 +77,6 @@ public class SageCommandBuilder {
 
         final List<String> arguments = Lists.newArrayList();
 
-        if (tumorSamples == 0) {
-            throw new IllegalStateException("Must be at least one tumor");
-        }
-
         if (shallowSomaticMode && !somaticMode) {
             throw new IllegalStateException("Shallow somatic mode enabled while not in shallow mode");
         }

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageConfiguration.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageConfiguration.java
@@ -51,13 +51,13 @@ public interface SageConfiguration {
                 .tumorSampleBqrPlot(DataType.GERMLINE_TUMOR_SAMPLE_BQR_PLOT)
                 .refSampleBqrPlot(DataType.GERMLINE_REF_SAMPLE_BQR_PLOT)
                 .filteredTemplate(m -> String.format("%s.%s.%s",
-                        m.tumor().sampleName(),
+                        m.reference().sampleName(),
                         SageGermlinePostProcess.SAGE_GERMLINE_FILTERED,
                         FileTypes.GZIPPED_VCF))
-                .unfilteredTemplate(m -> String.format("%s.%s.%s", m.tumor().sampleName(), "sage.germline", FileTypes.GZIPPED_VCF))
+                .unfilteredTemplate(m -> String.format("%s.%s.%s", m.reference().sampleName(), "sage.germline", FileTypes.GZIPPED_VCF))
                 .geneCoverageTemplate(m -> String.format("%s.%s", m.reference().sampleName(), SageCaller.SAGE_GENE_COVERAGE_TSV))
                 .commandBuilder(new SageCommandBuilder(resourceFiles).germlineMode().addCoverage().maxHeap("15G"))
-                .postProcess(m -> new SageGermlinePostProcess(m.reference().sampleName(), m.tumor().sampleName()))
+                .postProcess(m -> new SageGermlinePostProcess(m.reference().sampleName(), m.reference().sampleName()))
                 .jobDefinition(VirtualMachineJobDefinition::sageGermlineCalling)
                 .build();
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageGermlineCaller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageGermlineCaller.java
@@ -20,9 +20,9 @@ public class SageGermlineCaller extends SageCaller {
     @Override
     public List<BashCommand> referenceOnlyCommands(final SomaticRunMetadata metadata) {
         return new SageApplication(sageConfiguration.commandBuilder()
-                .addTumor(metadata.reference().sampleName(), getReferenceBamDownload().getLocalTargetPath()))
-                .andThen(sageConfiguration.postProcess().apply(metadata))
-                .apply(SubStageInputOutput.empty(metadata.tumor().sampleName()))
+                .addReference(metadata.reference().sampleName(),
+                        getReferenceBamDownload().getLocalTargetPath())).andThen(sageConfiguration.postProcess().apply(metadata))
+                .apply(SubStageInputOutput.empty(metadata.reference().sampleName()))
                 .bash();
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/pave/PaveGermline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/pave/PaveGermline.java
@@ -50,7 +50,7 @@ public class PaveGermline extends Pave {
     @Override
     protected String outputFile(final SomaticRunMetadata metadata) {
         return String.format("%s.%s.%s.%s",
-                metadata.tumor().sampleName(),
+                metadata.sampleName(),
                 SageGermlinePostProcess.SAGE_GERMLINE_FILTERED, PAVE_FILE_NAME,
                 FileTypes.GZIPPED_VCF);
     }


### PR DESCRIPTION
Fixes several places where the tumor sample is referenced by in reference only mode.

Remove check in sage command builder making tumor mandatory