### PR TITLE
DEV-2705 Add starting point for Protect-only runs

### DIFF
--- a/cluster/pom.xml
+++ b/cluster/pom.xml
@@ -109,6 +109,11 @@
             <version>${htsjdk.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/germline/GermlineCaller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/germline/GermlineCaller.java
@@ -29,11 +29,13 @@ import com.hartwig.pipeline.report.ZippedVcfAndIndexComponent;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.reruns.PersistedLocations;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.stages.SubStageInputOutput;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 
+@Namespace(GermlineCaller.NAMESPACE)
 public class GermlineCaller implements Stage<GermlineCallerOutput, SingleSampleRunMetadata> {
 
     public static final String NAMESPACE = "germline_caller";

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageCaller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageCaller.java
@@ -28,7 +28,7 @@ import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 import com.hartwig.pipeline.tertiary.TertiaryStage;
 
-public class SageCaller extends TertiaryStage<SageOutput> {
+public abstract class SageCaller extends TertiaryStage<SageOutput> {
 
     public static final String SAGE_GENE_COVERAGE_TSV = "sage.gene.coverage.tsv";
     public static final String SAGE_BQR_PNG = "sage.bqr.png";

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageGermlineCaller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageGermlineCaller.java
@@ -7,9 +7,11 @@ import com.hartwig.pipeline.execution.vm.BashCommand;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.stages.SubStageInputOutput;
 
+@Namespace(SageConfiguration.SAGE_GERMLINE_NAMESPACE)
 public class SageGermlineCaller extends SageCaller {
 
     public SageGermlineCaller(final AlignmentPair alignmentPair, final PersistedDataset persistedDataset,

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageSomaticCaller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/sage/SageSomaticCaller.java
@@ -8,9 +8,11 @@ import com.hartwig.pipeline.execution.vm.BashCommand;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.stages.SubStageInputOutput;
 
+@Namespace(SageConfiguration.SAGE_SOMATIC_NAMESPACE)
 public class SageSomaticCaller extends SageCaller {
 
     public SageSomaticCaller(final AlignmentPair alignmentPair, final PersistedDataset persistedDataset, final ResourceFiles resourceFiles,

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/structural/gridss/Gridss.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/structural/gridss/Gridss.java
@@ -32,11 +32,13 @@ import com.hartwig.pipeline.report.ZippedVcfAndIndexComponent;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.reruns.PersistedLocations;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.SubStageInputOutput;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 import com.hartwig.pipeline.tertiary.TertiaryStage;
 
+@Namespace(Gridss.NAMESPACE)
 public class Gridss extends TertiaryStage<GridssOutput> {
     public static final String NAMESPACE = "gridss";
 

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/structural/gripss/Gripss.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/structural/gripss/Gripss.java
@@ -27,12 +27,13 @@ import com.hartwig.pipeline.report.ZippedVcfAndIndexComponent;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.reruns.PersistedLocations;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 import com.hartwig.pipeline.tools.Versions;
 
-public class Gripss implements Stage<GripssOutput, SomaticRunMetadata> {
+public abstract class Gripss implements Stage<GripssOutput, SomaticRunMetadata> {
 
     private final InputDownload gridssVcf;
     private final InputDownload gridssVcfIndex;

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/structural/gripss/GripssGermline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/structural/gripss/GripssGermline.java
@@ -13,8 +13,10 @@ import com.hartwig.pipeline.execution.vm.BashCommand;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
 
+@Namespace(GripssGermline.GERMLINE_NAMESPACE)
 public class GripssGermline extends Gripss {
 
     public static final String GERMLINE_NAMESPACE = "gripss_germline";

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/structural/gripss/GripssSomatic.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/structural/gripss/GripssSomatic.java
@@ -13,8 +13,10 @@ import com.hartwig.pipeline.execution.vm.BashCommand;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
 
+@Namespace(GripssSomatic.SOMATIC_NAMESPACE)
 public class GripssSomatic extends Gripss {
 
     public static final String SOMATIC_NAMESPACE = "gripss_somatic";

--- a/cluster/src/main/java/com/hartwig/pipeline/cram/CramConversion.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/cram/CramConversion.java
@@ -26,10 +26,12 @@ import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.report.SingleFileComponent;
 import com.hartwig.pipeline.report.StartupScriptComponent;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 
+@Namespace(CramConversion.NAMESPACE)
 public class CramConversion implements Stage<CramOutput, SingleSampleRunMetadata> {
     public static final String NAMESPACE = "cram";
     static final int NUMBER_OF_CORES = 6;

--- a/cluster/src/main/java/com/hartwig/pipeline/cram2bam/Cram2Bam.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/cram2bam/Cram2Bam.java
@@ -17,10 +17,12 @@ import com.hartwig.pipeline.execution.vm.VirtualMachinePerformanceProfile;
 import com.hartwig.pipeline.execution.vm.VmDirectories;
 import com.hartwig.pipeline.metadata.SingleSampleRunMetadata;
 import com.hartwig.pipeline.report.RunLogComponent;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 
+@Namespace("cram2bam")
 public class Cram2Bam implements Stage<AlignmentOutput, SingleSampleRunMetadata> {
 
     private final InputDownload bamDownload;

--- a/cluster/src/main/java/com/hartwig/pipeline/flagstat/Flagstat.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/flagstat/Flagstat.java
@@ -23,10 +23,12 @@ import com.hartwig.pipeline.report.SingleFileComponent;
 import com.hartwig.pipeline.report.StartupScriptComponent;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.reruns.PersistedLocations;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 
+@Namespace(Flagstat.NAMESPACE)
 public class Flagstat implements Stage<FlagstatOutput, SingleSampleRunMetadata> {
     public static final String NAMESPACE = "flagstat";
 

--- a/cluster/src/main/java/com/hartwig/pipeline/metrics/BamMetrics.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metrics/BamMetrics.java
@@ -24,10 +24,12 @@ import com.hartwig.pipeline.report.StartupScriptComponent;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.reruns.PersistedLocations;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 
+@Namespace(BamMetrics.NAMESPACE)
 public class BamMetrics implements Stage<BamMetricsOutput, SingleSampleRunMetadata> {
 
     public static final String NAMESPACE = "bam_metrics";

--- a/cluster/src/main/java/com/hartwig/pipeline/reruns/StartingPoint.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/reruns/StartingPoint.java
@@ -20,8 +20,15 @@ import com.hartwig.pipeline.flagstat.Flagstat;
 import com.hartwig.pipeline.metrics.BamMetrics;
 import com.hartwig.pipeline.snpgenotype.SnpGenotype;
 import com.hartwig.pipeline.tertiary.amber.Amber;
+import com.hartwig.pipeline.tertiary.chord.Chord;
 import com.hartwig.pipeline.tertiary.cobalt.Cobalt;
+import com.hartwig.pipeline.tertiary.linx.LinxGermline;
+import com.hartwig.pipeline.tertiary.linx.LinxSomatic;
+import com.hartwig.pipeline.tertiary.pave.PaveGermline;
+import com.hartwig.pipeline.tertiary.pave.PaveSomatic;
 import com.hartwig.pipeline.tertiary.purple.Purple;
+import com.hartwig.pipeline.tertiary.virus.VirusAnalysis;
+import com.hartwig.pipeline.tertiary.virus.VirusOutput;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -52,7 +59,9 @@ public class StartingPoint {
                         SageConfiguration.SAGE_GERMLINE_NAMESPACE))),
         GRIPSS_COMPLETE(concat(CALLING_COMPLETE.namespaces,
                 List.of(SOMATIC_NAMESPACE, GERMLINE_NAMESPACE))),
-        PURPLE_COMPLETE(concat(GRIPSS_COMPLETE.namespaces, List.of(Purple.NAMESPACE)));
+        PURPLE_COMPLETE(concat(GRIPSS_COMPLETE.namespaces, List.of(PaveSomatic.NAMESPACE, PaveGermline.NAMESPACE, Purple.NAMESPACE))),
+        PROTECT_ONLY(concat(PURPLE_COMPLETE.namespaces,
+                List.of(LinxGermline.NAMESPACE, LinxSomatic.NAMESPACE, VirusAnalysis.NAMESPACE, Chord.NAMESPACE)));
 
         private final List<String> namespaces;
 

--- a/cluster/src/main/java/com/hartwig/pipeline/snpgenotype/SnpGenotype.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/snpgenotype/SnpGenotype.java
@@ -23,10 +23,12 @@ import com.hartwig.pipeline.report.SingleFileComponent;
 import com.hartwig.pipeline.report.StartupScriptComponent;
 import com.hartwig.pipeline.resource.RefGenomeVersion;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 
+@Namespace(SnpGenotype.NAMESPACE)
 public class SnpGenotype implements Stage<SnpGenotypeOutput, SingleSampleRunMetadata> {
 
     public static final String NAMESPACE = "snp_genotype";

--- a/cluster/src/main/java/com/hartwig/pipeline/stages/Namespace.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/stages/Namespace.java
@@ -1,0 +1,12 @@
+package com.hartwig.pipeline.stages;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Namespace {
+    String value() default "";
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/amber/Amber.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/amber/Amber.java
@@ -23,11 +23,13 @@ import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.reruns.PersistedLocations;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 import com.hartwig.pipeline.tertiary.TertiaryStage;
 import com.hartwig.pipeline.tools.Versions;
 
+@Namespace(Amber.NAMESPACE)
 public class Amber extends TertiaryStage<AmberOutput> {
 
     public static final String NAMESPACE = "amber";

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/chord/Chord.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/chord/Chord.java
@@ -23,11 +23,13 @@ import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.reruns.PersistedLocations;
 import com.hartwig.pipeline.resource.RefGenomeVersion;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 import com.hartwig.pipeline.tertiary.purple.PurpleOutput;
 
+@Namespace(Chord.NAMESPACE)
 public class Chord implements Stage<ChordOutput, SomaticRunMetadata> {
     public static final String NAMESPACE = "chord";
     public static final String PREDICTION_TXT = "_chord_prediction.txt";

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/cobalt/Cobalt.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/cobalt/Cobalt.java
@@ -23,11 +23,15 @@ import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.reruns.PersistedLocations;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 import com.hartwig.pipeline.tertiary.TertiaryStage;
 import com.hartwig.pipeline.tools.Versions;
 
+import jdk.jfr.Name;
+
+@Namespace(Cobalt.NAMESPACE)
 public class Cobalt extends TertiaryStage<CobaltOutput> {
 
     public static final String NAMESPACE = "cobalt";

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/cuppa/Cuppa.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/cuppa/Cuppa.java
@@ -29,6 +29,7 @@ import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.reruns.PersistedLocations;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
@@ -39,13 +40,14 @@ import com.hartwig.pipeline.tools.Versions;
 
 import org.jetbrains.annotations.NotNull;
 
+@Namespace(Cuppa.NAMESPACE)
 public class Cuppa implements Stage<CuppaOutput, SomaticRunMetadata> {
     public static final String CUP_REPORT_SUMMARY_PNG = ".cup.report.summary.png";
     public static final String CUP_DATA_CSV = ".cup.data.csv";
     public static final String CUPPA_FEATURE_PLOT = ".cup.report.features.png";
     public static final String CUPPA_CONCLUSION_TXT = ".cuppa.conclusion.txt";
     public static final String CUPPA_CONCLUSION_CHART = ".cuppa.chart.png";
-    public static String NAMESPACE = "cuppa";
+    public static final String NAMESPACE = "cuppa";
     private final InputDownload purpleSomaticVariantsDownload;
     private final InputDownload purpleStructuralVariantsDownload;
     private final InputDownload purpleOutputDirectory;

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/healthcheck/HealthChecker.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/healthcheck/HealthChecker.java
@@ -20,6 +20,7 @@ import com.hartwig.pipeline.metrics.BamMetricsOutput;
 import com.hartwig.pipeline.report.EntireOutputComponent;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.report.RunLogComponent;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
@@ -29,6 +30,7 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Namespace(HealthChecker.NAMESPACE)
 public class HealthChecker implements Stage<HealthCheckOutput, SomaticRunMetadata> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HealthChecker.class);

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/lilac/Lilac.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/lilac/Lilac.java
@@ -28,6 +28,7 @@ import com.hartwig.pipeline.report.EntireOutputComponent;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 import com.hartwig.pipeline.tertiary.TertiaryStage;
@@ -35,6 +36,7 @@ import com.hartwig.pipeline.tertiary.purple.PurpleOutput;
 import com.hartwig.pipeline.tertiary.purple.PurpleOutputLocations;
 import com.hartwig.pipeline.tools.Versions;
 
+@Namespace(Lilac.NAMESPACE)
 public class Lilac extends TertiaryStage<LilacOutput> {
     public static final String NAMESPACE = "lilac";
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/LinxGermline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/LinxGermline.java
@@ -29,6 +29,7 @@ import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.reruns.PersistedLocations;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
@@ -36,6 +37,7 @@ import com.hartwig.pipeline.tools.Versions;
 
 import org.jetbrains.annotations.NotNull;
 
+@Namespace(LinxGermline.NAMESPACE)
 public class LinxGermline implements Stage<LinxGermlineOutput, SomaticRunMetadata> {
 
     public static final String NAMESPACE = "linx_germline";

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/LinxSomatic.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/linx/LinxSomatic.java
@@ -24,6 +24,7 @@ import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.reruns.PersistedLocations;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
@@ -33,6 +34,7 @@ import com.hartwig.pipeline.tools.Versions;
 
 import org.jetbrains.annotations.NotNull;
 
+@Namespace(LinxSomatic.NAMESPACE)
 public class LinxSomatic implements Stage<LinxSomaticOutput, SomaticRunMetadata> {
 
     public static final String NAMESPACE = "linx";

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/orange/Orange.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/orange/Orange.java
@@ -27,6 +27,7 @@ import com.hartwig.pipeline.report.EntireOutputComponent;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
@@ -44,6 +45,7 @@ import com.hartwig.pipeline.tertiary.purple.PurpleOutputLocations;
 import com.hartwig.pipeline.tertiary.virus.VirusOutput;
 import com.hartwig.pipeline.tools.Versions;
 
+@Namespace(Orange.NAMESPACE)
 public class Orange implements Stage<OrangeOutput, SomaticRunMetadata> {
     public static final String NAMESPACE = "orange";
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/pave/PaveGermline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/pave/PaveGermline.java
@@ -10,8 +10,10 @@ import com.hartwig.pipeline.execution.vm.BashCommand;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
 
+@Namespace(PaveGermline.NAMESPACE)
 public class PaveGermline extends Pave {
     public static final String NAMESPACE = "pave_germline";
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/pave/PaveSomatic.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/pave/PaveSomatic.java
@@ -10,8 +10,10 @@ import com.hartwig.pipeline.execution.vm.BashCommand;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
 
+@Namespace(PaveSomatic.NAMESPACE)
 public class PaveSomatic extends Pave {
     public static final String NAMESPACE = "pave_somatic";
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/peach/Peach.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/peach/Peach.java
@@ -24,6 +24,7 @@ import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.reruns.PersistedLocations;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
@@ -32,6 +33,7 @@ import com.hartwig.pipeline.tools.Versions;
 
 import org.jetbrains.annotations.NotNull;
 
+@Namespace(Peach.NAMESPACE)
 public class Peach implements Stage<PeachOutput, SomaticRunMetadata> {
     public static final String NAMESPACE = "peach";
     private static final String PEACH_CALLS_TSV = ".peach.calls.tsv";

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/protect/Protect.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/protect/Protect.java
@@ -24,6 +24,7 @@ import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.reruns.PersistedLocations;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
@@ -36,6 +37,7 @@ import com.hartwig.pipeline.tertiary.virus.VirusOutput;
 
 import org.jetbrains.annotations.NotNull;
 
+@Namespace(Protect.NAMESPACE)
 public class Protect implements Stage<ProtectOutput, SomaticRunMetadata> {
 
     public static final String NAMESPACE = "protect";

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/purple/Purple.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/purple/Purple.java
@@ -27,6 +27,7 @@ import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.reruns.PersistedLocations;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
@@ -35,6 +36,7 @@ import com.hartwig.pipeline.tertiary.cobalt.CobaltOutput;
 import com.hartwig.pipeline.tertiary.pave.PaveOutput;
 import com.hartwig.pipeline.tools.Versions;
 
+@Namespace(Purple.NAMESPACE)
 public class Purple implements Stage<PurpleOutput, SomaticRunMetadata> {
 
     public static final String NAMESPACE = "purple";

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/sigs/Sigs.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/sigs/Sigs.java
@@ -22,14 +22,16 @@ import com.hartwig.pipeline.report.EntireOutputComponent;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.report.RunLogComponent;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
 import com.hartwig.pipeline.tertiary.purple.PurpleOutput;
 import com.hartwig.pipeline.tools.Versions;
 
+@Namespace(Sigs.NAMESPACE)
 public class Sigs implements Stage<SigsOutput, SomaticRunMetadata> {
-    public static String NAMESPACE = "sigs";
+    public static final String NAMESPACE = "sigs";
 
     private final InputDownload purpleSomaticVariantsDownload;
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/virus/VirusAnalysis.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/virus/VirusAnalysis.java
@@ -22,6 +22,7 @@ import com.hartwig.pipeline.report.SingleFileComponent;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.reruns.PersistedLocations;
 import com.hartwig.pipeline.resource.ResourceFiles;
+import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.SubStageInputOutput;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
 import com.hartwig.pipeline.storage.RuntimeBucket;
@@ -31,6 +32,7 @@ import com.hartwig.pipeline.tertiary.purple.PurpleOutputLocations;
 
 import org.jetbrains.annotations.NotNull;
 
+@Namespace(VirusAnalysis.NAMESPACE)
 public class VirusAnalysis extends TertiaryStage<VirusOutput> {
 
     public static final String NAMESPACE = "virusbreakend";

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageGermlineCallerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageGermlineCallerTest.java
@@ -23,9 +23,9 @@ public class SageGermlineCallerTest extends TertiaryStageTest<SageOutput> {
 
     @Override
     protected Stage<SageOutput, SomaticRunMetadata> createVictim() {
-        return new SageCaller(TestInputs.defaultPair(),
+        return new SageGermlineCaller(TestInputs.defaultPair(),
                 new NoopPersistedDataset(),
-                SageConfiguration.germline(TestInputs.REF_GENOME_37_RESOURCE_FILES));
+                TestInputs.REF_GENOME_37_RESOURCE_FILES);
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageSomaticCallerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageSomaticCallerTest.java
@@ -25,17 +25,17 @@ public class SageSomaticCallerTest extends TertiaryStageTest<SageOutput> {
 
     @Test
     public void shallowModeUsesHotspotQualOverride() {
-        SageCaller victim = new SageCaller(TestInputs.defaultPair(),
+        SageSomaticCaller victim = new SageSomaticCaller(TestInputs.defaultPair(),
                 new NoopPersistedDataset(),
-                SageConfiguration.somatic(TestInputs.REF_GENOME_37_RESOURCE_FILES, Arguments.testDefaultsBuilder().shallow(true).build()));
+                TestInputs.REF_GENOME_37_RESOURCE_FILES, Arguments.testDefaultsBuilder().shallow(true).build());
         assertThat(victim.tumorReferenceCommands(input()).get(0).asBash()).contains("-hotspot_min_tumor_qual 40");
     }
 
     @Override
     protected Stage<SageOutput, SomaticRunMetadata> createVictim() {
-        return new SageCaller(TestInputs.defaultPair(),
+        return new SageSomaticCaller(TestInputs.defaultPair(),
                 new NoopPersistedDataset(),
-                SageConfiguration.somatic(TestInputs.REF_GENOME_37_RESOURCE_FILES, Arguments.testDefaults()));
+                TestInputs.REF_GENOME_37_RESOURCE_FILES, Arguments.testDefaults());
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/reruns/StartingPointTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/reruns/StartingPointTest.java
@@ -1,6 +1,16 @@
 package com.hartwig.pipeline.reruns;
 
+import static java.util.stream.Collectors.toList;
+
+import static com.hartwig.pipeline.reruns.StartingPoint.StartingPoints.values;
+
 import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.alignment.Aligner;
@@ -8,14 +18,29 @@ import com.hartwig.pipeline.calling.germline.GermlineCaller;
 import com.hartwig.pipeline.calling.sage.SageConfiguration;
 import com.hartwig.pipeline.calling.structural.gridss.Gridss;
 import com.hartwig.pipeline.cram.CramConversion;
+import com.hartwig.pipeline.cram2bam.Cram2Bam;
 import com.hartwig.pipeline.flagstat.Flagstat;
 import com.hartwig.pipeline.metrics.BamMetrics;
+import com.hartwig.pipeline.reruns.StartingPoint.StartingPoints;
 import com.hartwig.pipeline.snpgenotype.SnpGenotype;
+import com.hartwig.pipeline.stages.Namespace;
+import com.hartwig.pipeline.stages.NamespacesTest;
+import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.tertiary.amber.Amber;
 import com.hartwig.pipeline.tertiary.cobalt.Cobalt;
+import com.hartwig.pipeline.tertiary.cuppa.Cuppa;
+import com.hartwig.pipeline.tertiary.healthcheck.HealthChecker;
+import com.hartwig.pipeline.tertiary.lilac.Lilac;
+import com.hartwig.pipeline.tertiary.orange.Orange;
+import com.hartwig.pipeline.tertiary.peach.Peach;
+import com.hartwig.pipeline.tertiary.protect.Protect;
 import com.hartwig.pipeline.tertiary.purple.Purple;
+import com.hartwig.pipeline.tertiary.sigs.Sigs;
 
 import org.junit.Test;
+import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
+import org.reflections.util.ClasspathHelper;
 
 public class StartingPointTest {
 
@@ -72,7 +97,26 @@ public class StartingPointTest {
         assertThat(victim.usePersisted(Purple.NAMESPACE)).isTrue();
     }
 
+    @Test
+    public void startingPointsAreUpToDate() {
+        List<Namespace> endStages = namespacesOf(Sigs.class, Orange.class, Cram2Bam.class, HealthChecker.class, Protect.class, Lilac.class,
+                Cuppa.class, Peach.class);
+        NamespacesTest.allNamespaces().stream().filter(n -> !endStages.contains(n)).map(Namespace::value).collect(toList()).forEach(n -> {
+            boolean referenced = false;
+            for (StartingPoints points: StartingPoints.values()) {
+                if (new StartingPoint(testArgumentsWithStartingPoint(points.name())).usePersisted(n)) {
+                    referenced = true;
+                }
+            }
+            assertThat(referenced).as("Namespace %s is referenced from at least one starting point", n).isTrue();
+        });
+    }
+
     public static Arguments testArgumentsWithStartingPoint(final String startingPoint) {
         return Arguments.testDefaultsBuilder().startingPoint(startingPoint).build();
+    }
+
+    private static List<Namespace> namespacesOf(Class<? extends Stage>...classes) {
+        return Arrays.stream(classes).map(c -> c.getAnnotation(Namespace.class)).collect(toList());
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/stages/NamespacesTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/stages/NamespacesTest.java
@@ -1,0 +1,58 @@
+package com.hartwig.pipeline.stages;
+
+import static java.util.stream.Collectors.toList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
+import org.reflections.util.ClasspathHelper;
+
+public class NamespacesTest {
+    @Test
+    public void everyStageIsAnnotatedWithNonEmptyNamespace() {
+        allConcreteStages().stream().forEach(subType -> {
+            Namespace namespace = subType.getAnnotation(Namespace.class);
+            assertThat(namespace).as("%s is annotated with a namespace", subType.getSimpleName()).isNotNull();
+            assertThat(namespace.value()).as("Namespace for %s is null or empty", subType.getSimpleName()).isNotEmpty();
+        });
+    }
+
+    @Test
+    public void everyStageNamespaceIsUnique() {
+        List<String> namespaces = new ArrayList<>(allNamespaces().stream().map(n -> n.value()).collect(toList()));
+        assertThat(namespaces.stream().sorted().collect(toList())).isEqualTo(namespaces.stream().distinct().sorted().collect(toList()));
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static List<Class<Stage>> allConcreteStages() {
+        Reflections scanner = new Reflections(ClasspathHelper.forPackage("com.hartwig.pipeline"), new SubTypesScanner(false));
+        List<Class<Stage>> stages = new ArrayList<>();
+        scanner.getSubTypesOf(Object.class).stream().filter(t -> t != null).forEach(subType -> {
+            if (implementsStage(subType) && !Modifier.isAbstract(subType.getModifiers())) {
+                stages.add((Class<Stage>) subType);
+            }
+        });
+        return stages;
+    }
+
+    private static boolean implementsStage(final Class<?> cut) {
+        if (cut == null || cut == Object.class) {
+            return false;
+        }
+        if (cut.getInterfaces() != null && Arrays.stream(cut.getInterfaces()).anyMatch(i -> i == Stage.class)) {
+            return true;
+        }
+        return implementsStage(cut.getSuperclass());
+    }
+
+    public static List<Namespace> allNamespaces() {
+        return allConcreteStages().stream().map(stage -> stage.getAnnotation(Namespace.class)).collect(toList());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <pipeline-events.version>2.2.1</pipeline-events.version>
         <java-client.version>1.12.0</java-client.version>
         <compar.version>1.0.0</compar.version>
+        <org-reflections.version>0.9.11</org-reflections.version>
     </properties>
 
     <scm>
@@ -216,18 +217,18 @@
                 <version>${htsjdk.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.reflections</groupId>
+                <artifactId>reflections</artifactId>
+                <version>${org-reflections.version}</version>
+                <scope>test</scope>
+            </dependency>
 
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
                 <version>${slf4j-log4j12.version}</version>
                 <scope>runtime</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.reflections</groupId>
-                <artifactId>reflections</artifactId>
-                <version>${org-reflections.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This can probably use some work as several of the later steps are run, not just
Protect. Also a couple of the recently-added stages were never added to the
existing starting points so I have added those.

I have also added a `Namespace` annotation for the stages and a couple of tests
that use reflection to do some basic checks on the namespaces and starting
points. This may be a first step toward a more cohesive structure for the
starting points but also is a move closer to a more official interface for the
stages. For the moment almost all of the stages reference existing constants
as the value for their new annotation but this too is just a first step.