### PR TITLE
DEV-2674 Bump Sage, Linx and Pave versions

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
@@ -19,13 +19,13 @@ public interface Versions {
     String GRIPSS = "2.1";
     String HEALTH_CHECKER = "3.4";
     String LILAC = "1.1";
-    String LINX = "1.19";
+    String LINX = "1.19.1";
     String ORANGE = "1.7";
-    String PAVE = "1.2.1";
+    String PAVE = "1.2.2";
     String PEACH = "1.6";
     String PROTECT = "2.1";
     String PURPLE = "3.4.2";
-    String SAGE = "3.0.1";
+    String SAGE = "3.0.2";
     String SIGS = "1.0";
     String VIRUSBREAKEND_GRIDSS = "2.13.2";
     String VIRUS_INTERPRETER = "1.2";

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageCommandBuilderTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageCommandBuilderTest.java
@@ -22,7 +22,7 @@ public class SageCommandBuilderTest {
 
     private static final String REFERENCE_OUT = VmDirectories.OUTPUT + "/" + REFERENCE + ".out.vcf.gz";
     private static final String REFERENCE_SAGE_COMMAND =
-            "java -Xmx31G -jar /opt/tools/sage/3.0.1/sage.jar "
+            "java -Xmx31G -jar /opt/tools/sage/3.0.2/sage.jar "
                     + "-tumor COLO829v003R -tumor_bam /data/input/COLO829v003R.bam "
                     + "-reference COLO829v003T -reference_bam /data/input/COLO829v003T.bam "
                     + "-hotspots /opt/resources/sage/37/KnownHotspots.germline.37.vcf.gz "

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageGermlineCallerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageGermlineCallerTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
-import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.reruns.NoopPersistedDataset;
 import com.hartwig.pipeline.stages.Stage;
@@ -32,7 +31,7 @@ public class SageGermlineCallerTest extends TertiaryStageTest<SageOutput> {
     @Override
     protected List<String> expectedCommands() {
         return ImmutableList.of(
-                "java -Xmx31G -jar /opt/tools/sage/3.0.1/sage.jar "
+                "java -Xmx31G -jar /opt/tools/sage/3.0.2/sage.jar "
                         + "-tumor reference -tumor_bam /data/input/reference.bam "
                         + "-reference tumor -reference_bam /data/input/tumor.bam "
                         + "-hotspots /opt/resources/sage/37/KnownHotspots.germline.37.vcf.gz "

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageSomaticCallerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageSomaticCallerTest.java
@@ -40,7 +40,7 @@ public class SageSomaticCallerTest extends TertiaryStageTest<SageOutput> {
 
     @Override
     protected List<String> expectedCommands() {
-        return ImmutableList.of("java -Xmx60G -jar /opt/tools/sage/3.0.1/sage.jar " + "-tumor tumor -tumor_bam /data/input/tumor.bam "
+        return ImmutableList.of("java -Xmx60G -jar /opt/tools/sage/3.0.2/sage.jar " + "-tumor tumor -tumor_bam /data/input/tumor.bam "
                         + "-reference reference -reference_bam /data/input/reference.bam "
                         + "-hotspots /opt/resources/sage/37/KnownHotspots.somatic.37.vcf.gz "
                         + "-panel_bed /opt/resources/sage/37/ActionableCodingPanel.somatic.37.bed.gz "

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/linx/LinxGermlineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/linx/LinxGermlineTest.java
@@ -40,7 +40,7 @@ public class LinxGermlineTest extends TertiaryStageTest<LinxGermlineOutput> {
 
         List<String> commands = Lists.newArrayList();
 
-        commands.add("java -Xmx8G -jar /opt/tools/linx/1.19/linx.jar -sample tumor -germline "
+        commands.add("java -Xmx8G -jar /opt/tools/linx/1.19.1/linx.jar -sample tumor -germline "
                 + "-sv_vcf /data/input/tumor.gripss.filtered.vcf.gz -ref_genome_version V37 -output_dir /data/output "
                 + "-line_element_file /opt/resources/linx/37/line_elements.37.csv "
                 + "-ensembl_data_dir /opt/resources/ensembl_data_cache/37/ "

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/linx/LinxSomaticTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/linx/LinxSomaticTest.java
@@ -38,16 +38,15 @@ public class LinxSomaticTest extends TertiaryStageTest<LinxSomaticOutput> {
 
         List<String> commands = Lists.newArrayList();
 
-        commands.add("java -Xmx8G -jar /opt/tools/linx/1.19/linx.jar -sample tumor -sv_vcf "
+        commands.add("java -Xmx8G -jar /opt/tools/linx/1.19.1/linx.jar -sample tumor -sv_vcf "
                 + "/data/input/tumor.purple.sv.vcf.gz -purple_dir /data/input/results -ref_genome_version V37 -output_dir /data/output "
                 + "-fragile_site_file /opt/resources/linx/37/fragile_sites_hmf.37.csv "
                 + "-line_element_file /opt/resources/linx/37/line_elements.37.csv "
                 + "-ensembl_data_dir /opt/resources/ensembl_data_cache/37/ "
                 + "-check_fusions -known_fusion_file /opt/resources/fusions/37/known_fusion_data.37.csv "
-                + "-check_drivers -driver_gene_panel /opt/resources/gene_panel/37/DriverGenePanel.37.tsv "
-                + "-write_vis_data");
+                + "-check_drivers -driver_gene_panel /opt/resources/gene_panel/37/DriverGenePanel.37.tsv " + "-write_vis_data");
 
-        commands.add("java -Xmx8G -cp /opt/tools/linx/1.19/linx.jar com.hartwig.hmftools.linx.visualiser.SvVisualiser "
+        commands.add("java -Xmx8G -cp /opt/tools/linx/1.19.1/linx.jar com.hartwig.hmftools.linx.visualiser.SvVisualiser "
                 + "-sample tumor -ref_genome_version V37 -circos /opt/tools/circos/0.69.6/bin/circos -vis_file_dir /data/output "
                 + "-data_out /data/output/circos/ -plot_out /data/output/plot/ -plot_reportable");
 

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/pave/PaveGermlineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/pave/PaveGermlineTest.java
@@ -34,7 +34,7 @@ public class PaveGermlineTest extends StageTest<PaveOutput, SomaticRunMetadata> 
     @Override
     protected List<String> expectedCommands() {
         return ImmutableList.of(
-                "java -Xmx16G -jar /opt/tools/pave/1.2.1/pave.jar "
+                "java -Xmx16G -jar /opt/tools/pave/1.2.2/pave.jar "
                         + "-sample tumor "
                         + "-vcf_file /data/input/tumor.germline.vcf.gz "
                         + "-ref_genome /opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta "

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/pave/PaveSomaticTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/pave/PaveSomaticTest.java
@@ -34,7 +34,7 @@ public class PaveSomaticTest extends StageTest<PaveOutput, SomaticRunMetadata> {
     @Override
     protected List<String> expectedCommands() {
         return ImmutableList.of(
-                "java -Xmx16G -jar /opt/tools/pave/1.2.1/pave.jar "
+                "java -Xmx16G -jar /opt/tools/pave/1.2.2/pave.jar "
                         + "-sample tumor "
                         + "-vcf_file /data/input/tumor.somatic.vcf.gz "
                         + "-ref_genome /opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta "


### PR DESCRIPTION
If I'm reading the commit history properly there is nothing to do for the `common-resources` repository so this is all that has to be done before we do the next 5.28 rerun.
