### PR TITLE
DEV-2974 Add "publish events only" mode/argument

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
@@ -87,6 +87,8 @@ public interface Arguments extends CommonArguments {
 
     Pipeline.Context context();
 
+    boolean publishEventsOnly();
+
     static String workingDir() {
         return System.getProperty("user.dir");
     }
@@ -137,6 +139,7 @@ public interface Arguments extends CommonArguments {
                     .outputCram(true)
                     .publishToTurquoise(false)
                     .publishDbLoadEvent(false)
+                    .publishEventsOnly(false)
                     .pollInterval(DEFAULT_POLL_INTERVAL)
                     .refGenomeVersion(DEFAULT_REF_GENOME_VERSION)
                     .maxConcurrentLanes(DEFAULT_MAX_CONCURRENT_LANES)
@@ -166,6 +169,7 @@ public interface Arguments extends CommonArguments {
                     .outputCram(true)
                     .publishToTurquoise(false)
                     .publishDbLoadEvent(false)
+                    .publishEventsOnly(false)
                     .pollInterval(DEFAULT_POLL_INTERVAL)
                     .refGenomeVersion(DEFAULT_REF_GENOME_VERSION)
                     .maxConcurrentLanes(DEFAULT_MAX_CONCURRENT_LANES)
@@ -200,6 +204,7 @@ public interface Arguments extends CommonArguments {
                     .outputCram(true)
                     .publishToTurquoise(false)
                     .publishDbLoadEvent(false)
+                    .publishEventsOnly(false)
                     .pollInterval(DEFAULT_POLL_INTERVAL)
                     .refGenomeVersion(DEFAULT_REF_GENOME_VERSION)
                     .maxConcurrentLanes(DEFAULT_MAX_CONCURRENT_LANES)
@@ -230,6 +235,7 @@ public interface Arguments extends CommonArguments {
                     .outputCram(true)
                     .publishToTurquoise(false)
                     .publishDbLoadEvent(false)
+                    .publishEventsOnly(false)
                     .pollInterval(DEFAULT_POLL_INTERVAL)
                     .refGenomeVersion(RefGenomeVersion.V38)
                     .maxConcurrentLanes(DEFAULT_MAX_CONCURRENT_LANES)

--- a/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
@@ -77,6 +77,7 @@ public class CommandLineOptions {
     private static final String USE_TARGET_REGIONS = "use_target_regions";
     private static final String PUBLISH_DB_LOAD_EVENT_FLAG = "publish_db_load_event";
     private static final String PUBSUB_TOPIC_WORKFLOW_FLAG = "pubsub_topic_workflow";
+    private static final String PUBLISH_EVENTS_ONLY_FLAG = "publish_events_only";
 
     private static Options options() {
         return new Options().addOption(profile())
@@ -138,7 +139,9 @@ public class CommandLineOptions {
                 .addOption(userLabel())
                 .addOption(useTargetRegions())
                 .addOption(publishDbLoadEvent())
-                .addOption(pubsubTopicWorkflow());
+                .addOption(pubsubTopicWorkflow())
+                .addOption(optionWithBooleanArg(PUBLISH_EVENTS_ONLY_FLAG,
+                        "Compute nothing, only publish events for downstream consumption"));
     }
 
     private static Option useTargetRegions() { return optionWithBooleanArg(USE_TARGET_REGIONS, "Enable target-regions mode"); }
@@ -360,6 +363,7 @@ public class CommandLineOptions {
                     .useTargetRegions(booleanOptionWithDefault(commandLine, USE_TARGET_REGIONS, defaults.useTargetRegions()))
                     .publishDbLoadEvent(booleanOptionWithDefault(commandLine, PUBLISH_DB_LOAD_EVENT_FLAG, defaults.publishDbLoadEvent()))
                     .pubsubTopicWorkflow(pubsubTopicWorkflow(commandLine, defaults))
+                    .publishEventsOnly(booleanOptionWithDefault(commandLine, PUBLISH_EVENTS_ONLY_FLAG, defaults.publishEventsOnly()))
                     .build();
         } catch (ParseException e) {
             LOGGER.error("Could not parse command line args", e);

--- a/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
@@ -14,6 +14,7 @@ import com.hartwig.pipeline.cleanup.CleanupProvider;
 import com.hartwig.pipeline.credentials.CredentialProvider;
 import com.hartwig.pipeline.execution.PipelineStatus;
 import com.hartwig.pipeline.execution.vm.GoogleComputeEngine;
+import com.hartwig.pipeline.execution.vm.NoOpComputeEngine;
 import com.hartwig.pipeline.flagstat.FlagstatOutput;
 import com.hartwig.pipeline.jackson.ObjectMappers;
 import com.hartwig.pipeline.labels.Labels;
@@ -153,12 +154,12 @@ public class PipelineMain {
             final SomaticRunMetadata metadata, final BlockingQueue<BamMetricsOutput> referenceBamMetricsOutputQueue,
             final BlockingQueue<BamMetricsOutput> tumourBamMetricsOutputQueue,
             final BlockingQueue<FlagstatOutput> referenceFlagstatOutputQueue, final BlockingQueue<FlagstatOutput> tumorFlagstatOutputQueue,
-            final StartingPoint startingPoint, final PersistedDataset persistedDataset, final InputMode mode) throws Exception {
+            final StartingPoint startingPoint, final PersistedDataset persistedDataset, final InputMode mode) {
         final Labels labels = Labels.of(arguments, metadata);
         return new SomaticPipeline(arguments,
                 new StageRunner<>(storage,
                         arguments,
-                        GoogleComputeEngine.from(arguments, credentials, labels),
+                        arguments.publishEventsOnly() ? new NoOpComputeEngine() : GoogleComputeEngine.from(arguments, credentials, labels),
                         ResultsDirectory.defaultDirectory(),
                         startingPoint,
                         labels,
@@ -182,7 +183,7 @@ public class PipelineMain {
         return new SingleSamplePipeline(eventListener,
                 new StageRunner<>(storage,
                         arguments,
-                        GoogleComputeEngine.from(arguments, credentials, labels),
+                        arguments.publishEventsOnly() ? new NoOpComputeEngine() : GoogleComputeEngine.from(arguments, credentials, labels),
                         ResultsDirectory.defaultDirectory(),
                         startingPoint,
                         labels,

--- a/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
@@ -154,7 +154,7 @@ public class PipelineMain {
             final SomaticRunMetadata metadata, final BlockingQueue<BamMetricsOutput> referenceBamMetricsOutputQueue,
             final BlockingQueue<BamMetricsOutput> tumourBamMetricsOutputQueue,
             final BlockingQueue<FlagstatOutput> referenceFlagstatOutputQueue, final BlockingQueue<FlagstatOutput> tumorFlagstatOutputQueue,
-            final StartingPoint startingPoint, final PersistedDataset persistedDataset, final InputMode mode) {
+            final StartingPoint startingPoint, final PersistedDataset persistedDataset, final InputMode mode) throws Exception {
         final Labels labels = Labels.of(arguments, metadata);
         return new SomaticPipeline(arguments,
                 new StageRunner<>(storage,

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/AlignerProvider.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/AlignerProvider.java
@@ -48,8 +48,8 @@ public abstract class AlignerProvider {
     }
 
     private static BwaAligner constructVmAligner(final Arguments arguments, final GoogleCredentials credentials, final Storage storage,
-            final SampleSource sampleSource, final SampleUpload sampleUpload, final ResultsDirectory resultsDirectory,
-            final Labels labels) {
+            final SampleSource sampleSource, final SampleUpload sampleUpload, final ResultsDirectory resultsDirectory, final Labels labels)
+            throws Exception {
         ComputeEngine computeEngine =
                 arguments.publishEventsOnly() ? new NoOpComputeEngine() : GoogleComputeEngine.from(arguments, credentials, labels);
         return new BwaAligner(arguments,
@@ -98,14 +98,18 @@ public abstract class AlignerProvider {
 
         @Override
         BwaAligner wireUp(final GoogleCredentials credentials, final Storage storage, final ResultsDirectory resultsDirectory,
-                final Labels labels) {
+                final Labels labels) throws Exception {
             SampleSource sampleSource =
                     getArguments().sampleJson().<SampleSource>map(JsonSampleSource::new).orElse(new GoogleStorageSampleSource(storage,
                             getArguments(),
                             labels));
             GSUtilCloudCopy gsUtilCloudCopy = new GSUtilCloudCopy(getArguments().cloudSdkPath());
             SampleUpload sampleUpload = new CloudSampleUpload(new GSFileSource(), gsUtilCloudCopy);
-            return AlignerProvider.constructVmAligner(getArguments(), credentials, storage, sampleSource, sampleUpload,
+            return AlignerProvider.constructVmAligner(getArguments(),
+                    credentials,
+                    storage,
+                    sampleSource,
+                    sampleUpload,
                     resultsDirectory,
                     labels);
         }
@@ -120,12 +124,17 @@ public abstract class AlignerProvider {
 
         @Override
         BwaAligner wireUp(final GoogleCredentials credentials, final Storage storage, final ResultsDirectory resultsDirectory,
-                final Labels labels) {
+                final Labels labels) throws Exception {
             SbpRestApi sbpRestApi = SbpRestApi.newInstance(getArguments().sbpApiUrl());
             SampleSource sampleSource = new SbpS3SampleSource(new SbpSampleReader(sbpRestApi));
             CloudCopy cloudCopy = new GSUtilCloudCopy(getArguments().cloudSdkPath());
             SampleUpload sampleUpload = new CloudSampleUpload(new GSFileSource(), cloudCopy);
-            return AlignerProvider.constructVmAligner(getArguments(), credentials, storage, sampleSource, sampleUpload, resultsDirectory,
+            return AlignerProvider.constructVmAligner(getArguments(),
+                    credentials,
+                    storage,
+                    sampleSource,
+                    sampleUpload,
+                    resultsDirectory,
                     labels);
         }
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngine.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngine.java
@@ -84,26 +84,30 @@ public class GoogleComputeEngine implements ComputeEngine {
         this.labels = labels;
     }
 
-    public static ComputeEngine from(final CommonArguments arguments, final GoogleCredentials credentials, final Labels labels) {
-        try {
-            final InstancesClient instances =
-                    InstancesClient.create(InstancesSettings.newBuilder().setCredentialsProvider(() -> credentials).build());
-            GoogleComputeEngine engine = new GoogleComputeEngine(arguments,
-                    ZonesClient.create(ZonesSettings.newBuilder().setCredentialsProvider(() -> credentials).build()),
-                    ImagesClient.create(ImagesSettings.newBuilder().setCredentialsProvider(() -> credentials).build()),
-                    Collections::shuffle,
-                    new InstanceLifecycleManager(arguments,
-                            instances,
-                            ZonesClient.create(ZonesSettings.newBuilder().setCredentialsProvider(() -> credentials).build()),
-                            ZoneOperationsClient.create(ZoneOperationsSettings.newBuilder()
-                                    .setCredentialsProvider(() -> credentials)
-                                    .build())),
-                    new BucketCompletionWatcher(),
-                    labels);
-            return new QuotaConstrainedComputeEngine(engine, initServiceUsage(credentials), arguments.region(), arguments.project(), 0.6);
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to initialise compute engine", e);
-        }
+    public static ComputeEngine from(final CommonArguments arguments, final GoogleCredentials credentials, final Labels labels)
+            throws Exception {
+        return from(arguments, credentials, true, labels);
+    }
+
+    public static ComputeEngine from(final CommonArguments arguments, final GoogleCredentials credentials, final boolean constrainQuotas,
+            final Labels labels) throws Exception {
+        final InstancesClient instances =
+                InstancesClient.create(InstancesSettings.newBuilder().setCredentialsProvider(() -> credentials).build());
+        GoogleComputeEngine engine = new GoogleComputeEngine(arguments,
+                ZonesClient.create(ZonesSettings.newBuilder().setCredentialsProvider(() -> credentials).build()),
+                ImagesClient.create(ImagesSettings.newBuilder().setCredentialsProvider(() -> credentials).build()),
+                Collections::shuffle,
+                new InstanceLifecycleManager(arguments,
+                        instances,
+                        ZonesClient.create(ZonesSettings.newBuilder().setCredentialsProvider(() -> credentials).build()),
+                        ZoneOperationsClient.create(ZoneOperationsSettings.newBuilder().setCredentialsProvider(() -> credentials).build())),
+                new BucketCompletionWatcher(),
+                labels);
+        return constrainQuotas ? new QuotaConstrainedComputeEngine(engine,
+                initServiceUseage(credentials),
+                arguments.region(),
+                arguments.project(),
+                0.6) : engine;
     }
 
     public PipelineStatus submit(final RuntimeBucket bucket, final VirtualMachineJobDefinition jobDefinition) {
@@ -221,7 +225,7 @@ public class GoogleComputeEngine implements ComputeEngine {
         return result.getError().getErrorsList().stream().anyMatch(error -> error.getCode().startsWith(errorCode));
     }
 
-    private static ServiceUsage initServiceUsage(final GoogleCredentials credentials) throws Exception {
+    private static ServiceUsage initServiceUseage(final GoogleCredentials credentials) throws Exception {
         HttpTransport http = GoogleNetHttpTransport.newTrustedTransport();
         JsonFactory json = GsonFactory.getDefaultInstance();
         return new ServiceUsage.Builder(http, json, new HttpCredentialsAdapter(credentials)).setApplicationName(APPLICATION_NAME).build();
@@ -245,7 +249,7 @@ public class GoogleComputeEngine implements ComputeEngine {
     }
 
     private Image attachDisks(final Instance.Builder instanceBuilder, final VirtualMachineJobDefinition jobDefinition,
-            final String projectName, final String zone, final Image sourceImage, final Map<String, String> labels) {
+            final String projectName, final String zone, final Image sourceImage, final Map<String, String> labels) throws IOException {
         AttachedDisk bootDisk = AttachedDisk.newBuilder()
                 .setBoot(true)
                 .setAutoDelete(true)
@@ -306,7 +310,8 @@ public class GoogleComputeEngine implements ComputeEngine {
         instance.setMetadata(startupMetadata);
     }
 
-    private Image resolveLatestImage(final ImagesClient images, final String sourceImageFamily, final String projectName) {
+    private Image resolveLatestImage(final ImagesClient images, final String sourceImageFamily, final String projectName)
+            throws IOException {
         Image image = images.getFromFamily(projectName, sourceImageFamily);
         if (image != null) {
             return image;
@@ -345,7 +350,7 @@ public class GoogleComputeEngine implements ComputeEngine {
         });
     }
 
-    private List<Zone> fetchZones() {
+    private List<Zone> fetchZones() throws IOException {
         return StreamSupport.stream(zonesClient.list(arguments.project()).iterateAll().spliterator(), false)
                 .filter(zone -> zone.getRegion().endsWith(arguments.region()))
                 .collect(Collectors.toList());

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/NoOpComputeEngine.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/NoOpComputeEngine.java
@@ -1,0 +1,23 @@
+package com.hartwig.pipeline.execution.vm;
+
+import com.hartwig.pipeline.execution.PipelineStatus;
+import com.hartwig.pipeline.storage.RuntimeBucket;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class NoOpComputeEngine implements ComputeEngine {
+    private static final Logger LOGGER = LoggerFactory.getLogger(NoOpComputeEngine.class);
+
+    @Override
+    public PipelineStatus submit(final RuntimeBucket bucket, final VirtualMachineJobDefinition jobDefinition) {
+        LOGGER.info("Skipping compute on event-only pipeline invocation");
+        return PipelineStatus.SUCCESS;
+    }
+
+    @Override
+    public PipelineStatus submit(final RuntimeBucket bucket, final VirtualMachineJobDefinition jobDefinition, final String discriminator) {
+        LOGGER.info("Skipping compute on event-only pipeline invocation");
+        return PipelineStatus.SUCCESS;
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/report/PipelineResults.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/report/PipelineResults.java
@@ -24,12 +24,14 @@ public class PipelineResults {
     private final String version;
     private final Storage storage;
     private final Bucket reportBucket;
+    private final boolean isNoOp;
     private final List<ReportComponent> components = new ArrayList<>();
 
-    PipelineResults(final String version, final Storage storage, final Bucket reportBucket) {
+    PipelineResults(final String version, final Storage storage, final Bucket reportBucket, final boolean isNoOp) {
         this.version = version;
         this.storage = storage;
         this.reportBucket = reportBucket;
+        this.isNoOp = isNoOp;
     }
 
     public <T extends StageOutput> T add(final T stageOutput) {
@@ -40,10 +42,14 @@ public class PipelineResults {
     }
 
     public void compose(final RunMetadata metadata, final String qualifier) {
-        String name = metadata.set();
-        Folder folder = Folder.root();
-        writeMetadata(metadata, name, folder);
-        compose(name, folder, qualifier);
+        if (!isNoOp) {
+            String name = metadata.set();
+            Folder folder = Folder.root();
+            writeMetadata(metadata, name, folder);
+            compose(name, folder, qualifier);
+        } else {
+            LOGGER.info("Skipping composition as this pipeline invocation will only publish events");
+        }
     }
 
     private void compose(final String name, final Folder folder, final String qualifier) {

--- a/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageCommandBuilderTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/calling/sage/SageCommandBuilderTest.java
@@ -22,21 +22,17 @@ public class SageCommandBuilderTest {
 
     private static final String REFERENCE_OUT = VmDirectories.OUTPUT + "/" + REFERENCE + ".out.vcf.gz";
     private static final String REFERENCE_SAGE_COMMAND =
-            "java -Xmx31G -jar /opt/tools/sage/3.1.1/sage.jar "
-                    + "-tumor COLO829v003R -tumor_bam /data/input/COLO829v003R.bam "
+            "java -Xmx31G -jar /opt/tools/sage/3.1.1/sage.jar " + "-tumor COLO829v003R -tumor_bam /data/input/COLO829v003R.bam "
                     + "-reference COLO829v003T -reference_bam /data/input/COLO829v003T.bam "
                     + "-hotspots /opt/resources/sage/37/KnownHotspots.germline.37.vcf.gz "
                     + "-hotspot_min_tumor_qual 50 -panel_min_tumor_qual 75 -hotspot_max_germline_vaf 100 -hotspot_max_germline_rel_raw_base_qual 100 "
                     + "-panel_max_germline_vaf 100 -panel_max_germline_rel_raw_base_qual 100 -mnv_filter_enabled false "
-                    + "-panel_only "
+                    + "-panel_only -ref_sample_count 0 "
                     + "-high_confidence_bed /opt/resources/giab_high_conf/37/NA12878_GIAB_highconf_IllFB-IllGATKHC-CG-Ion-Solid_ALLCHROM_v3.2.2_highconf.bed.gz "
                     + "-panel_bed /opt/resources/sage/37/ActionableCodingPanel.37.bed.gz "
-                    + "-ref_genome /opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta "
-                    + "-ref_genome_version V37 "
-                    + "-ensembl_data_dir /opt/resources/ensembl_data_cache/37/ "
-                    + "-write_bqr_data -write_bqr_plot "
-                    + "-out /data/output/COLO829v003R.out.vcf.gz "
-                    + "-threads $(grep -c '^processor' /proc/cpuinfo)";
+                    + "-ref_genome /opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta " + "-ref_genome_version V37 "
+                    + "-ensembl_data_dir /opt/resources/ensembl_data_cache/37/ " + "-write_bqr_data -write_bqr_plot "
+                    + "-out /data/output/COLO829v003R.out.vcf.gz " + "-threads $(grep -c '^processor' /proc/cpuinfo)";
 
     @Test
     public void runsOnGermlineBam() {


### PR DESCRIPTION
This will allow us to escape from the current situation in which the events for the 5.30 rerun have expired leaving us with no way to archive them now that they have been verified.

By invoking the pipeline with the new argument set we should incur little cost and also be more-confident of the correct outcome than if we were for instance trying to construct the datasets out of the data in the output bucket.

Also fix the `SageCommandBuilderTest` which appears to have been broken since the last commit to the hotfix branch.

I don't love the name of the argument but want to get across that it's not purely a "no op" since it does publish events, but it's also doing none of the heavy lifting that a full pipeline run does. Suggestions welcome.