### PR TITLE
DEV-3144 Pull in set name from PDL

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
@@ -41,7 +41,7 @@ public interface Arguments extends CommonArguments {
 
     DefaultsProfile profile();
 
-    String setId();
+    String setName();
 
     Optional<String> biopsy();
 
@@ -125,7 +125,7 @@ public interface Arguments extends CommonArguments {
                     .runGermlineCaller(true)
                     .runTertiary(true)
                     .shallow(false)
-                    .setId(EMPTY)
+                    .setName(EMPTY)
                     .cmek(EMPTY)
                     .outputBucket(DEFAULT_PRODUCTION_PATIENT_REPORT_BUCKET)
                     .uploadPrivateKeyPath(Optional.empty())
@@ -157,7 +157,7 @@ public interface Arguments extends CommonArguments {
                     .runGermlineCaller(true)
                     .runTertiary(true)
                     .shallow(false)
-                    .setId(EMPTY)
+                    .setName(EMPTY)
                     .outputBucket(DEFAULT_DEVELOPMENT_PATIENT_REPORT_BUCKET)
                     .uploadPrivateKeyPath(DEFAULT_DEVELOPMENT_KEY_PATH)
                     .outputCram(true)
@@ -192,7 +192,7 @@ public interface Arguments extends CommonArguments {
                     .runGermlineCaller(true)
                     .runTertiary(true)
                     .shallow(false)
-                    .setId(EMPTY)
+                    .setName(EMPTY)
                     .outputBucket(DEFAULT_DEVELOPMENT_PATIENT_REPORT_BUCKET)
                     .uploadPrivateKeyPath(DEFAULT_DOCKER_UPLOAD_KEY_PATH)
                     .network(DEFAULT_NETWORK)
@@ -225,7 +225,7 @@ public interface Arguments extends CommonArguments {
                     .runGermlineCaller(true)
                     .runTertiary(true)
                     .shallow(false)
-                    .setId(EMPTY)
+                    .setName(EMPTY)
                     .uploadPrivateKeyPath(DEFAULT_DOCKER_UPLOAD_KEY_PATH)
                     .network(DEFAULT_NETWORK)
                     .outputCram(true)

--- a/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
@@ -50,7 +50,7 @@ public class CommandLineOptions {
     private static final String RUN_CUPPA_FLAG = "run_cuppa";
     private static final String OUTPUT_BUCKET_FLAG = "output_bucket";
     private static final String UPLOAD_PRIVATE_KEY_FLAG = "upload_private_key_path";
-    private static final String SET_ID_FLAG = "set_id";
+    private static final String SET_NAME_FLAG = "set_id";
     private static final String NETWORK_FLAG = "network";
     private static final String SUBNET_FLAG = "subnet";
     private static final String NETWORK_TAGS_FLAG = "network_tags";
@@ -186,6 +186,7 @@ public class CommandLineOptions {
     private static Option biopsy() {
         return optionWithArg(BIOPSY_FLAG, "Name of the biopsy registered in the API.");
     }
+
     private static Option hmfApiUrl() {
         return optionWithArg(HMF_API_URL_FLAG, "URL of the HMF-API.");
     }
@@ -229,7 +230,7 @@ public class CommandLineOptions {
     }
 
     private static Option setId() {
-        return optionWithArg(SET_ID_FLAG,
+        return optionWithArg(SET_NAME_FLAG,
                 "The id of the set for which to run a somatic pipeline. A set represents a valid reference/tumor pair (ie CPCT12345678). "
                         + "Can only be used when mode is somatic and the single sample pipelines have been run for each sample");
     }
@@ -300,7 +301,8 @@ public class CommandLineOptions {
             CommandLine commandLine = defaultParser.parse(options(), args);
             Arguments defaults = Arguments.defaults(commandLine.getOptionValue(PROFILE_FLAG, DEFAULT_PROFILE));
 
-            return Arguments.builder().setName(commandLine.getOptionValue(SET_ID_FLAG, defaults.setName()))
+            return Arguments.builder()
+                    .setName(commandLine.getOptionValue(SET_NAME_FLAG, defaults.setName()))
                     .privateKeyPath(CommonArguments.privateKey(commandLine).or(defaults::privateKeyPath))
                     .project(commandLine.getOptionValue(PROJECT_FLAG, defaults.project()))
                     .region(handleDashesInRegion(commandLine, defaults.region()))

--- a/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
@@ -300,8 +300,7 @@ public class CommandLineOptions {
             CommandLine commandLine = defaultParser.parse(options(), args);
             Arguments defaults = Arguments.defaults(commandLine.getOptionValue(PROFILE_FLAG, DEFAULT_PROFILE));
 
-            return Arguments.builder()
-                    .setId(commandLine.getOptionValue(SET_ID_FLAG, defaults.setId()))
+            return Arguments.builder().setName(commandLine.getOptionValue(SET_ID_FLAG, defaults.setName()))
                     .privateKeyPath(CommonArguments.privateKey(commandLine).or(defaults::privateKeyPath))
                     .project(commandLine.getOptionValue(PROJECT_FLAG, defaults.project()))
                     .region(handleDashesInRegion(commandLine, defaults.region()))

--- a/cluster/src/main/java/com/hartwig/pipeline/RunTag.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/RunTag.java
@@ -2,9 +2,9 @@ package com.hartwig.pipeline;
 
 public class RunTag {
 
-    public static String apply(final CommonArguments arguments, final String id) {
+    public static String apply(final CommonArguments arguments, final String setName) {
         return arguments.runTag()
-                .map(runId -> id + "-" + runId)
-                .orElse(id + arguments.sbpApiRunId().map(String::valueOf).map(str -> "-" + str).orElse(""));
+                .map(runId -> setName + "-" + runId)
+                .orElse(setName + arguments.sbpApiRunId().map(String::valueOf).map(str -> "-" + str).orElse(""));
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/input/MetadataProvider.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/input/MetadataProvider.java
@@ -19,24 +19,19 @@ public class MetadataProvider {
     }
 
     public SomaticRunMetadata get() {
-        String setId = RunTag.apply(arguments, arguments.setId());
+        String setName = RunTag.apply(arguments, pipelineInput.setName().orElse(arguments.setName()));
         Optional<SampleInput> reference = Inputs.sample(pipelineInput, SampleType.REFERENCE);
         Optional<SampleInput> tumor = Inputs.sample(pipelineInput, SampleType.TUMOR);
 
-        return SomaticRunMetadata.builder()
-                .set(setId)
+        return SomaticRunMetadata.builder().set(setName)
                 .bucket(arguments.outputBucket())
-                .maybeTumor(tumor.map(t -> SingleSampleRunMetadata.builder()
-                        .bucket(arguments.outputBucket())
-                        .set(setId)
+                .maybeTumor(tumor.map(t -> SingleSampleRunMetadata.builder().bucket(arguments.outputBucket()).set(setName)
                         .type(SingleSampleRunMetadata.SampleType.TUMOR)
                         .barcode(t.name())
                         .sampleName(t.name())
                         .primaryTumorDoids(t.primaryTumorDoids())
                         .build()))
-                .maybeReference(reference.map(r -> SingleSampleRunMetadata.builder()
-                        .bucket(arguments.outputBucket())
-                        .set(setId)
+                .maybeReference(reference.map(r -> SingleSampleRunMetadata.builder().bucket(arguments.outputBucket()).set(setName)
                         .type(SingleSampleRunMetadata.SampleType.REFERENCE)
                         .barcode(r.name())
                         .sampleName(r.name())

--- a/cluster/src/main/java/com/hartwig/pipeline/input/MetadataProvider.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/input/MetadataProvider.java
@@ -23,15 +23,20 @@ public class MetadataProvider {
         Optional<SampleInput> reference = Inputs.sample(pipelineInput, SampleType.REFERENCE);
         Optional<SampleInput> tumor = Inputs.sample(pipelineInput, SampleType.TUMOR);
 
-        return SomaticRunMetadata.builder().set(setName)
+        return SomaticRunMetadata.builder()
+                .set(setName)
                 .bucket(arguments.outputBucket())
-                .maybeTumor(tumor.map(t -> SingleSampleRunMetadata.builder().bucket(arguments.outputBucket()).set(setName)
+                .maybeTumor(tumor.map(t -> SingleSampleRunMetadata.builder()
+                        .bucket(arguments.outputBucket())
+                        .set(setName)
                         .type(SingleSampleRunMetadata.SampleType.TUMOR)
                         .barcode(t.name())
                         .sampleName(t.name())
                         .primaryTumorDoids(t.primaryTumorDoids())
                         .build()))
-                .maybeReference(reference.map(r -> SingleSampleRunMetadata.builder().bucket(arguments.outputBucket()).set(setName)
+                .maybeReference(reference.map(r -> SingleSampleRunMetadata.builder()
+                        .bucket(arguments.outputBucket())
+                        .set(setName)
                         .type(SingleSampleRunMetadata.SampleType.REFERENCE)
                         .barcode(r.name())
                         .sampleName(r.name())

--- a/cluster/src/test/java/com/hartwig/pipeline/CommandLineOptionsTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/CommandLineOptionsTest.java
@@ -35,7 +35,7 @@ public class CommandLineOptionsTest {
     @Test
     public void defaultOptionsCanBeOverridden() throws Exception {
         Arguments result = CommandLineOptions.from(new String[] { "-profile", "development", "-set_id", OVERRIDDEN_SET_ID });
-        assertThat(result.setId()).isEqualTo(OVERRIDDEN_SET_ID);
+        assertThat(result.setName()).isEqualTo(OVERRIDDEN_SET_ID);
     }
 
     @Test

--- a/cluster/src/test/java/com/hartwig/pipeline/smoke/SmokeTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/smoke/SmokeTest.java
@@ -96,7 +96,7 @@ public class SmokeTest {
                 .context(Pipeline.Context.PLATINUM)
                 .sampleJson(Resources.testResource(fixtureDir + "samples.json"))
                 .cloudSdkPath(findCloudSdk())
-                .setId(setName)
+                .setName(setName)
                 .runTag(randomRunId)
                 .runGermlineCaller(false)
                 .outputBucket("smoketest-pipeline-output-pilot-1")

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <java-client.version>1.31.1</java-client.version>
         <compar.version>0.0.3</compar.version>
         <org-reflections.version>0.9.11</org-reflections.version>
-        <pdl.version>0.1.1</pdl.version>
+        <pdl.version>local-SNAPSHOT</pdl.version>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <java-client.version>1.31.1</java-client.version>
         <compar.version>0.0.3</compar.version>
         <org-reflections.version>0.9.11</org-reflections.version>
-        <pdl.version>local-SNAPSHOT</pdl.version>
+        <pdl.version>0.2.0</pdl.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
Prefer the PDL set name to the command-line argument. Also rename the command line option as `set_id` is confusing, it's a name.

I think I must be missing something here, seems like there should be more references to this parameter.