### PR TITLE
DEV-2705 Imager changes to support regular CKB updates

### DIFF
--- a/cluster/images/create_private_image.sh
+++ b/cluster/images/create_private_image.sh
@@ -11,9 +11,9 @@ DEST_SERVICE_ACCOUNT="649805142670-compute@developer.gserviceaccount.com"
 
 which jq >/dev/null || (echo Please install jq && exit 1)
 which gcloud >/dev/null || (echo Please install gcloud && exit 1)
-[[ $# -ne 1 && $# -ne 2 ]] && echo "USAGE: $0 [base image] [optional tag for resources instead of HEAD]" && exit 1
+[[ $# -ne 1 && $# -ne 2 ]] && echo "USAGE: $0 [base image] [optional SHA1 for resources instead of HEAD]" && exit 1
 source_image="$1"
-resource_tag="$2"
+commit_sha="$2"
 
 json="$(gcloud compute images describe $source_image --project=$IMAGE_SOURCE_PROJECT --format=json)"
 [[ $? -ne 0 ]] && echo "Unable to find image $source_image in $IMAGE_SOURCE_PROJECT" && exit 1
@@ -51,8 +51,8 @@ echo "Instance running, continuing with imaging"
 set -e
 gcloud compute scp $(dirname $0)/private_resource_checkout.sh ${imager_vm}:/tmp/ --zone=$ZONE --project=$DEST_PROJECT --tunnel-through-iap 
 sleep 60
-if [[ -n $resource_tag ]]; then
-    additional_args="--checkout-tag $resource_tag"
+if [[ -n $commit_sha ]]; then
+    additional_args="--checkout-commit $commit_sha"
 else
     additional_args="--tag-as-version $dest_image"
 fi    

--- a/cluster/images/create_private_image.sh
+++ b/cluster/images/create_private_image.sh
@@ -11,8 +11,9 @@ DEST_SERVICE_ACCOUNT="649805142670-compute@developer.gserviceaccount.com"
 
 which jq >/dev/null || (echo Please install jq && exit 1)
 which gcloud >/dev/null || (echo Please install gcloud && exit 1)
-[[ $# -ne 1 ]] && echo "Provide the source image" && exit 1
+[[ $# -ne 1 && $# -ne 2 ]] && echo "USAGE: $0 [base image] [optional tag for resources instead of HEAD]" && exit 1
 source_image="$1"
+resource_tag="$2"
 
 json="$(gcloud compute images describe $source_image --project=$IMAGE_SOURCE_PROJECT --format=json)"
 [[ $? -ne 0 ]] && echo "Unable to find image $source_image in $IMAGE_SOURCE_PROJECT" && exit 1
@@ -50,7 +51,13 @@ echo "Instance running, continuing with imaging"
 set -e
 gcloud compute scp $(dirname $0)/private_resource_checkout.sh ${imager_vm}:/tmp/ --zone=$ZONE --project=$DEST_PROJECT --tunnel-through-iap 
 sleep 60
-$ssh --command="sudo /tmp/private_resource_checkout.sh $dest_image $SOURCE_REPO_PROJECT"
+if [[ -n $resource_tag ]]; then
+    additional_args="--checkout-tag $resource_tag"
+else
+    additional_args="--tag-as-version $dest_image"
+fi    
+
+$ssh --command="sudo /tmp/private_resource_checkout.sh --project $SOURCE_REPO_PROJECT $additional_args"
 
 gcloud compute instances stop $imager_vm --zone=${ZONE} --project=$DEST_PROJECT
 gcloud compute images create $dest_image --family=$image_family --source-disk=$imager_vm --source-disk-zone=$ZONE \

--- a/cluster/images/private_resource_checkout.sh
+++ b/cluster/images/private_resource_checkout.sh
@@ -8,7 +8,7 @@ USAGE: $0 [--project project] [--tag-as-version new-version || --checkout-tag ex
   --project [project]              Project in GCP containing the source repository
 Specify ONLY ONE of:
   --tag-as-version [new-version]   Create tag [new-version] in source repo after checking out HEAD
-  --checkout-tag [existing-tag]    Checkout tag [existing-tag] rather than HEAD and create no new tags
+  --checkout-commit [commit-sha]   Checkout [commit-sha] rather than HEAD and create no new tags
 EOM
 }
 
@@ -20,12 +20,12 @@ while true; do
     case "$1" in
         --project) project=$2 ; shift 2 ;;
         --tag-as-version) new_version=$2 ; shift 2 ;;
-        --checkout-tag) checkout_tag=$2 ; shift 2 ;;
+        --checkout-commit) commit_sha=$2 ; shift 2 ;;
         --) shift; break ;;
     esac
 done
 
-if [[ -z "$project" || ( -z "$new_version" && -z "$checkout_tag" ) || ( -n "$new_version" && -n "$checkout_tag" ) ]]; then
+if [[ -z "$project" || ( -z "$new_version" && -z "$commit_sha" ) || ( -n "$new_version" && -n "$commit_sha" ) ]]; then
     print_usage
     exit 1
 fi
@@ -38,8 +38,8 @@ if [[ -n $new_version ]]; then
     git tag "$new_version"
     git push origin "$new_version"
 else
-   "Checking out existing tag '$checkout_tag'"
-    git checkout tags/$checkout_tag
+   "Checking out commit '$commit_sha'"
+    git checkout $commit_sha
 fi
 
 rm -r .git/

--- a/cluster/images/private_resource_checkout.sh
+++ b/cluster/images/private_resource_checkout.sh
@@ -2,12 +2,46 @@
 
 set -e
 
-[[ $# -ne 2 ]] && echo "USAGE: $(basename $0) [version] [private resources repo project]" && exit 1
+print_usage() {
+    cat <<EOM
+USAGE: $0 [--project project] [--tag-as-version new-version || --checkout-tag existing-tag]
+  --project [project]              Project in GCP containing the source repository
+Specify ONLY ONE of:
+  --tag-as-version [new-version]   Create tag [new-version] in source repo after checking out HEAD
+  --checkout-tag [existing-tag]    Checkout tag [existing-tag] rather than HEAD and create no new tags
+EOM
+}
+
+args=$(getopt -o "" --longoptions project:,tag-as-version:,checkout-tag: -- "$@")
+[[ $? != 0 ]] && print_usage && exit 1
+eval set -- "$args"
+
+while true; do
+    case "$1" in
+        --project) project=$2 ; shift 2 ;;
+        --tag-as-version) new_version=$2 ; shift 2 ;;
+        --checkout-tag) checkout_tag=$2 ; shift 2 ;;
+        --) shift; break ;;
+    esac
+done
+
+if [[ -z "$project" || ( -z "$new_version" && -z "$checkout_tag" ) || ( -n "$new_version" && -n "$checkout_tag" ) ]]; then
+    print_usage
+    exit 1
+fi
+
 mkdir /tmp/resources
-gcloud source repos clone common-resources-private /tmp/resources --project=${2}
+gcloud source repos clone common-resources-private /tmp/resources --project=$project
 cd /tmp/resources
-git tag "$1"
-git push origin "$1"
+if [[ -n $new_version ]]; then
+    "Adding tag '$new_version'"
+    git tag "$new_version"
+    git push origin "$new_version"
+else
+   "Checking out existing tag '$checkout_tag'"
+    git checkout tags/$checkout_tag
+fi
+
 rm -r .git/
 find . -type f | while read f; do
     dirname $(echo "$f" | sed 's#^\./##')


### PR DESCRIPTION
The imager will be invoked with the extra parameters added here to allow us to build an automated workflow to ease CKB updates.

Argument parsing has been rewritten for `private_resource_checkout.sh` as the new functionality requires us to be able to request a particular commit of the resources be used for imaging, while the typical development flow is looser and just always uses `HEAD`. Also in the development flow we generate a new tag to automatically apply to the resources repository while in the automated flow we want to use a particular commit of the resources and _not_ tag anything.

Changes to `create_private_image.sh` are minor and just support the changes to the other script.