### PR TITLE
DEV-2959 Default to cram when bam not present

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/AlignerProvider.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/AlignerProvider.java
@@ -149,7 +149,7 @@ public abstract class AlignerProvider {
         @Override
         Aligner wireUp(final GoogleCredentials credentials, final Storage storage, final ResultsDirectory resultsDirectory,
                 final Labels labels) {
-            return new PersistedAlignment(persistedDataset, getArguments());
+            return new PersistedAlignment(persistedDataset, getArguments(), storage);
         }
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/alignment/persisted/PersistedAlignmentTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/alignment/persisted/PersistedAlignmentTest.java
@@ -6,6 +6,9 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
+import com.google.api.gax.paging.Page;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Storage;
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.alignment.AlignmentOutput;
 import com.hartwig.pipeline.datatypes.DataType;
@@ -13,20 +16,31 @@ import com.hartwig.pipeline.execution.PipelineStatus;
 import com.hartwig.pipeline.reruns.NoopPersistedDataset;
 import com.hartwig.pipeline.reruns.PersistedDataset;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
+import com.hartwig.pipeline.testsupport.TestBlobs;
 import com.hartwig.pipeline.testsupport.TestInputs;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class PersistedAlignmentTest {
 
-    public static final GoogleStorageLocation PERSISTED_REFERENCE_CRAM = GoogleStorageLocation.of("bucket", "persisted/reference.cram");
+    private static final GoogleStorageLocation PERSISTED_REFERENCE_CRAM =
+            GoogleStorageLocation.of(TestInputs.BUCKET, "set/reference/cram/reference.cram");
+    private static final GoogleStorageLocation PERSISTED_REFERENCE_BAM =
+            GoogleStorageLocation.of(TestInputs.BUCKET, "set/reference/aligner/reference.bam");
+    private Storage storage;
+
+    @Before
+    public void setUp() throws Exception {
+        storage = mock(Storage.class);
+    }
 
     @Test
     public void returnsPersistedCramsWhenExists() {
         PersistedDataset persistedDataset = mock(PersistedDataset.class);
         when(persistedDataset.path(TestInputs.referenceRunMetadata().sampleName(), DataType.ALIGNED_READS)).thenReturn(Optional.of(
                 PERSISTED_REFERENCE_CRAM));
-        PersistedAlignment victim = new PersistedAlignment(persistedDataset, Arguments.testDefaults());
+        PersistedAlignment victim = new PersistedAlignment(persistedDataset, Arguments.testDefaults(), storage);
         AlignmentOutput output = victim.run(TestInputs.referenceRunMetadata());
         assertThat(output.sample()).isEqualTo("reference");
         assertThat(output.status()).isEqualTo(PipelineStatus.PERSISTED);
@@ -34,21 +48,35 @@ public class PersistedAlignmentTest {
     }
 
     @Test
-    public void returnsBamsInConventionalLocationIfNoPersisted() {
-        PersistedAlignment victim = new PersistedAlignment(new NoopPersistedDataset(), Arguments.testDefaults());
+    public void returnsBamsInConventionalLocationIfNotPersistedAndTheyExist() {
+        final Blob blob = TestBlobs.blob(PERSISTED_REFERENCE_BAM.path());
+        final Page<Blob> page = TestBlobs.pageOf(blob);
+        when(storage.list(TestInputs.BUCKET, Storage.BlobListOption.prefix(PERSISTED_REFERENCE_BAM.path()))).thenReturn(page);
+        PersistedAlignment victim = new PersistedAlignment(new NoopPersistedDataset(), Arguments.testDefaults(), storage);
         AlignmentOutput output = victim.run(TestInputs.referenceRunMetadata());
         assertThat(output.sample()).isEqualTo("reference");
         assertThat(output.status()).isEqualTo(PipelineStatus.PERSISTED);
-        assertThat(output.alignments()).isEqualTo(GoogleStorageLocation.of("bucket", "set/reference/aligner/reference.bam"));
+        assertThat(output.alignments()).isEqualTo(PERSISTED_REFERENCE_BAM);
+    }
+
+    @Test
+    public void returnsCramsInConventionalLocationIfNotPersistedAndBamsDontExist() {
+        final Page<Blob> page = TestBlobs.pageOf();
+        when(storage.list(TestInputs.BUCKET, Storage.BlobListOption.prefix(PERSISTED_REFERENCE_CRAM.path()))).thenReturn(page);
+        PersistedAlignment victim = new PersistedAlignment(new NoopPersistedDataset(), Arguments.testDefaults(), storage);
+        AlignmentOutput output = victim.run(TestInputs.referenceRunMetadata());
+        assertThat(output.sample()).isEqualTo("reference");
+        assertThat(output.status()).isEqualTo(PipelineStatus.PERSISTED);
+        assertThat(output.alignments()).isEqualTo(PERSISTED_REFERENCE_CRAM);
     }
 
     @Test
     public void returnsCramsInConventionalLocationIfNoPersistedAndUseCrams() {
         PersistedAlignment victim =
-                new PersistedAlignment(new NoopPersistedDataset(), Arguments.testDefaultsBuilder().useCrams(true).build());
+                new PersistedAlignment(new NoopPersistedDataset(), Arguments.testDefaultsBuilder().useCrams(true).build(), storage);
         AlignmentOutput output = victim.run(TestInputs.referenceRunMetadata());
         assertThat(output.sample()).isEqualTo("reference");
         assertThat(output.status()).isEqualTo(PipelineStatus.PERSISTED);
-        assertThat(output.alignments()).isEqualTo(GoogleStorageLocation.of("bucket", "set/reference/cram/reference.cram"));
+        assertThat(output.alignments()).isEqualTo(PERSISTED_REFERENCE_CRAM);
     }
 }


### PR DESCRIPTION
When use cram is false, and we start from alignment complete, and no API dataset is available, we first try to locate the bams and then the crams.