### PR TITLE
DEV-2835 Add persisted output to lilac

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/SomaticPipeline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/SomaticPipeline.java
@@ -186,7 +186,7 @@ public class SomaticPipeline {
                                 new LinxGermline(gripssGermlineProcessOutput, resourceFiles, persistedDataset)));
                         LilacBamSliceOutput lilacBamSliceOutput = pipelineResults.add(state.add(lilacBamSliceOutputFuture.get()));
                         Future<LilacOutput> lilacOutputFuture = executorService.submit(() -> stageRunner.run(metadata,
-                                new Lilac(lilacBamSliceOutput, resourceFiles, purpleOutput)));
+                                new Lilac(lilacBamSliceOutput, resourceFiles, purpleOutput, persistedDataset)));
                         Future<SigsOutput> signatureOutputFuture =
                                 executorService.submit(() -> stageRunner.run(metadata, new Sigs(purpleOutput, resourceFiles)));
                         Future<ChordOutput> chordOutputFuture = executorService.submit(() -> stageRunner.run(metadata,

--- a/cluster/src/main/java/com/hartwig/pipeline/reruns/StartingPoint.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/reruns/StartingPoint.java
@@ -90,6 +90,7 @@ public class StartingPoint {
                         VirusBreakend.NAMESPACE,
                         VirusInterpreter.NAMESPACE,
                         Chord.NAMESPACE,
+                        LilacBamSlicer.NAMESPACE,
                         Lilac.NAMESPACE,
                         Peach.NAMESPACE,
                         Sigs.NAMESPACE,

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/lilac/Lilac.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/lilac/Lilac.java
@@ -25,6 +25,8 @@ import com.hartwig.pipeline.metadata.SomaticRunMetadata;
 import com.hartwig.pipeline.report.EntireOutputComponent;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.report.RunLogComponent;
+import com.hartwig.pipeline.reruns.PersistedDataset;
+import com.hartwig.pipeline.reruns.PersistedLocations;
 import com.hartwig.pipeline.resource.ResourceFiles;
 import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
@@ -44,9 +46,12 @@ public class Lilac implements Stage<LilacOutput, SomaticRunMetadata> {
     private final InputDownload purpleSomaticVariants;
     private final InputDownload slicedReference;
     private final InputDownload slicedTumor;
+    private final PersistedDataset persistedDataset;
 
-    public Lilac(final LilacBamSliceOutput slicedOutput, final ResourceFiles resourceFiles, final PurpleOutput purpleOutput) {
+    public Lilac(final LilacBamSliceOutput slicedOutput, final ResourceFiles resourceFiles, final PurpleOutput purpleOutput,
+            final PersistedDataset persistedDataset) {
         this.resourceFiles = resourceFiles;
+        this.persistedDataset = persistedDataset;
         PurpleOutputLocations purpleOutputLocations = purpleOutput.outputLocations();
         this.purpleGeneCopyNumber = initialiseOptionalLocation(purpleOutputLocations.geneCopyNumber());
         this.purpleSomaticVariants = initialiseOptionalLocation(purpleOutputLocations.somaticVariants());
@@ -124,18 +129,20 @@ public class Lilac implements Stage<LilacOutput, SomaticRunMetadata> {
     @Override
     public LilacOutput output(final SomaticRunMetadata metadata, final PipelineStatus jobStatus, final RuntimeBucket bucket,
             final ResultsDirectory resultsDirectory) {
-        String results = lilacOutput(metadata.sampleName());
-        String qc = lilacQcMetrics(metadata.sampleName());
+        String lilacOutput = lilacOutput(metadata.sampleName());
+        String lilacQc = lilacQcMetrics(metadata.sampleName());
         return LilacOutput.builder()
                 .status(jobStatus)
                 .addFailedLogLocations(GoogleStorageLocation.of(bucket.name(), RunLogComponent.LOG_FILE))
                 .addReportComponents(new EntireOutputComponent(bucket, Folder.root(), namespace(), resultsDirectory))
-                .qc(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(qc)))
-                .result(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(results)))
+                .qc(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(lilacQc)))
+                .result(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path(lilacOutput)))
                 .addDatatypes(new AddDatatype(DataType.LILAC_OUTPUT,
                                 metadata.barcode(),
-                                new ArchivePath(Folder.root(), namespace(), results)),
-                        new AddDatatype(DataType.LILAC_QC_METRICS, metadata.barcode(), new ArchivePath(Folder.root(), namespace(), qc)))
+                                new ArchivePath(Folder.root(), namespace(), lilacOutput)),
+                        new AddDatatype(DataType.LILAC_QC_METRICS,
+                                metadata.barcode(),
+                                new ArchivePath(Folder.root(), namespace(), lilacQc)))
                 .build();
     }
 
@@ -146,14 +153,22 @@ public class Lilac implements Stage<LilacOutput, SomaticRunMetadata> {
 
     @Override
     public LilacOutput persistedOutput(final SomaticRunMetadata metadata) {
+        String lilacOutput = lilacOutput(metadata.sampleName());
+        String lilacQc = lilacQcMetrics(metadata.sampleName());
         return LilacOutput.builder()
                 .status(PipelineStatus.PERSISTED)
+                .qc(persistedDataset.path(metadata.tumor().sampleName(), DataType.LILAC_QC_METRICS)
+                        .orElse(GoogleStorageLocation.of(metadata.bucket(),
+                                PersistedLocations.blobForSet(metadata.set(), namespace(), lilacQc))))
+                .result(persistedDataset.path(metadata.tumor().sampleName(), DataType.LILAC_OUTPUT)
+                        .orElse(GoogleStorageLocation.of(metadata.bucket(),
+                                PersistedLocations.blobForSet(metadata.set(), namespace(), lilacOutput))))
                 .addDatatypes(new AddDatatype(DataType.LILAC_OUTPUT,
                                 metadata.barcode(),
-                                new ArchivePath(Folder.root(), namespace(), lilacOutput(metadata.sampleName()))),
+                                new ArchivePath(Folder.root(), namespace(), lilacOutput)),
                         new AddDatatype(DataType.LILAC_QC_METRICS,
                                 metadata.barcode(),
-                                new ArchivePath(Folder.root(), namespace(), lilacQcMetrics(metadata.sampleName()))))
+                                new ArchivePath(Folder.root(), namespace(), lilacQc)))
                 .build();
     }
 


### PR DESCRIPTION
And the required tests. rerun_530 starting point is updated to not run the
slicer for now.