### PR TITLE
DEV-3153 Reorder event publishing and API update

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/metadata/HmfApiStatusUpdate.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/metadata/HmfApiStatusUpdate.java
@@ -5,53 +5,77 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 import com.hartwig.api.RunApi;
-import com.hartwig.api.model.Run;
 import com.hartwig.api.model.RunFailure;
 import com.hartwig.api.model.Status;
 import com.hartwig.api.model.UpdateRun;
+import com.hartwig.pdl.OperationalReferences;
 import com.hartwig.pdl.PipelineInput;
 import com.hartwig.pipeline.Arguments;
-import com.hartwig.pipeline.PipelineState;
 import com.hartwig.pipeline.execution.PipelineStatus;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class HmfApiStatusUpdate {
-
-    private final static Logger LOGGER = LoggerFactory.getLogger(HmfApiStatusUpdate.class);
-    private static final String PIPELINE_SOURCE = "Pipeline";
-    private static final String HEALTH_CHECK = "HealthCheck";
-    private final RunApi runApi;
-
-    public HmfApiStatusUpdate(final RunApi runApi) {
-        this.runApi = runApi;
-    }
-
-    public void start(final Long runId) {
-        LOGGER.info("Recording pipeline start status in hmf-api [{}]", Status.PROCESSING);
-        runApi.update(runId, new UpdateRun().failure(null).status(Status.PROCESSING).startTime(timestamp()));
-    }
-
-    public void finish(final Long runId, final PipelineStatus pipelineStatus) {
-        LOGGER.info("Recording pipeline finish status in hmf-api [{}]", pipelineStatus);
-        runApi.update(runId, statusUpdate(pipelineStatus).endTime(timestamp()));
-    }
-
-    private static UpdateRun statusUpdate(final PipelineStatus status) {
-        switch (status) {
-            case FAILED:
-                return new UpdateRun().status(Status.FAILED)
-                        .failure(new RunFailure().type(RunFailure.TypeEnum.TECHNICALFAILURE).source(PIPELINE_SOURCE));
-            case QC_FAILED:
-                return new UpdateRun().status(Status.FAILED)
-                        .failure(new RunFailure().type(RunFailure.TypeEnum.QCFAILURE).source(HEALTH_CHECK));
-            default:
-                return new UpdateRun().status(Status.FINISHED);
+public interface HmfApiStatusUpdate {
+    static HmfApiStatusUpdate from(final Arguments arguments, final RunApi runApi, final PipelineInput input) {
+        if (arguments.hmfApiUrl().isPresent()) {
+            return new RealApiStatusUpdate(runApi, input.operationalReferences().map(OperationalReferences::runId).orElseThrow());
+        } else {
+            return new NoOpStatusUpdate();
         }
     }
 
-    private static String timestamp() {
-        return ZonedDateTime.now(ZoneOffset.UTC).toLocalDateTime().format(DateTimeFormatter.ISO_DATE_TIME);
+    void start();
+
+    void finish(PipelineStatus status);
+
+    class NoOpStatusUpdate implements HmfApiStatusUpdate {
+        @Override
+        public void start() {
+        }
+
+        @Override
+        public void finish(final PipelineStatus status) {
+        }
+    }
+
+    class RealApiStatusUpdate implements HmfApiStatusUpdate {
+        private final static Logger LOGGER = LoggerFactory.getLogger(HmfApiStatusUpdate.class);
+        private static final String PIPELINE_SOURCE = "Pipeline";
+        private static final String HEALTH_CHECK = "HealthCheck";
+        private final RunApi runApi;
+        private Long runId;
+
+        public RealApiStatusUpdate(final RunApi runApi, final Long runId) {
+            this.runApi = runApi;
+            this.runId = runId;
+        }
+
+        public void start() {
+            LOGGER.info("Recording pipeline start status in hmf-api [{}]", Status.PROCESSING);
+            runApi.update(runId, new UpdateRun().failure(null).status(Status.PROCESSING).startTime(timestamp()));
+        }
+
+        public void finish(final PipelineStatus pipelineStatus) {
+            LOGGER.info("Recording pipeline finish status in hmf-api [{}]", pipelineStatus);
+            runApi.update(runId, statusUpdate(pipelineStatus).endTime(timestamp()));
+        }
+
+        private static UpdateRun statusUpdate(final PipelineStatus status) {
+            switch (status) {
+                case FAILED:
+                    return new UpdateRun().status(Status.FAILED)
+                            .failure(new RunFailure().type(RunFailure.TypeEnum.TECHNICALFAILURE).source(PIPELINE_SOURCE));
+                case QC_FAILED:
+                    return new UpdateRun().status(Status.FAILED)
+                            .failure(new RunFailure().type(RunFailure.TypeEnum.QCFAILURE).source(HEALTH_CHECK));
+                default:
+                    return new UpdateRun().status(Status.FINISHED);
+            }
+        }
+
+        private static String timestamp() {
+            return ZonedDateTime.now(ZoneOffset.UTC).toLocalDateTime().format(DateTimeFormatter.ISO_DATE_TIME);
+        }
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/FullPipelineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/FullPipelineTest.java
@@ -17,6 +17,7 @@ import com.hartwig.pipeline.alignment.ImmutableAlignmentOutput;
 import com.hartwig.pipeline.cram.cleanup.Cleanup;
 import com.hartwig.pipeline.execution.PipelineStatus;
 import com.hartwig.pipeline.input.SomaticRunMetadata;
+import com.hartwig.pipeline.metadata.HmfApiStatusUpdate;
 import com.hartwig.pipeline.metrics.BamMetricsOutput;
 import com.hartwig.pipeline.output.OutputPublisher;
 import com.hartwig.pipeline.testsupport.TestInputs;
@@ -56,7 +57,8 @@ public class FullPipelineTest {
                 referenceListener,
                 tumorListener,
                 cleanup,
-                outputPublisher);
+                outputPublisher,
+                mock(HmfApiStatusUpdate.class));
     }
 
     @Test


### PR DESCRIPTION
This necessitated a refactor as the "finish" update for the API could no longer
be in the top-level `PipelineMain` class and some of the data required was not
being passed further down into the `FullPipeline` instance.