### PR TITLE
DEV-2853 Check for correct getopt before running

### DIFF
--- a/cluster/images/check_deps.sh
+++ b/cluster/images/check_deps.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+getopt -V | egrep -E '^getopty'
+if [[ $? != 0 ]]; then
+    echo "Your getopt implementation is not as expected and may not support long options!"
+    echo "If you are on MacOS try running: "
+    echo "  brew install gnu-getopt"
+    echo "and make sure the new binary is before $(which getopt) on your PATH, then try again"
+    exit 1
+fi
+

--- a/cluster/images/create_private_image.sh
+++ b/cluster/images/create_private_image.sh
@@ -31,6 +31,7 @@ EOM
 
 set -o pipefail
 
+"$(dirname "$0")/check_deps.sh" || exit 1
 [[ $# -eq 0 ]] && print_usage && exit 1
 source_image="$1"
 shift

--- a/cluster/images/create_public_image.sh
+++ b/cluster/images/create_public_image.sh
@@ -21,6 +21,7 @@ Optional arguments:
 EOM
 }
 
+"$(dirname "$0")/check_deps.sh" || exit 1
 args=$(getopt -o "" --longoptions tools-only,flavour:,checkout-target: -- "$@")
 [[ $? != 0 ]] && print_usage && exit 1
 eval set -- "$args"

--- a/cluster/images/private_resource_checkout.sh
+++ b/cluster/images/private_resource_checkout.sh
@@ -43,6 +43,7 @@ if [[ $IN_GCP && $# -eq 0 ]]; then
     checkout_target="$(metadata checkout-commit)"
     result_code_url="$(metadata result-code-url)"
 else
+    "$(dirname "$0")/check_deps.sh" || exit 1
     args=$(getopt -o "" --longoptions project:,tag-as-version:,checkout-commit:,checkout-branch:,result-code-url: -- "$@")
     [[ $? != 0 ]] && print_usage && exit 1
     eval set -- "$args"


### PR DESCRIPTION
This may be an anaemic check but it is better than what we had. On MacOS
the default getopt implementation is based on the BSD version and
doesn't support long options.

When invoked with "-V", the default version on modern Linux
installations (from the GNU foundation) returns a version, while the
MacOS version just returns "--". I've used this to create a simple
suitability check and we now print a warning with details for MacOS
users.