### PR TITLE
DEV-2831 Update arguments for ROSE

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/resource/ResourceFiles.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/resource/ResourceFiles.java
@@ -149,6 +149,10 @@ public interface ResourceFiles {
         return of(ROSE, "actionability.tsv");
     }
 
+    default String roseCuratedPrimaryTumors() {
+        return of(ROSE, "curated_primary_tumor_header-only.tsv");
+    }
+
     default String formPath(final String name, final String file) {
         return String.format("%s/%s/%s/%s", VmDirectories.RESOURCES, name, versionDirectory(), file);
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/rose/Rose.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/rose/Rose.java
@@ -152,7 +152,11 @@ public class Rose implements Stage<RoseOutput, SomaticRunMetadata> {
                 "-tumor_sample_id",
                 metadata.tumor().sampleName(),
                 "-ref_sample_id",
-                metadata.reference().sampleName());
+                metadata.reference().sampleName(),
+                "-patient_id",
+                "not_used_because_primary_tumor_tsv_has_only_headers",
+                "-primary_tumor_tsv",
+                resourceFiles.roseCuratedPrimaryTumors());
         return List.of(new JavaJarCommand("rose", Versions.ROSE, "rose.jar", "8G", arguments));
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/rose/Rose.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/rose/Rose.java
@@ -119,9 +119,7 @@ public class Rose implements Stage<RoseOutput, SomaticRunMetadata> {
                 resourceFiles.roseActionabilityDb(),
                 "-ref_genome_version",
                 resourceFiles.version().numeric(),
-                "-driver_gene_37_tsv",
-                resourceFiles.driverGenePanel(),
-                "-driver_gene_38_tsv",
+                "-driver_gene_tsv",
                 resourceFiles.driverGenePanel(),
                 "-purple_purity_tsv",
                 purplePurity.getLocalTargetPath(),
@@ -152,7 +150,9 @@ public class Rose implements Stage<RoseOutput, SomaticRunMetadata> {
                 "-output_dir",
                 VmDirectories.OUTPUT,
                 "-tumor_sample_id",
-                metadata.tumor().sampleName(), "-ref_sample_id", metadata.reference().sampleName());
+                metadata.tumor().sampleName(),
+                "-ref_sample_id",
+                metadata.reference().sampleName());
         return List.of(new JavaJarCommand("rose", Versions.ROSE, "rose.jar", "8G", arguments));
     }
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/Versions.java
@@ -25,7 +25,7 @@ public interface Versions {
     String PEACH = "1.6";
     String PROTECT = "2.2";
     String PURPLE = "3.5.1";
-    String ROSE = "1.0";
+    String ROSE = "1.1";
     String SAGE = "3.1";
     String SIGS = "1.1";
     String VIRUSBREAKEND_GRIDSS = "2.13.2";

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/rose/RoseTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/rose/RoseTest.java
@@ -55,7 +55,9 @@ public class RoseTest extends TertiaryStageTest<RoseOutput> {
                         + " -annotated_virus_tsv /data/input/tumor.virus.annotated.tsv"
                         + " -chord_prediction_txt /data/input/tumor_chord_prediction.txt"
                         + " -molecular_tissue_origin_txt /data/input/tumor.cuppa.conclusion.txt" + " -output_dir /data/output"
-                        + " -tumor_sample_id tumor" + " -ref_sample_id reference");
+                        + " -tumor_sample_id tumor" + " -ref_sample_id reference" + " -patient_id"
+                        + " not_used_because_primary_tumor_tsv_has_only_headers" + " -primary_tumor_tsv"
+                        + " /opt/resources/rose/curated_primary_tumor_header-only.tsv");
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/rose/RoseTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/rose/RoseTest.java
@@ -42,9 +42,8 @@ public class RoseTest extends TertiaryStageTest<RoseOutput> {
     @Override
     protected List<String> expectedCommands() {
         return Collections.singletonList(
-                "java -Xmx8G -jar /opt/tools/rose/1.0/rose.jar" + " -actionability_database_tsv /opt/resources/rose/actionability.tsv"
-                        + " -ref_genome_version 37" + " -driver_gene_37_tsv /opt/resources/gene_panel/37/DriverGenePanel.37.tsv"
-                        + " -driver_gene_38_tsv /opt/resources/gene_panel/37/DriverGenePanel.37.tsv"
+                "java -Xmx8G -jar /opt/tools/rose/1.1/rose.jar" + " -actionability_database_tsv /opt/resources/rose/actionability.tsv"
+                        + " -ref_genome_version 37" + " -driver_gene_tsv /opt/resources/gene_panel/37/DriverGenePanel.37.tsv"
                         + " -purple_purity_tsv /data/input/tumor.purple.purity.tsv" + " -purple_qc_file /data/input/tumor.purple.qc"
                         + " -purple_gene_copy_number_tsv /data/input/tumor.purple.cnv.gene.tsv"
                         + " -purple_somatic_driver_catalog_tsv /data/input/tumor.driver.catalog.somatic.tsv"


### PR DESCRIPTION
Upgrade to ROSE v1.1. Note the use of some temporary/dummy arguments as the new version requires them but the report will still generate fine without "real" data.