### PR TITLE
DEV-3163 Disable ROSE and PROTECT for research

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/protect/Protect.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/protect/Protect.java
@@ -188,6 +188,6 @@ public class Protect implements Stage<ProtectOutput, SomaticRunMetadata> {
 
     @Override
     public boolean shouldRun(final Arguments arguments) {
-        return arguments.runTertiary() && !arguments.shallow() && !(arguments.context() == Context.RESEARCH);
+        return arguments.runTertiary() && !arguments.shallow() && arguments.context() != Context.RESEARCH;
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/protect/Protect.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/protect/Protect.java
@@ -4,6 +4,7 @@ import static com.hartwig.pipeline.execution.vm.InputDownload.initialiseOptional
 
 import java.util.List;
 
+import com.hartwig.events.pipeline.Pipeline.Context;
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.ResultsDirectory;
 import com.hartwig.pipeline.datatypes.DataType;
@@ -15,9 +16,9 @@ import com.hartwig.pipeline.execution.vm.InputDownload;
 import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
 import com.hartwig.pipeline.execution.vm.VirtualMachinePerformanceProfile;
 import com.hartwig.pipeline.execution.vm.VmDirectories;
+import com.hartwig.pipeline.input.SomaticRunMetadata;
 import com.hartwig.pipeline.output.AddDatatype;
 import com.hartwig.pipeline.output.ArchivePath;
-import com.hartwig.pipeline.input.SomaticRunMetadata;
 import com.hartwig.pipeline.report.EntireOutputComponent;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.report.RunLogComponent;
@@ -187,6 +188,6 @@ public class Protect implements Stage<ProtectOutput, SomaticRunMetadata> {
 
     @Override
     public boolean shouldRun(final Arguments arguments) {
-        return arguments.runTertiary() && !arguments.shallow();
+        return arguments.runTertiary() && !arguments.shallow() && !(arguments.context() == Context.RESEARCH);
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/rose/Rose.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/rose/Rose.java
@@ -5,6 +5,7 @@ import static com.hartwig.pipeline.execution.vm.InputDownload.initialiseOptional
 import java.util.Collections;
 import java.util.List;
 
+import com.hartwig.events.pipeline.Pipeline.Context;
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.ResultsDirectory;
 import com.hartwig.pipeline.execution.PipelineStatus;
@@ -15,8 +16,8 @@ import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
 import com.hartwig.pipeline.execution.vm.VirtualMachinePerformanceProfile;
 import com.hartwig.pipeline.execution.vm.VmDirectories;
 import com.hartwig.pipeline.execution.vm.java.JavaJarCommand;
-import com.hartwig.pipeline.output.AddDatatype;
 import com.hartwig.pipeline.input.SomaticRunMetadata;
+import com.hartwig.pipeline.output.AddDatatype;
 import com.hartwig.pipeline.report.EntireOutputComponent;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.report.RunLogComponent;
@@ -176,6 +177,6 @@ public class Rose implements Stage<RoseOutput, SomaticRunMetadata> {
 
     @Override
     public boolean shouldRun(final Arguments arguments) {
-        return !arguments.shallow() && arguments.runTertiary();
+        return !arguments.shallow() && !(arguments.context() == Context.RESEARCH) && arguments.runTertiary();
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/rose/Rose.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/rose/Rose.java
@@ -177,6 +177,6 @@ public class Rose implements Stage<RoseOutput, SomaticRunMetadata> {
 
     @Override
     public boolean shouldRun(final Arguments arguments) {
-        return !arguments.shallow() && !(arguments.context() == Context.RESEARCH) && arguments.runTertiary();
+        return !arguments.shallow() && arguments.context() != Context.RESEARCH && arguments.runTertiary();
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/protect/ProtectTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/protect/ProtectTest.java
@@ -1,5 +1,6 @@
 package com.hartwig.pipeline.tertiary.protect;
 
+import static com.hartwig.pipeline.Arguments.testDefaultsBuilder;
 import static com.hartwig.pipeline.testsupport.TestInputs.SOMATIC_BUCKET;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -10,9 +11,9 @@ import java.util.List;
 import com.google.common.collect.ImmutableList;
 import com.hartwig.pipeline.ResultsDirectory;
 import com.hartwig.pipeline.datatypes.DataType;
+import com.hartwig.pipeline.input.SomaticRunMetadata;
 import com.hartwig.pipeline.output.AddDatatype;
 import com.hartwig.pipeline.output.ArchivePath;
-import com.hartwig.pipeline.input.SomaticRunMetadata;
 import com.hartwig.pipeline.report.Folder;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.storage.GoogleStorageLocation;
@@ -104,5 +105,15 @@ public class ProtectTest extends TertiaryStageTest<ProtectOutput> {
         return List.of(new AddDatatype(DataType.PROTECT_EVIDENCE,
                 TestInputs.defaultSomaticRunMetadata().barcode(),
                 new ArchivePath(Folder.root(), Protect.NAMESPACE, "tumor.protect.tsv")));
+    }
+
+    @Override
+    public void disabledAppropriately() {
+        assertThat(victim.shouldRun(testDefaultsBuilder().runTertiary(false).shallow(false).build())).isFalse();
+    }
+
+    @Override
+    public void enabledAppropriately() {
+        assertThat(victim.shouldRun(testDefaultsBuilder().runTertiary(true).shallow(false).build())).isTrue();
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/rose/RoseTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/rose/RoseTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Collections;
 import java.util.List;
 
+import com.hartwig.events.pipeline.Pipeline.Context;
 import com.hartwig.pipeline.input.SomaticRunMetadata;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.tertiary.TertiaryStageTest;
@@ -26,12 +27,12 @@ public class RoseTest extends TertiaryStageTest<RoseOutput> {
 
     @Override
     public void disabledAppropriately() {
-        assertThat(victim.shouldRun(testDefaultsBuilder().runTertiary(false).shallow(false).build())).isFalse();
+        assertThat(victim.shouldRun(testDefaultsBuilder().runTertiary(false).shallow(false).context(Context.RESEARCH).build())).isFalse();
     }
 
     @Override
     public void enabledAppropriately() {
-        assertThat(victim.shouldRun(testDefaultsBuilder().runTertiary(true).shallow(false).build())).isTrue();
+        assertThat(victim.shouldRun(testDefaultsBuilder().runTertiary(true).shallow(false).context(Context.DIAGNOSTIC).build())).isTrue();
     }
 
     @Override


### PR DESCRIPTION
These are out of date and for now it's easiest just to disable them.

I believe the smoke test will continue to function with no further changes and the unit tests also pass. We will likely be removing them soon anyway.