### PR TITLE
DEV-2832 Remove termination action for local ssd/reduce amber footprint

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngine.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngine.java
@@ -148,9 +148,6 @@ public class GoogleComputeEngine implements ComputeEngine {
 
                 if (arguments.usePreemptibleVms()) {
                     final Scheduling.Builder schedulingBuilder = Scheduling.newBuilder().setProvisioningModel("SPOT");
-                    if (arguments.useLocalSsds()) {
-                        schedulingBuilder.setInstanceTerminationAction("DELETE");
-                    }
                     instanceBuilder.setScheduling(schedulingBuilder.build());
                 }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
@@ -142,7 +142,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
                 .name("amber")
                 .startupCommand(startupScript)
                 .namespacedResults(resultsDirectory)
-                .performanceProfile(custom(32, 120))
+                .performanceProfile(custom(16, 64))
                 .build();
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/amber/Amber.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/amber/Amber.java
@@ -106,7 +106,7 @@ public class Amber extends TertiaryStage<AmberOutput> {
         arguments.add(String.format("-ref_genome_version %s", resourceFiles.version()));
         arguments.add(String.format("-loci %s", resourceFiles.amberHeterozygousLoci()));
         arguments.add(String.format("-output_dir %s", VmDirectories.OUTPUT));
-        arguments.add(String.format("-threads %s", Bash.allCpus()));
+        arguments.add(String.format("-threads %s", "12"));
     }
 
     private void addTargetRegionsArguments(final List<String> amberArguments) {

--- a/cluster/src/test/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngineTest.java
@@ -260,7 +260,6 @@ public class GoogleComputeEngineTest {
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
         Scheduling scheduling = instanceArgumentCaptor.getValue().getScheduling();
         assertThat(scheduling.getProvisioningModel()).isEqualTo("SPOT");
-        assertThat(scheduling.getInstanceTerminationAction()).isEqualTo("DELETE");
     }
 
     @Test

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/amber/AmberTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/amber/AmberTest.java
@@ -67,6 +67,6 @@ public class AmberTest extends TertiaryStageTest<AmberOutput> {
                 + "-ref_genome_version V37 "
                 + "-loci /opt/resources/amber/37/GermlineHetPon.37.vcf.gz "
                 + "-output_dir /data/output "
-                + "-threads $(grep -c '^processor' /proc/cpuinfo)");
+                + "-threads 12");
     }
 }


### PR DESCRIPTION
Removing the termination action entirely to allow for manual deletion of vms without
the pipeline restarting them.

Amber settings reduced as per Charles/Hongs recommendations and using a slightly
smaller thread count than available CPU to reduce saturation of VM.