### PR TITLE
DEV-3178 Eliminate endless looping on GCP ops

### DIFF
--- a/cluster/src/test/java/com/hartwig/pipeline/execution/vm/InstanceLifecycleManagerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/execution/vm/InstanceLifecycleManagerTest.java
@@ -92,9 +92,9 @@ public class InstanceLifecycleManagerTest {
     @Test
     public void shouldDelete() throws Exception {
         Operation deleteOperation = Operation.newBuilder().setName("delete").setStatus(Operation.Status.DONE).build();
-        OperationFuture<Operation, Operation> operationFuture = operationFuture();
-        when(operationFuture.get()).thenReturn(deleteOperation);
-        when(instances.deleteAsync(ARGUMENTS.project(), zoneOne, vmName)).thenReturn(operationFuture);
+        OperationFuture<Operation, Operation> deleteOperationFuture = operationFuture();
+        when(deleteOperationFuture.get()).thenReturn(deleteOperation);
+        when(instances.deleteAsync(ARGUMENTS.project(), zoneOne, vmName)).thenReturn(deleteOperationFuture);
 
         when(zoneOperations.get(ARGUMENTS.project(), zoneOne, "delete")).thenReturn(deleteOperation);
 


### PR DESCRIPTION
We have had several signficant cost overruns in production recently due to endless retries of GCP operations. This is most certainly due to a bug in the code changed in this commit.