### PR TITLE
DEV-2991 Handle GCP InvalidArgumentException

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/failsafe/DefaultBackoffPolicy.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/failsafe/DefaultBackoffPolicy.java
@@ -3,6 +3,8 @@ package com.hartwig.pipeline.failsafe;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
 
+import com.google.api.gax.rpc.InvalidArgumentException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,6 +17,8 @@ public class DefaultBackoffPolicy<R> extends RetryPolicy<R> {
     DefaultBackoffPolicy(final int delay, final long maxDelay, final String taskName) {
         withBackoff(delay, maxDelay, ChronoUnit.SECONDS);
         withMaxRetries(-1);
+        abortOn(InvalidArgumentException.class);
+        onAbort(e -> LOGGER.error("Unable to submit operation", e.getFailure()));
         handle(Exception.class);
         onFailedAttempt(rExecutionAttemptedEvent -> LOGGER.warn("[{}] failed: {}",
                 taskName,


### PR DESCRIPTION
We have witnessed this exception multiple times in production but it does not reproduce easily. Because we retry forever when there is any issue this bug threatens the stability and turnaround characteristics of the pipeline, since once it has been encountered once in a given invocation it will never succeed. We have also seen it in the batch framework.

The current handling mechanism just prints out the message from any exception; I have decided to abort when this specific exception is encountered and instead of retrying print the full stack trace. If nothing else maybe we will get hints on what is happening so we can address the root cause. This will also ensure the pipeline doesn't sit forever but instead the rest of our framework will restart the job.

In my testing this approach results in a proper error message being printed and from what I can tell a proper death of the thread containing the retry loop. Hopefully this holds in the wild but I'm limited in how well I can unit test this code while still retaining a realistic representation of how the GCP libraries behave in use.