### PR TITLE
DEV-2793 Allow using branch for public resources

### DIFF
--- a/cluster/images/create_private_image.sh
+++ b/cluster/images/create_private_image.sh
@@ -53,7 +53,7 @@ dest_image="${source_image}-$(date +%Y%m%d%H%M)-private"
 gcloud compute images describe $dest_image --project=$DEST_PROJECT >/dev/null 2>&1
 [[ $? -eq 0 ]] && echo "$dest_image exists in project $DEST_PROJECT!" && exit 1
 
-image_family="$(echo $json | jq -r '.family')"
+image_family="$(echo $json | jq -r '.family')${resources_commit:+"-unofficial"}"
 imager_vm="${image_family}-imager"
 
 cat <<EOM

--- a/cluster/images/create_private_image.sh
+++ b/cluster/images/create_private_image.sh
@@ -67,8 +67,8 @@ EOM
 read -p "Continue [y|N]? " response
 [[ $response != 'y' && $response != 'Y' ]] && echo "Aborting at user request" && exit 0
 
-if [[ -n $commit_sha ]]; then
-    additional_args="--checkout-commit $commit_sha"
+if [[ -n $resources_commit ]]; then
+    additional_args="--checkout-commit $resources_commit"
 else
     additional_args="--tag-as-version $dest_image"
 fi    

--- a/cluster/images/private_resource_checkout.sh
+++ b/cluster/images/private_resource_checkout.sh
@@ -5,7 +5,7 @@ IN_GCP=$?
 
 print_usage() {
     cat <<EOM
-USAGE: $0 [--project project] [--tag-as-version new-version || --checkout-tag existing-tag] [--result-code-url gs-url]
+USAGE: $0 [--project project] [--tag-as-version new-version || --checkout-tag existing-tag || --checkout-branch branch-name] [--result-code-url gs-url]
 
 Required:
   --project [project]              Project in GCP containing the source repository
@@ -13,6 +13,7 @@ Required:
 Specify ONLY ONE of:
   --tag-as-version [new-version]   Create tag [new-version] in source repo after checking out HEAD
   --checkout-commit [commit-sha]   Checkout [commit-sha] rather than HEAD and create no new tags
+  --checkout-branch [branch-name]  Checkout HEAD of [branch-name] rather than [master] and create no new tags
 
 Optional:
   --result-code-url [gs-url]        GCS (eg "gs://bucket/path") URL to write exit code to (bucket must be writable).
@@ -39,10 +40,10 @@ if [[ $IN_GCP && $# -eq 0 ]]; then
     echo "Running inside GCP, fetching arguments from metadata"
     project="$(metadata project)"
     new_version="$(metadata tag-as-version)"
-    commit_sha="$(metadata checkout-commit)"
+    checkout_target="$(metadata checkout-commit)"
     result_code_url="$(metadata result-code-url)"
 else
-    args=$(getopt -o "" --longoptions project:,tag-as-version:,checkout-commit:,result-code-url: -- "$@")
+    args=$(getopt -o "" --longoptions project:,tag-as-version:,checkout-commit:,checkout-branch:,result-code-url: -- "$@")
     [[ $? != 0 ]] && print_usage && exit 1
     eval set -- "$args"
 
@@ -50,14 +51,23 @@ else
         case "$1" in
             --project) project=$2 ; shift 2 ;;
             --tag-as-version) new_version=$2 ; shift 2 ;;
-            --checkout-commit) commit_sha=$2 ; shift 2 ;;
+            --checkout-commit) checkout_commit=$2 ; shift 2 ;;
+            --checkout-branch) checkout_branch=$2 ; shift 2 ;;
             --result-code-url) result_code_url=$2 ; shift 2 ;;
             --) shift; break ;;
         esac
     done
 fi
 
-if [[ -z "$project" || ( -z "$new_version" && -z "$commit_sha" ) || ( -n "$new_version" && -n "$commit_sha" ) ]]; then
+if [[ -n "$checkout_commit" || -n "$checkout_branch" ]]; then
+    if [[ -n "$checkout_commit" && -n "$checkout_branch" ]]; then
+        print_usage
+        exit 1
+    fi
+    checkout_target="${checkout_commit:-$checkout_branch}"
+fi
+
+if [[ -z "$project" || ( -z "$new_version" && -z "$checkout_target" ) || ( -n "$new_version" && -n "$checkout_target" ) ]]; then
     print_usage
     exit 1
 fi
@@ -76,8 +86,8 @@ if [[ -n $new_version ]]; then
     git tag "$new_version"
     git push origin "$new_version"
 else
-    echo "Checking out commit '$commit_sha'"
-    git checkout $commit_sha
+    echo "Checking out '$checkout_target'"
+    git checkout $checkout_target
 fi
 
 rm -r .git/


### PR DESCRIPTION
This makes our development process more robust by allowing multiple developers
to work in parallel on tickets that amend the resources, and also protects the
production image from changes that haven't been explicitly merged to `master`.

When a branch is used for the public image, a distinct family will also be used
and no tag will be written to the repository so that image won't be available
to use as the base for a private image.

I've also amended the private imaging script to allow passing any "target"
instead of just a SHA on the command line; the user can now use a tag, commit
SHA or branch. When run from within GCP though only a SHA will be supported.

Options in the public script have switched to long-only to match the private
script's behaviour.