### PR TITLE
DEV-2873 Make keys optional, remove defaults

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
@@ -49,7 +49,7 @@ public interface Arguments extends CommonArguments {
 
     String outputBucket();
 
-    String uploadPrivateKeyPath();
+    Optional<String> uploadPrivateKeyPath();
 
     Optional<Integer> sbpApiRunId();
 
@@ -118,7 +118,7 @@ public interface Arguments extends CommonArguments {
                     .region(CommonArguments.DEFAULT_REGION)
                     .project(DEFAULT_PRODUCTION_PROJECT)
                     .sbpApiUrl(DEFAULT_PRODUCTION_SBP_API_URL)
-                    .privateKeyPath(DEFAULT_DOCKER_KEY_PATH)
+                    .privateKeyPath(Optional.empty())
                     .serviceAccountEmail(DEFAULT_PRODUCTION_SERVICE_ACCOUNT_EMAIL)
                     .cloudSdkPath(DEFAULT_DOCKER_CLOUD_SDK_PATH)
                     .cleanup(true)
@@ -132,7 +132,7 @@ public interface Arguments extends CommonArguments {
                     .setId(EMPTY)
                     .cmek(EMPTY)
                     .outputBucket(DEFAULT_PRODUCTION_PATIENT_REPORT_BUCKET)
-                    .uploadPrivateKeyPath(DEFAULT_DOCKER_KEY_PATH)
+                    .uploadPrivateKeyPath(Optional.empty())
                     .network(DEFAULT_NETWORK)
                     .outputCram(true)
                     .publishToTurquoise(false)
@@ -182,6 +182,7 @@ public interface Arguments extends CommonArguments {
                     .region(CommonArguments.DEFAULT_DEVELOPMENT_REGION)
                     .project(CommonArguments.DEFAULT_DEVELOPMENT_PROJECT)
                     .cloudSdkPath(DEFAULT_DOCKER_CLOUD_SDK_PATH)
+                    .privateKeyPath(DEFAULT_DEVELOPMENT_KEY_PATH)
                     .serviceAccountEmail(CommonArguments.DEFAULT_DEVELOPMENT_SERVICE_ACCOUNT_EMAIL)
                     .cleanup(true)
                     .cmek(DEFAULT_DEVELOPMENT_CMEK)
@@ -208,8 +209,7 @@ public interface Arguments extends CommonArguments {
                     .anonymize(false)
                     .context(DEFAULT_CONTEXT);
         } else if (profile.equals(DefaultsProfile.PUBLIC)) {
-            return ImmutableArguments.builder()
-                    .profile(profile)
+            return ImmutableArguments.builder().profile(profile).privateKeyPath(DEFAULT_DEVELOPMENT_KEY_PATH)
                     .outputBucket(EMPTY)
                     .region(EMPTY)
                     .project(EMPTY)

--- a/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
@@ -327,7 +327,7 @@ public class CommandLineOptions {
                     .network(commandLine.getOptionValue(NETWORK_FLAG, defaults.network()))
                     .subnet(subnet(commandLine, defaults))
                     .tags(networkTags(commandLine, defaults))
-                    .uploadPrivateKeyPath(commandLine.getOptionValue(UPLOAD_PRIVATE_KEY_FLAG, defaults.uploadPrivateKeyPath()))
+                    .uploadPrivateKeyPath(uploadKeyPath(commandLine))
                     .cmek(cmek(commandLine, defaults))
                     .shallow(booleanOptionWithDefault(commandLine, SHALLOW_FLAG, defaults.shallow()))
                     .outputCram(booleanOptionWithDefault(commandLine, OUTPUT_CRAM_FLAG, defaults.outputCram()))
@@ -494,6 +494,13 @@ public class CommandLineOptions {
         } catch (NumberFormatException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static Optional<String> uploadKeyPath(final CommandLine commandLine) {
+        if (commandLine.hasOption(UPLOAD_PRIVATE_KEY_FLAG)) {
+            return Optional.of(commandLine.getOptionValue(UPLOAD_PRIVATE_KEY_FLAG));
+        }
+        return Optional.empty();
     }
 
     private static boolean booleanOptionWithDefault(final CommandLine commandLine, final String flag, final boolean defaultValue)


### PR DESCRIPTION
In the interests of eliminating friction for Platinum after we've rolled out 5.31, change as little as possible in the argument handling.

However currently we use defaults for the private key if it is not specified; we don't want to do that anymore as it will interfere with the delegation to defaults when run in GCP.