### PR TITLE
DEV-2686 Write pilot images to separate family

### DIFF
--- a/cluster/images/create_pilot_image.sh
+++ b/cluster/images/create_pilot_image.sh
@@ -35,8 +35,8 @@ dest_image="${source_image}-$(date +%Y%m%d%H%M)-pilot"
 gcloud compute images describe $dest_image --project=$IMAGE_PROJECT >/dev/null 2>&1
 [[ $? -eq 0 ]] && echo "$dest_image exists in project $IMAGE_PROJECT!" && exit 1
 
-image_family="$(echo $json | jq -r '.family')"
-imager_vm="${image_family}-$(whoami)-pilot-imager"
+image_family="$(echo $json | jq -r '.family')-pilot"
+imager_vm="${image_family}-$(whoami)-imager"
 
 cat << EOM
 Ready to create VM [${imager_vm}] in project [${IMAGE_PROJECT}].


### PR DESCRIPTION
Really a small change just to make sure that there is a pilot image
family. The original changes to add the pilot imaging capability were
done so that there is little chance of a pilot version getting beyond
the development environment.

However this change makes it easier for multiple devs to work at the
same time without trampling one another. While we've always had the
situation where multiple imagers working at the same time will trample
one another, it's never really been an issue. However the pilot workflow
and the "regular" dev workflow are distinct so it's better to keep them
separate.

This change puts the onus on the developer to make sure they're setting
the image in their run's arguments for the pilot flow.