### PR TITLE
DEV-3146 Shutdown at end of startup script

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/BashStartupScript.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/BashStartupScript.java
@@ -53,13 +53,13 @@ public class BashStartupScript {
                 format("  gsutil -m cp %s gs://%s", localLogFile, runtimeBucketName),
                 format("  echo $exit_code > %s", jobFailedFlag),
                 format("  gsutil -m cp %s gs://%s", jobFailedFlag, runtimeBucketName),
-                "  exit $exit_code\n" + "}\n"));
+                "  shutdown -h now\n" + "}\n"));
         preamble.addAll(storageStrategy.initialise());
         preamble.add("ulimit -n 102400");
         addCompletionCommands();
         return String.join("\n", preamble) + "\n" + commands.stream().collect(joining(format("%s\n", commandSuffix))) + (commands.isEmpty()
                 ? ""
-                : commandSuffix);
+                : commandSuffix) + "\nshutdown -h now";
     }
 
     BashStartupScript addLine(final String lineOne) {

--- a/cluster/src/test/resources/script_generation/complete_script-local_ssds
+++ b/cluster/src/test/resources/script_generation/complete_script-local_ssds
@@ -8,7 +8,7 @@ function die() {
   gsutil -m cp /var/log/run.log gs://outputBucket
   echo $exit_code > /tmp/JOB_FAILURE
   gsutil -m cp /tmp/JOB_FAILURE gs://outputBucket
-  exit $exit_code
+  shutdown -h now
 }
 
 mkdir -p /data
@@ -26,3 +26,4 @@ uname -a >>/var/log/run.log 2>&1 || die
 echo $(date "+%Y-%m-%d %H:%M:%S") "Running command ComplexCommand with bash: not_really_so_complex \"quoted\"" >>/var/log/run.log 2>&1 || die
 not_really_so_complex "quoted" >>/var/log/run.log 2>&1 || die
 (echo 0 > /tmp/JOB_SUCCESS && gsutil cp /tmp/JOB_SUCCESS gs://outputBucket) >>/var/log/run.log 2>&1 || die
+shutdown -h now

--- a/cluster/src/test/resources/script_generation/complete_script-persistent_storage
+++ b/cluster/src/test/resources/script_generation/complete_script-persistent_storage
@@ -8,7 +8,7 @@ function die() {
   gsutil -m cp /var/log/run.log gs://outputBucket
   echo $exit_code > /tmp/JOB_FAILURE
   gsutil -m cp /tmp/JOB_FAILURE gs://outputBucket
-  exit $exit_code
+  shutdown -h now
 }
 
 ulimit -n 102400
@@ -22,3 +22,4 @@ uname -a >>/var/log/run.log 2>&1 || die
 echo $(date "+%Y-%m-%d %H:%M:%S") "Running command ComplexCommand with bash: not_really_so_complex \"quoted\"" >>/var/log/run.log 2>&1 || die
 not_really_so_complex "quoted" >>/var/log/run.log 2>&1 || die
 (echo 0 > /tmp/JOB_SUCCESS && gsutil cp /tmp/JOB_SUCCESS gs://outputBucket) >>/var/log/run.log 2>&1 || die
+shutdown -h now


### PR DESCRIPTION
I've tested this and it appears to work correctly but there may be some corner cases.

Just shut down the VM when it finishes doing its work. We never ended up using the exit code on-VM so replace the "exit" command with it in the "die" block.