### PR TITLE
DEV-3035 Run germline caller for research runs

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/calling/germline/GermlineCaller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/germline/GermlineCaller.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.hartwig.events.pipeline.Pipeline;
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.ResultsDirectory;
 import com.hartwig.pipeline.alignment.AlignmentOutput;
@@ -183,6 +184,6 @@ public class GermlineCaller implements Stage<GermlineCallerOutput, SingleSampleR
 
     @Override
     public boolean shouldRun(final Arguments arguments) {
-        return arguments.runGermlineCaller() && !arguments.shallow();
+        return arguments.runGermlineCaller() && arguments.context().equals(Pipeline.Context.RESEARCH) && !arguments.shallow();
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/calling/germline/GermlineCaller.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/calling/germline/GermlineCaller.java
@@ -184,6 +184,6 @@ public class GermlineCaller implements Stage<GermlineCallerOutput, SingleSampleR
 
     @Override
     public boolean shouldRun(final Arguments arguments) {
-        return arguments.runGermlineCaller() && arguments.context().equals(Pipeline.Context.RESEARCH) && !arguments.shallow();
+        return arguments.runGermlineCaller() && !arguments.context().equals(Pipeline.Context.DIAGNOSTIC) && !arguments.shallow();
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/reruns/StartingPoint.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/reruns/StartingPoint.java
@@ -45,11 +45,7 @@ public class StartingPoint {
 
     enum StartingPoints {
         BEGINNING(Collections.emptyList()),
-        ALIGNMENT_COMPLETE(List.of(Aligner.NAMESPACE,
-                BamMetrics.NAMESPACE,
-                GermlineCaller.NAMESPACE,
-                Flagstat.NAMESPACE,
-                SnpGenotype.NAMESPACE)),
+        ALIGNMENT_COMPLETE(List.of(Aligner.NAMESPACE, BamMetrics.NAMESPACE, Flagstat.NAMESPACE, SnpGenotype.NAMESPACE)),
         CRAM_COMPLETE(concat(ALIGNMENT_COMPLETE.namespaces, List.of(CramConversion.NAMESPACE))),
         SKIP_GRIDSS(List.of(Aligner.NAMESPACE,
                 BamMetrics.NAMESPACE,


### PR DESCRIPTION
Remove germline caller from the skipped stages in alignment complete starting point.

Don't run the germline caller if the context is not research. 