### PR TITLE
DEV-2798 Python venv support for pilot images

### DIFF
--- a/cluster/images/link_pilot_venvs.sh
+++ b/cluster/images/link_pilot_venvs.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Makes symlinks to the latest Python virtualenv for each tool to support "pilot" versions
+# 
+# Known limitation: assumes two-level versioning for tools and will get confused if a given tool mixes two- and three-level (or
+# more) versions. For instance it will think "1.6" is newer than "1.6.1". Fixing this results in a more-complicated script and
+# honestly I don't think it will happen that often, nor do I think that the virtualenvs for a patch release would be much
+# different than those for the corresponding minor release.
+
+set -e
+
+find /opt/tools -type d -name '*_venv' | while read d; do 
+    dirname $d; 
+done | sort -u | while read tool; do 
+    target="$(find ${tool} -type d -name '*_venv' | sort | tail -n1)"
+    ln -s "$target" "${tool}/pilot_venv"
+    echo "Symlinked ${target} as the virtual environment for ${tool}"
+done


### PR DESCRIPTION
We create Python virtualenvs in their own directories for several of our
tools. However when we try to run these tools with a pilot version,
there is no virtualenv with a name matching the version and so it can't
be found at runtime.

I've added a script to locate the virtualenv for the latest version of
the tool (with some limitations) and this should be enough to get us
working in 99% of cases. Actually I expect this will only ever really be
an issue with Cuppa but it's possible we add tools later in a similar
vein.