### PR TITLE
DEV-2712 Bump Cuppa to 1.6.1

### DIFF
--- a/cluster/images/tools.cmds
+++ b/cluster/images/tools.cmds
@@ -26,6 +26,10 @@ sudo mkdir -p /opt/tools/cuppa-chart/1.6
 sudo unzip /opt/tools/cuppa/1.6/cuppa.jar cuppa-chart/* -d /tmp/cuppa-chart-1.6
 sudo mv /tmp/cuppa-chart-1.6/cuppa-chart/* /opt/tools/cuppa-chart/1.6/
 sudo /tmp/mk_python_venv --no-extract-tarball cuppa-chart 1.6 3.6.10
+sudo mkdir -p /opt/tools/cuppa-chart/1.6.1
+sudo unzip /opt/tools/cuppa/1.6.1/cuppa.jar cuppa-chart/* -d /tmp/cuppa-chart-1.6.1
+sudo mv /tmp/cuppa-chart-1.6.1/cuppa-chart/* /opt/tools/cuppa-chart/1.6.1/
+sudo /tmp/mk_python_venv --no-extract-tarball cuppa-chart 1.6.1 3.6.10
 
 # NOTE: This extracts overtop the system-managed R libraries.
 sudo tar xvf /opt/tools/R/rlibs.tar -C /

--- a/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
@@ -14,7 +14,7 @@ public interface Versions {
     String AMBER = "3.9";
     String CHORD = "2.00_1.14";
     String COBALT = "1.13";
-    String CUPPA = "1.6";
+    String CUPPA = "1.6.1";
     String GRIDSS = "2.13.2";
     String GRIPSS = "2.1";
     String HEALTH_CHECKER = "3.4";

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/cuppa/CuppaTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/cuppa/CuppaTest.java
@@ -64,12 +64,12 @@ public class CuppaTest extends TertiaryStageTest<CuppaOutput> {
 
     @Override
     protected List<String> expectedCommands() {
-        return List.of("java -Xmx4G -jar /opt/tools/cuppa/1.6/cuppa.jar -categories DNA -ref_data_dir /opt/resources/cuppa/ "
+        return List.of("java -Xmx4G -jar /opt/tools/cuppa/1.6.1/cuppa.jar -categories DNA -ref_data_dir /opt/resources/cuppa/ "
                         + "-sample_data tumor -sample_data_dir /data/input/results -sample_sv_file /data/input/tumor.purple.sv.vcf.gz "
                         + "-sample_somatic_vcf /data/input/tumor.purple.somatic.vcf.gz -output_dir /data/output",
-                "/opt/tools/cuppa-chart/1.6_venv/bin/python /opt/tools/cuppa-chart/1.6/cuppa-chart.py -sample tumor "
+                "/opt/tools/cuppa-chart/1.6.1_venv/bin/python /opt/tools/cuppa-chart/1.6.1/cuppa-chart.py -sample tumor "
                         + "-sample_data /data/output/" + TUMOR_CUP_DATA_CSV + " -output_dir /data/output",
-                "Rscript /opt/tools/cuppa/1.6/CupGenerateReport_pipeline.R tumor /data/output/");
+                "Rscript /opt/tools/cuppa/1.6.1/CupGenerateReport_pipeline.R tumor /data/output/");
     }
 
     @Override


### PR DESCRIPTION
This hotfix updates the Python charting component only.