### PR TITLE
DEV-2705 Support bucket-based completion detection

### DIFF
--- a/cluster/images/create_private_image.sh
+++ b/cluster/images/create_private_image.sh
@@ -9,11 +9,42 @@ SOURCE_REPO_PROJECT="hmf-pipeline-prod-e45b00f2"
 DEST_PROJECT="hmf-pipeline-prod-e45b00f2"
 DEST_SERVICE_ACCOUNT="649805142670-compute@developer.gserviceaccount.com"
 
+print_usage() {
+    cat <<EOM
+USAGE: $0 [source image] [optional arguments]
+
+[source image] is the name of an image that already exists in ${IMAGE_SOURCE_PROJECT}
+
+Optional arguments:
+
+  --resources-commit [sha1]     SHA1 in private resources repository to checkout instead of HEAD.
+                                No tagging will be done in the private resources repository.
+  --result-code-url [GCS url]   GCS (eg "gs://bucket/path") URL to write the exit code to (bucket must be writable).
+                                This script will interact with the bucket rather than with the imager instance over SSH.
+EOM
+}
+
+set -o pipefail
+
+[[ $# -eq 0 ]] && print_usage && exit 1
+source_image="$1"
+shift
+
+args=$(getopt -o "" --longoptions resources-commit:,result-code-url: -- "$@")
+[[ $? != 0 ]] && print_usage && exit 1
+eval set -- "$args"
+
+while true; do
+    case "$1" in
+        --resources-commit) resources_commit=$2; shift 2 ;;
+        --result-code-url) result_code_url=$2; shift 2 ;;
+        --) shift; break ;;
+    esac
+done
+
 which jq >/dev/null || (echo Please install jq && exit 1)
 which gcloud >/dev/null || (echo Please install gcloud && exit 1)
-[[ $# -ne 1 && $# -ne 2 ]] && echo "USAGE: $0 [base image] [optional SHA1 for resources instead of HEAD]" && exit 1
-source_image="$1"
-commit_sha="$2"
+which gsutil >/dev/null || (echo Please install gsutil && exit 1)
 
 json="$(gcloud compute images describe $source_image --project=$IMAGE_SOURCE_PROJECT --format=json)"
 [[ $? -ne 0 ]] && echo "Unable to find image $source_image in $IMAGE_SOURCE_PROJECT" && exit 1
@@ -25,39 +56,63 @@ gcloud compute images describe $dest_image --project=$DEST_PROJECT >/dev/null 2>
 image_family="$(echo $json | jq -r '.family')"
 imager_vm="${image_family}-imager"
 
-echo Ready to create VM [${imager_vm}] in project [${DEST_PROJECT}]
-echo The VM will be used to create private image [${dest_image}] in family [${image_family}]
-echo You must have sufficient permissions in [${DEST_PROJECT}]
-echo
-echo 'If you ARE NOT currently doing a PRODUCTION upgrade maybe you should not be running this script!'
-echo
+cat <<EOM
+Ready to create VM [${imager_vm}] in project [${DEST_PROJECT}]
+The VM will be used to create private image [${dest_image}] in family [${image_family}]
+You must have sufficient permissions in [${DEST_PROJECT}]
+
+If you ARE NOT currently doing a PRODUCTION upgrade maybe you should not be running this script!
+
+EOM
 read -p "Continue [y|N]? " response
-[[ $response != 'y' && $response != 'Y' ]] && echo "Aborting at user request" && exit 1
+[[ $response != 'y' && $response != 'Y' ]] && echo "Aborting at user request" && exit 0
 
-gcloud compute instances create $imager_vm --description="Instance for private pipeline5 disk image creation" \
-    --zone=${ZONE} --boot-disk-size 200 --boot-disk-type pd-ssd --machine-type n1-highcpu-2 \
-    --image-project=$IMAGE_SOURCE_PROJECT --image=$source_image --scopes=default,cloud-source-repos-ro \
-    --project=$DEST_PROJECT --service-account=$DEST_SERVICE_ACCOUNT --network-interface=no-address || exit 1
-
-ssh="gcloud compute ssh $imager_vm --zone=$ZONE --project=$DEST_PROJECT --tunnel-through-iap"
-echo "Polling for active instance"
-while true; do
-    sleep 1
-    $ssh --command="exit 0"
-    [[ $? -eq 0 ]] && break
-done
-echo "Instance running, continuing with imaging"
-
-set -e
-gcloud compute scp $(dirname $0)/private_resource_checkout.sh ${imager_vm}:/tmp/ --zone=$ZONE --project=$DEST_PROJECT --tunnel-through-iap 
-sleep 60
 if [[ -n $commit_sha ]]; then
     additional_args="--checkout-commit $commit_sha"
 else
     additional_args="--tag-as-version $dest_image"
 fi    
 
-$ssh --command="sudo /tmp/private_resource_checkout.sh --project $SOURCE_REPO_PROJECT $additional_args"
+if [[ -n $result_code_url ]]; then
+    gsutil -q stat $result_code_url && echo "Result code URL $result_code_url already exists!" && exit 1
+    more_args="--metadata-from-file=startup-script=$(dirname $0)/private_resource_checkout.sh"
+    more_args="$more_args --metadata=result-code-url=$result_code_url"
+    more_args="${more_args},project=$SOURCE_REPO_PROJECT"
+    more_args="${more_args},$(echo $additional_args | sed -e 's/^--//' -e 's/ /=/g')"
+fi
+
+gcloud compute instances create $imager_vm --description="Instance for private pipeline5 disk image creation" \
+    --zone=${ZONE} --boot-disk-size 200 --boot-disk-type pd-ssd --machine-type n1-highcpu-2 \
+    --image-project=$IMAGE_SOURCE_PROJECT --image=$source_image --scopes=default,cloud-platform \
+    --project=$DEST_PROJECT --service-account=$DEST_SERVICE_ACCOUNT --network-interface=no-address $more_args || exit 1
+
+if [[ -n $result_code_url ]]; then
+    echo "Waiting for the presence of ${result_code_url}."
+    echo "If this does not return after a reasonable time check /var/log/daemon.log on the $imager_vm instance."
+    while true; do
+        sleep 10
+        if gsutil -q stat $result_code_url; then
+            exit_code=$(gsutil cat $result_code_url)
+            echo "${result_code_url} present. Returning its contents as our exit code: $exit_code"
+            exit $exit_code
+        fi
+    done
+else
+    ssh="gcloud compute ssh $imager_vm --zone=$ZONE --project=$DEST_PROJECT --tunnel-through-iap"
+    echo "Polling for active instance"
+    while true; do
+        sleep 1
+        $ssh --command="exit 0"
+        [[ $? -eq 0 ]] && break
+    done
+    echo "Instance running, continuing with imaging"
+    
+    set -e
+    gcloud compute scp $(dirname $0)/private_resource_checkout.sh ${imager_vm}:/tmp/ --zone=$ZONE --project=$DEST_PROJECT --tunnel-through-iap 
+    sleep 60
+    
+    $ssh --command="sudo /tmp/private_resource_checkout.sh --project $SOURCE_REPO_PROJECT $additional_args"
+fi
 
 gcloud compute instances stop $imager_vm --zone=${ZONE} --project=$DEST_PROJECT
 gcloud compute images create $dest_image --family=$image_family --source-disk=$imager_vm --source-disk-zone=$ZONE \

--- a/cluster/images/private_resource_checkout.sh
+++ b/cluster/images/private_resource_checkout.sh
@@ -1,33 +1,69 @@
 #!/usr/bin/env bash
 
-set -e
+set -x
+
+dmidecode -s system-product-name | grep -q "Google Compute Engine"
+IN_GCP=$?
+
+#set -e
 
 print_usage() {
     cat <<EOM
-USAGE: $0 [--project project] [--tag-as-version new-version || --checkout-tag existing-tag]
+USAGE: $0 [--project project] [--tag-as-version new-version || --checkout-tag existing-tag] [--result-code-url gs-url]
+
+Required:
   --project [project]              Project in GCP containing the source repository
+
 Specify ONLY ONE of:
   --tag-as-version [new-version]   Create tag [new-version] in source repo after checking out HEAD
   --checkout-commit [commit-sha]   Checkout [commit-sha] rather than HEAD and create no new tags
+
+Optional:
+  --result-code-url [gs-url]        GCS (eg "gs://bucket/path") URL to write exit code to (bucket must be writable).
 EOM
 }
 
-args=$(getopt -o "" --longoptions project:,tag-as-version:,checkout-tag: -- "$@")
-[[ $? != 0 ]] && print_usage && exit 1
-eval set -- "$args"
+gsurl_exit_handler() {
+    gsutil cp <(echo $?) $result_code_url
+}
 
-while true; do
-    case "$1" in
-        --project) project=$2 ; shift 2 ;;
-        --tag-as-version) new_version=$2 ; shift 2 ;;
-        --checkout-commit) commit_sha=$2 ; shift 2 ;;
-        --) shift; break ;;
-    esac
-done
+metadata() {
+    #set +e
+    curl -f -s http://metadata.google.internal/computeMetadata/v1/instance/attributes/$1 -H "Metadata-Flavor: Google" 2>/dev/null
+    #set -e
+}
+
+set -o pipefail
+
+if [[ $IN_GCP && $# -eq 0 ]]; then
+    project="$(metadata project)"
+    new_version="$(metadata tag-as-version)"
+    commit_sha="$(metadata checkout-commit)"
+    result_code_url="$(metadata result-code-url)"
+else
+    echo "Command line: $0 $@"
+    args=$(getopt -o "" --longoptions project:,tag-as-version:,checkout-commit:,result-code-url: -- "$@")
+    [[ $? != 0 ]] && print_usage && exit 1
+    eval set -- "$args"
+
+    while true; do
+        case "$1" in
+            --project) project=$2 ; shift 2 ;;
+            --tag-as-version) new_version=$2 ; shift 2 ;;
+            --checkout-commit) commit_sha=$2 ; shift 2 ;;
+            --result-code-url) result_code_url=$2 ; shift 2 ;;
+            --) shift; break ;;
+        esac
+    done
+fi
 
 if [[ -z "$project" || ( -z "$new_version" && -z "$commit_sha" ) || ( -n "$new_version" && -n "$commit_sha" ) ]]; then
     print_usage
     exit 1
+fi
+
+if [[ -n $result_code_url ]]; then
+    trap gsurl_exit_handler EXIT
 fi
 
 mkdir /tmp/resources

--- a/cluster/images/private_resource_checkout.sh
+++ b/cluster/images/private_resource_checkout.sh
@@ -5,8 +5,6 @@ set -x
 dmidecode -s system-product-name | grep -q "Google Compute Engine"
 IN_GCP=$?
 
-#set -e
-
 print_usage() {
     cat <<EOM
 USAGE: $0 [--project project] [--tag-as-version new-version || --checkout-tag existing-tag] [--result-code-url gs-url]
@@ -28,9 +26,7 @@ gsurl_exit_handler() {
 }
 
 metadata() {
-    #set +e
     curl -f -s http://metadata.google.internal/computeMetadata/v1/instance/attributes/$1 -H "Metadata-Flavor: Google" 2>/dev/null
-    #set -e
 }
 
 set -o pipefail


### PR DESCRIPTION
This change for the private imager continues to support the existing
mode of operation, but adds support for a new flow in which instead of
using SSH to poll for activity, the script waits for the presence of the
given path in a bucket.

With this change we can support launching the imager from within a
Docker container launched by the Cloud Build environment and not having
to fiddle with creating and propagating SSH keys to the VM instance
doing the imaging.

When the script is provided a bucket URL argument, it switches into the
new bucket-based mode. In that case instead of copying the private
resource checkout script to the imager instance after it starts and
waiting for it to complete, the script will set the startup script
metadata of the instance to the local file. Also instead of passing
arguments on the command line we set metadata on the instance so it can
be retrieved without an SSH connection.

In addition, argument parsing has been modified in both the
`create_private_image.sh` and `private_resource_checkout.sh` scripts to
move away from positional parameters and to `getopt` long options for
clarity and also to support the new capabilities, as purely positional
parsing wouldn't support all cases with the new optional arguments.