### PR TITLE
DEV-3142 Add billing project for alignment output

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/bwa/BwaAligner.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/bwa/BwaAligner.java
@@ -82,14 +82,10 @@ public class BwaAligner implements Aligner {
 
         SampleInput sample = Inputs.sampleFor(input, metadata);
         if (sample.bam().isPresent()) {
-            String noPrefix = sample.bam().orElseThrow().replace("gs://", "");
-            int firstSlash = noPrefix.indexOf("/");
-            String bucket = noPrefix.substring(0, firstSlash);
-            String path = noPrefix.substring(firstSlash + 1);
             return AlignmentOutput.builder()
                     .sample(metadata.sampleName())
                     .status(PipelineStatus.PROVIDED)
-                    .maybeAlignments(GoogleStorageLocation.of(bucket, path))
+                    .maybeAlignments(GoogleStorageLocation.from(sample.bam().get(), arguments.project()))
                     .build();
         }
         final ResourceFiles resourceFiles = buildResourceFiles(arguments);

--- a/cluster/src/test/java/com/hartwig/pipeline/alignment/bwa/BwaAlignerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/alignment/bwa/BwaAlignerTest.java
@@ -34,7 +34,6 @@ import org.mockito.ArgumentCaptor;
 public class BwaAlignerTest {
 
     private static final SingleSampleRunMetadata METADATA = TestInputs.referenceRunMetadata();
-    private static final AlignmentOutput ALIGNMENT_OUTPUT = TestInputs.referenceAlignmentOutput();
     private BwaAligner victim;
     private SampleUpload sampleUpload;
     private Storage storage;
@@ -105,12 +104,9 @@ public class BwaAlignerTest {
 
     @Test
     public void returnsProvidedBamIfInSample() throws Exception {
-        PipelineInput input = PipelineInput.builder()
-                .reference(SampleInput.builder()
-                        .name(METADATA.sampleName())
-                        .bam("gs://bucket/path/reference.bam")
-                        .build())
-                .build();
+        String gsUrl = "gs://bucket/path/reference.bam";
+        PipelineInput input =
+                PipelineInput.builder().reference(SampleInput.builder().name(METADATA.sampleName()).bam(gsUrl).build()).build();
         victim = new BwaAligner(arguments,
                 computeEngine,
                 storage,
@@ -120,7 +116,7 @@ public class BwaAlignerTest {
                 Executors.newSingleThreadExecutor(),
                 mock(Labels.class));
         AlignmentOutput output = victim.run(METADATA);
-        assertThat(output.alignments()).isEqualTo(GoogleStorageLocation.of("bucket", "path/reference.bam"));
+        assertThat(output.alignments()).isEqualTo(GoogleStorageLocation.from(gsUrl, arguments.project()));
         assertThat(output.sample()).isEqualTo(METADATA.sampleName());
         assertThat(output.status()).isEqualTo(PipelineStatus.PROVIDED);
     }


### PR DESCRIPTION
I think this was a side-effect of the PDL conversion. Without this change there is no user project set on the inputs, so for instance cram2bam will not be able to fetch the CRAMs to do its work.