### PR TITLE
DEV-3178 Further simplify VM management

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngine.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngine.java
@@ -10,8 +10,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
@@ -135,7 +133,7 @@ public class GoogleComputeEngine implements ComputeEngine {
             }
 
             String project = arguments.project();
-            List<Zone> zones = fetchZones();
+            List<Zone> zones = lifecycleManager.fetchZones();
             zoneRandomizer.accept(zones);
             int index = 0;
             boolean keepTrying = !zones.isEmpty();
@@ -353,11 +351,5 @@ public class GoogleComputeEngine implements ComputeEngine {
                 return null;
             }
         });
-    }
-
-    private List<Zone> fetchZones() throws IOException {
-        return StreamSupport.stream(zonesClient.list(arguments.project()).iterateAll().spliterator(), false)
-                .filter(zone -> zone.getRegion().endsWith(arguments.region()))
-                .collect(Collectors.toList());
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/InstanceLifecycleManager.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/InstanceLifecycleManager.java
@@ -16,6 +16,7 @@ import com.google.cloud.compute.v1.Instance;
 import com.google.cloud.compute.v1.InstancesClient;
 import com.google.cloud.compute.v1.Metadata;
 import com.google.cloud.compute.v1.Operation;
+import com.google.cloud.compute.v1.Operation.Status;
 import com.google.cloud.compute.v1.Zone;
 import com.google.cloud.compute.v1.ZoneOperationsClient;
 import com.google.cloud.compute.v1.ZonesClient;
@@ -30,15 +31,13 @@ import net.jodah.failsafe.function.CheckedSupplier;
 
 class InstanceLifecycleManager {
     public static final String DELETE_VM = "deleteVm";
+    public static final String INSERT_VM = "insertVm";
     public static final String STOP_VM = "stopVm";
-    public static final String OPERATION_STATUS = "operationStatus";
     public static final String SET_METADATA = "setMetadata";
-    public static final String GET_ZONE_OPERATIONS = "getZoneOperations";
     public static final String LIST_ZONES = "listZones";
-    private static final String RUNNING_STATUS = "RUNNING";
-    private static final Logger LOGGER = LoggerFactory.getLogger(InstanceLifecycleManager.class);
     private static final String LIST_INSTANCES = "listInstances";
-    private static final int MAX_RETRIES = 5;
+    private static final Logger LOGGER = LoggerFactory.getLogger(InstanceLifecycleManager.class);
+    private static final int MAX_RETRIES = 4;
 
     private final String project;
     private final InstancesClient instances;
@@ -59,7 +58,9 @@ class InstanceLifecycleManager {
 
     Optional<Instance> findExistingInstance(final String vmName) {
         for (String zone : fetchZones().stream().map(Zone::getName).collect(Collectors.toList())) {
-            Iterable<Instance> instances = executeOperation(() -> this.instances.list(project, zone).iterateAll(), LIST_INSTANCES);
+            this.instances.list(project, zone);
+            Iterable<Instance> instances =
+                    executeSynchronouslyWithRetries(() -> this.instances.list(project, zone).iterateAll(), LIST_INSTANCES);
             if (instances != null) {
                 for (Instance instance : instances) {
                     if (instance.getName().equals(vmName)) {
@@ -76,28 +77,20 @@ class InstanceLifecycleManager {
             try {
                 String shortZone = new File(i.getZone()).getName();
                 LOGGER.debug("Removing existing VM instance [{}] in [{}]", i.getName(), shortZone);
-                Operation delete =
-                        executeSynchronously(() -> instances.deleteAsync(project, shortZone, vmName), project, shortZone, DELETE_VM);
-                if (!delete.getError().getErrorsList().isEmpty()) {
-                    throw new RuntimeException(delete.getError()
-                            .getErrorsList()
-                            .stream()
-                            .map(Errors::getMessage)
-                            .collect(Collectors.joining(",")));
-                }
+                executeSynchronously(instances.deleteAsync(project, shortZone, vmName), shortZone, DELETE_VM);
             } catch (Exception e) {
                 throw new RuntimeException("Could not delete existing [" + vmName + "] instance", e);
             }
         });
-        return executeSynchronously(() -> instances.insertAsync(project, zone, instance), project, zone, "insertVm");
+        return executeSynchronously(instances.insertAsync(project, zone, instance), zone, INSERT_VM);
     }
 
     void delete(final String zone, final String vm) {
-        executeSynchronously(() -> instances.deleteAsync(project, zone, vm), project, zone, DELETE_VM);
+        executeSynchronously(instances.deleteAsync(project, zone, vm), zone, DELETE_VM);
     }
 
     void stop(final String zone, final String vm) {
-        executeSynchronously(() -> instances.stopAsync(project, zone, vm), project, zone, STOP_VM);
+        executeSynchronously(instances.stopAsync(project, zone, vm), zone, STOP_VM);
     }
 
     String instanceStatus(final String vm, final String zone) {
@@ -113,52 +106,45 @@ class InstanceLifecycleManager {
         }
     }
 
-    private List<Zone> fetchZones() {
-        return executeOperation(() -> StreamSupport.stream(zones.list(project).iterateAll().spliterator(), false)
+    void disableStartupScript(final String zone, final String vm) throws IOException {
+        String latestFingerprint = instances.get(project, zone, vm).getMetadata().getFingerprint();
+        executeSynchronously(instances.setMetadataAsync(project, zone, vm, Metadata.newBuilder().setFingerprint(latestFingerprint).build()),
+                zone,
+                SET_METADATA);
+    }
+
+    List<Zone> fetchZones() {
+        return executeSynchronouslyWithRetries(() -> StreamSupport.stream(zones.list(project).iterateAll().spliterator(), false)
                 .filter(zone -> zone.getRegion().endsWith(region))
                 .collect(Collectors.toList()), LIST_ZONES);
     }
 
-    void disableStartupScript(final String zone, final String vm) throws IOException {
-        String latestFingerprint = instances.get(project, zone, vm).getMetadata().getFingerprint();
-        executeSynchronously(() -> instances.setMetadataAsync(project,
-                zone,
-                vm,
-                Metadata.newBuilder().setFingerprint(latestFingerprint).build()), project, zone, SET_METADATA);
-    }
-
-    private String operationStatus(final String jobName, final String zoneName) {
-        return executeOperation(() -> zoneOperations.get(project, zoneName, jobName), OPERATION_STATUS).getStatus()
-                .getValueDescriptor()
-                .getName();
-    }
-
-    private Operation executeSynchronously(final CheckedSupplier<OperationFuture<Operation, Operation>> supplier, final String projectName,
-            final String zoneName, final String opName) {
+    private Operation executeSynchronously(final OperationFuture<Operation, Operation> future, final String zoneName, final String opName) {
         try {
-            Operation asyncOp = executeOperation(supplier, opName).get();
-            String logId = format("Operation [%s:%s]", asyncOp.getOperationType(), asyncOp.getName());
-            LOGGER.debug("{} is executing asynchronously", logId);
-            while (RUNNING_STATUS.equals(operationStatus(asyncOp.getName(), zoneName))) {
-                LOGGER.debug("{} not done yet", logId);
-                try {
-                    //noinspection BusyWait
-                    Thread.sleep(1000);
-                } catch (InterruptedException ie) {
-                    Thread.currentThread().interrupt();
+            Operation operation = future.get();
+            if (operation.getStatus() != Status.DONE) {
+                Operation waitForCompletion = zoneOperations.wait(project, zoneName, opName);
+                if (waitForCompletion.hasError()) {
+                    throw new RuntimeException(waitForCompletion.getError()
+                            .getErrorsList()
+                            .stream()
+                            .map(Errors::getMessage)
+                            .collect(Collectors.joining(",")));
                 }
             }
-            return executeOperation(() -> zoneOperations.get(projectName, zoneName, asyncOp.getName()), GET_ZONE_OPERATIONS);
+            return operation;
         } catch (Exception e) {
-            throw new RuntimeException(format("Failed synchronous execution of [%s]", opName), e);
+            String message = format("Failed synchronous execution of [%s]", opName);
+            LOGGER.error(message, e);
+            throw new RuntimeException(message, e);
         }
     }
 
-    private <T> T executeOperation(final CheckedSupplier<T> operationCheckedSupplier, final String opName) {
+    private <T> T executeSynchronouslyWithRetries(final CheckedSupplier<T> operationCheckedSupplier, final String opName) {
         return Failsafe.with(new RetryPolicy<>().handle(Exception.class)
                 .withDelay(Duration.ofSeconds(pollInterval))
                 .withMaxRetries(MAX_RETRIES)
-                .onFailedAttempt(rExecutionAttemptedEvent -> LOGGER.warn("[{}] failed: {}",
+                .onFailedAttempt(rExecutionAttemptedEvent -> LOGGER.error("[{}] failed: {}",
                         opName,
                         rExecutionAttemptedEvent.getLastFailure().getMessage()))).get(operationCheckedSupplier);
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/InstanceLifecycleManager.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/InstanceLifecycleManager.java
@@ -2,7 +2,6 @@ package com.hartwig.pipeline.execution.vm;
 
 import static java.lang.String.format;
 
-import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
@@ -74,9 +73,8 @@ class InstanceLifecycleManager {
     Operation deleteOldInstancesAndStart(final Instance instance, final String vmName, final String zone) {
         findExistingInstance(vmName).ifPresent(i -> {
             try {
-                String shortZone = new File(i.getZone()).getName();
-                LOGGER.debug("Removing existing VM instance [{}] in [{}]", i.getName(), shortZone);
-                executeSynchronously(instances.deleteAsync(project, shortZone, vmName), DELETE_VM, shortZone);
+                LOGGER.debug("Removing existing VM instance [{}] in [{}]", i.getName(), zone);
+                delete(vmName, zone);
             } catch (Exception e) {
                 throw new RuntimeException("Could not delete existing [" + vmName + "] instance", e);
             }
@@ -85,7 +83,8 @@ class InstanceLifecycleManager {
     }
 
     void delete(final String vm, final String zone) {
-        executeSynchronously(instances.deleteAsync(project, zone, vm), DELETE_VM, zone);
+        String shortZone = zone.replaceAll(".*/", "");
+        executeSynchronously(instances.deleteAsync(project, shortZone, vm), DELETE_VM, shortZone);
     }
 
     void stop(final String vm, final String zone) {

--- a/cluster/src/test/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngineTest.java
@@ -104,7 +104,7 @@ public class GoogleComputeEngineTest {
         }, lifecycleManager, bucketWatcher, mock(Labels.class));
         returnFailed();
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
-        verify(lifecycleManager).disableStartupScript(FIRST_ZONE_NAME, INSTANCE_NAME);
+        verify(lifecycleManager).disableStartupScript(INSTANCE_NAME, FIRST_ZONE_NAME);
     }
 
     @Test
@@ -125,7 +125,7 @@ public class GoogleComputeEngineTest {
     public void deletesVmAfterJobIsSuccessful() {
         returnSuccess();
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
-        verify(lifecycleManager).delete(FIRST_ZONE_NAME, INSTANCE_NAME);
+        verify(lifecycleManager).delete(INSTANCE_NAME, FIRST_ZONE_NAME);
     }
 
     @Test
@@ -136,7 +136,7 @@ public class GoogleComputeEngineTest {
         when(mockedInstance.getName()).thenReturn(INSTANCE_NAME);
         when(mockedInstance.getZone()).thenReturn(FIRST_ZONE_NAME);
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
-        verify(lifecycleManager).delete(FIRST_ZONE_NAME, INSTANCE_NAME);
+        verify(lifecycleManager).delete(INSTANCE_NAME, FIRST_ZONE_NAME);
     }
 
     @Test
@@ -146,14 +146,14 @@ public class GoogleComputeEngineTest {
         }, lifecycleManager, bucketWatcher, mock(Labels.class));
         returnFailed();
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
-        verify(lifecycleManager).stop(FIRST_ZONE_NAME, INSTANCE_NAME);
+        verify(lifecycleManager).stop(INSTANCE_NAME, FIRST_ZONE_NAME);
     }
 
     @Test
     public void deletesInstanceWithLocalSSdsUponFailure() {
         returnFailed();
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
-        verify(lifecycleManager).delete(FIRST_ZONE_NAME, INSTANCE_NAME);
+        verify(lifecycleManager).delete(INSTANCE_NAME, FIRST_ZONE_NAME);
     }
 
     @Test
@@ -232,13 +232,13 @@ public class GoogleComputeEngineTest {
     @Test
     public void triesMultipleZonesWhenResourcesExhausted() {
         Operation resourcesExhausted = operationWithError(GoogleComputeEngine.ZONE_EXHAUSTED_ERROR_CODE);
-        when(lifecycleManager.deleteOldInstancesAndStart(any(), eq(FIRST_ZONE_NAME), eq(INSTANCE_NAME))).thenReturn(resourcesExhausted,
+        when(lifecycleManager.deleteOldInstancesAndStart(any(), eq(INSTANCE_NAME), eq(FIRST_ZONE_NAME))).thenReturn(resourcesExhausted,
                 Operation.newBuilder().build());
         when(bucketWatcher.currentState(any(), any())).thenReturn(BucketCompletionWatcher.State.STILL_WAITING,
                 BucketCompletionWatcher.State.STILL_WAITING,
                 BucketCompletionWatcher.State.SUCCESS);
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
-        verify(lifecycleManager).deleteOldInstancesAndStart(any(), eq(SECOND_ZONE_NAME), eq(INSTANCE_NAME));
+        verify(lifecycleManager).deleteOldInstancesAndStart(any(), eq(INSTANCE_NAME), eq(SECOND_ZONE_NAME));
     }
 
     @NotNull
@@ -253,13 +253,13 @@ public class GoogleComputeEngineTest {
     @Test
     public void triesMultipleZonesWhenUnsupportedOperation() {
         Operation resourcesExhausted = operationWithError(GoogleComputeEngine.UNSUPPORTED_OPERATION_ERROR_CODE);
-        when(lifecycleManager.deleteOldInstancesAndStart(any(), eq(FIRST_ZONE_NAME), eq(INSTANCE_NAME))).thenReturn(resourcesExhausted,
+        when(lifecycleManager.deleteOldInstancesAndStart(any(), eq(INSTANCE_NAME), eq(FIRST_ZONE_NAME))).thenReturn(resourcesExhausted,
                 Operation.newBuilder().build());
         when(bucketWatcher.currentState(any(), any())).thenReturn(BucketCompletionWatcher.State.STILL_WAITING,
                 BucketCompletionWatcher.State.STILL_WAITING,
                 BucketCompletionWatcher.State.SUCCESS);
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
-        verify(lifecycleManager).deleteOldInstancesAndStart(any(), eq(SECOND_ZONE_NAME), eq(INSTANCE_NAME));
+        verify(lifecycleManager).deleteOldInstancesAndStart(any(), eq(INSTANCE_NAME), eq(SECOND_ZONE_NAME));
     }
 
     @Test
@@ -277,8 +277,8 @@ public class GoogleComputeEngineTest {
                 BucketCompletionWatcher.State.STILL_WAITING,
                 BucketCompletionWatcher.State.SUCCESS);
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
-        verify(lifecycleManager).deleteOldInstancesAndStart(any(), eq(FIRST_ZONE_NAME), eq(INSTANCE_NAME));
-        verify(lifecycleManager).deleteOldInstancesAndStart(any(), eq(SECOND_ZONE_NAME), eq(INSTANCE_NAME));
+        verify(lifecycleManager).deleteOldInstancesAndStart(any(), eq(INSTANCE_NAME), eq(FIRST_ZONE_NAME));
+        verify(lifecycleManager).deleteOldInstancesAndStart(any(), eq(INSTANCE_NAME), eq(SECOND_ZONE_NAME));
     }
 
     @Test

--- a/cluster/src/test/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngineTest.java
@@ -66,10 +66,8 @@ public class GoogleComputeEngineTest {
         lifecycleManager = mock(InstanceLifecycleManager.class);
         when(lifecycleManager.deleteOldInstancesAndStart(instanceArgumentCaptor.capture(), any(), any())).thenReturn(insertOperation);
 
-        ZonesClient.ListPagedResponse zoneListResponse = mock(ZonesClient.ListPagedResponse.class);
-        when(zoneListResponse.iterateAll()).thenReturn(List.of(zone(GoogleComputeEngineTest.FIRST_ZONE_NAME),
+        when(lifecycleManager.fetchZones()).thenReturn(List.of(zone(GoogleComputeEngineTest.FIRST_ZONE_NAME),
                 zone(GoogleComputeEngineTest.SECOND_ZONE_NAME)));
-        when(zonesClient.list(ARGUMENTS.project())).thenReturn(zoneListResponse);
 
         bucketWatcher = mock(BucketCompletionWatcher.class);
         victim = new GoogleComputeEngine(ARGUMENTS, zonesClient, imagesClient, z -> {

--- a/cluster/src/test/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngineTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/execution/vm/GoogleComputeEngineTest.java
@@ -70,7 +70,7 @@ public class GoogleComputeEngineTest {
                 zone(GoogleComputeEngineTest.SECOND_ZONE_NAME)));
 
         bucketWatcher = mock(BucketCompletionWatcher.class);
-        victim = new GoogleComputeEngine(ARGUMENTS, zonesClient, imagesClient, z -> {
+        victim = new GoogleComputeEngine(ARGUMENTS, imagesClient, z -> {
         }, lifecycleManager, bucketWatcher, Labels.of(Arguments.testDefaults(), TestInputs.defaultSomaticRunMetadata()));
         runtimeBucket = MockRuntimeBucket.test();
         jobDefinition = VirtualMachineJobDefinition.builder()
@@ -100,7 +100,7 @@ public class GoogleComputeEngineTest {
     @Test
     public void disablesStartupScriptWhenInstanceWithPersistentDisksFailsRemotely() throws Exception {
         Arguments arguments = Arguments.testDefaultsBuilder().useLocalSsds(false).build();
-        victim = new GoogleComputeEngine(arguments, zonesClient, imagesClient, z -> {
+        victim = new GoogleComputeEngine(arguments, imagesClient, z -> {
         }, lifecycleManager, bucketWatcher, mock(Labels.class));
         returnFailed();
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
@@ -142,7 +142,7 @@ public class GoogleComputeEngineTest {
     @Test
     public void stopsInstanceWithPersistentDisksUponFailure() {
         Arguments arguments = Arguments.testDefaultsBuilder().useLocalSsds(false).build();
-        victim = new GoogleComputeEngine(arguments, zonesClient, imagesClient, z -> {
+        victim = new GoogleComputeEngine(arguments, imagesClient, z -> {
         }, lifecycleManager, bucketWatcher, mock(Labels.class));
         returnFailed();
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
@@ -170,7 +170,6 @@ public class GoogleComputeEngineTest {
     public void usesNetworkAndSubnetWhenSpecified() {
         returnSuccess();
         victim = new GoogleComputeEngine(Arguments.testDefaultsBuilder().network("private").subnet("subnet").build(),
-                zonesClient,
                 imagesClient,
                 z -> {
                 },
@@ -189,7 +188,7 @@ public class GoogleComputeEngineTest {
     @Test
     public void usesNetworkAsSubnetWhenNotSpecified() {
         returnSuccess();
-        victim = new GoogleComputeEngine(Arguments.testDefaultsBuilder().network("private").build(), zonesClient, imagesClient, z -> {
+        victim = new GoogleComputeEngine(Arguments.testDefaultsBuilder().network("private").build(), imagesClient, z -> {
         }, lifecycleManager, bucketWatcher, mock(Labels.class));
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
         List<NetworkInterface> networkInterfaces = instanceArgumentCaptor.getValue().getNetworkInterfacesList();
@@ -205,7 +204,6 @@ public class GoogleComputeEngineTest {
         String networkUrl = "projects/private";
         String subnetUrl = "projects/subnet";
         victim = new GoogleComputeEngine(Arguments.testDefaultsBuilder().network(networkUrl).subnet(subnetUrl).build(),
-                zonesClient,
                 imagesClient,
                 z -> {
                 },
@@ -223,7 +221,7 @@ public class GoogleComputeEngineTest {
     @Test
     public void addsTagsToComputeEngineInstances() {
         returnSuccess();
-        victim = new GoogleComputeEngine(Arguments.testDefaultsBuilder().tags(List.of("tag")).build(), zonesClient, imagesClient, z -> {
+        victim = new GoogleComputeEngine(Arguments.testDefaultsBuilder().tags(List.of("tag")).build(), imagesClient, z -> {
         }, lifecycleManager, bucketWatcher, mock(Labels.class));
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
         assertThat(instanceArgumentCaptor.getValue().getTags().getItemsList()).containsExactly("tag");
@@ -298,7 +296,7 @@ public class GoogleComputeEngineTest {
 
     @Test
     public void attachesTwoPersisentDisksWhenLocalSSDDisabled() {
-        victim = new GoogleComputeEngine(Arguments.builder().from(ARGUMENTS).useLocalSsds(false).build(), zonesClient, imagesClient, z -> {
+        victim = new GoogleComputeEngine(Arguments.builder().from(ARGUMENTS).useLocalSsds(false).build(), imagesClient, z -> {
         }, lifecycleManager, bucketWatcher, mock(Labels.class));
         returnSuccess();
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
@@ -314,7 +312,7 @@ public class GoogleComputeEngineTest {
 
     @Test
     public void usesLatestImageFromCurrentFamilyWhenNoImageGiven() {
-        victim = new GoogleComputeEngine(ARGUMENTS, zonesClient, imagesClient, z -> {
+        victim = new GoogleComputeEngine(ARGUMENTS, imagesClient, z -> {
         }, lifecycleManager, bucketWatcher, mock(Labels.class));
         returnSuccess();
         victim.submit(runtimeBucket.getRuntimeBucket(), jobDefinition);
@@ -325,7 +323,6 @@ public class GoogleComputeEngineTest {
     public void usesLatestImageFromCurrentFamilyWithGivenProject() {
         String givenProject = "givenProject";
         victim = new GoogleComputeEngine(Arguments.builder().from(ARGUMENTS).imageProject(givenProject).build(),
-                zonesClient,
                 imagesClient,
                 z -> {
                 },
@@ -344,7 +341,7 @@ public class GoogleComputeEngineTest {
     public void usesGivenImageFromPublicImageProjectWhenProvided() {
         String imageName = "alternate_image";
         Image specificImage = Image.newBuilder().setName(imageName).setSelfLink(imageName).build();
-        victim = new GoogleComputeEngine(Arguments.testDefaultsBuilder().imageName(imageName).build(), zonesClient, imagesClient, z -> {
+        victim = new GoogleComputeEngine(Arguments.testDefaultsBuilder().imageName(imageName).build(), imagesClient, z -> {
         }, lifecycleManager, bucketWatcher, mock(Labels.class));
         when(imagesClient.get(VirtualMachineJobDefinition.HMF_IMAGE_PROJECT, imageName)).thenReturn(specificImage);
         returnSuccess();
@@ -356,7 +353,6 @@ public class GoogleComputeEngineTest {
     @Test
     public void appliesLabelsToInstanceAndDisks() {
         victim = new GoogleComputeEngine(ARGUMENTS,
-                zonesClient,
                 imagesClient,
                 z -> {
                 },

--- a/cluster/src/test/java/com/hartwig/pipeline/execution/vm/InstanceLifecycleManagerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/execution/vm/InstanceLifecycleManagerTest.java
@@ -97,7 +97,7 @@ public class InstanceLifecycleManagerTest {
 
         when(zoneOperations.get(ARGUMENTS.project(), zoneOne, "delete")).thenReturn(deleteOperation);
 
-        victim.delete(zoneOne, vmName);
+        victim.delete(vmName, zoneOne);
     }
 
     @Test
@@ -110,7 +110,7 @@ public class InstanceLifecycleManagerTest {
         Operation statusOperation = Operation.newBuilder().setName("status").setStatus(Operation.Status.DONE).build();
         when(zoneOperations.get(ARGUMENTS.project(), zoneOne, "stop")).thenReturn(statusOperation);
 
-        victim.stop(zoneOne, vmName);
+        victim.stop(vmName, zoneOne);
     }
 
     private Zone zone(final String name) {

--- a/cluster/src/test/java/com/hartwig/pipeline/execution/vm/InstanceLifecycleManagerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/execution/vm/InstanceLifecycleManagerTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.cloud.compute.v1.Instance;
@@ -102,38 +101,11 @@ public class InstanceLifecycleManagerTest {
     }
 
     @Test
-    public void shouldRetryDeleteIfNotAtFirstSuccessful() throws ExecutionException, InterruptedException {
-        Operation deleteOperation = Operation.newBuilder().setName("delete").setStatus(Operation.Status.DONE).build();
-        OperationFuture<Operation, Operation> operationFuture = operationFuture();
-        when(operationFuture.get()).thenReturn(deleteOperation);
-        when(instances.deleteAsync(ARGUMENTS.project(), zoneOne, vmName)).thenThrow(new RuntimeException()).thenReturn(operationFuture);
-
-        Operation statusOperation = Operation.newBuilder().setName("status").setStatus(Operation.Status.DONE).build();
-        when(zoneOperations.get(ARGUMENTS.project(), zoneOne, "delete")).thenReturn(statusOperation);
-
-        victim.delete(zoneOne, vmName);
-    }
-
-    @Test
     public void shouldStop() throws Exception {
         Operation stopOperation = Operation.newBuilder().setName("stop").setStatus(Operation.Status.DONE).build();
         OperationFuture<Operation, Operation> operationFuture = operationFuture();
         when(operationFuture.get()).thenReturn(stopOperation);
         when(instances.stopAsync(ARGUMENTS.project(), zoneOne, vmName)).thenReturn(operationFuture);
-
-        Operation statusOperation = Operation.newBuilder().setName("status").setStatus(Operation.Status.DONE).build();
-        when(zoneOperations.get(ARGUMENTS.project(), zoneOne, "stop")).thenReturn(statusOperation);
-
-        victim.stop(zoneOne, vmName);
-    }
-
-    @Test
-    public void shouldRetryStopIfNotAtFirstSuccessful() throws Exception {
-        Operation stopOperation = Operation.newBuilder().setName("stop").setStatus(Operation.Status.DONE).build();
-        OperationFuture<Operation, Operation> operationFuture = operationFuture();
-        when(operationFuture.get()).thenReturn(stopOperation);
-
-        when(instances.stopAsync(ARGUMENTS.project(), zoneOne, vmName)).thenThrow(new RuntimeException()).thenReturn(operationFuture);
 
         Operation statusOperation = Operation.newBuilder().setName("status").setStatus(Operation.Status.DONE).build();
         when(zoneOperations.get(ARGUMENTS.project(), zoneOne, "stop")).thenReturn(statusOperation);


### PR DESCRIPTION
I have removed the messy loop that previously composed much of the executeSynchronously() method, replacing it with the mechanism recommended in Google's documentation for waiting on a running operation.

Logging of any errors in the InstanceLifecycleManager now occurs at the ERROR level, though most exceptions will be thrown back up to the StageRunner where the stage itself will be retried. This is somewhat of a middle ground; it can only result in more production alerts but should help us get a handle on which operations actually routinely fail, while also properly handling any errors that do come up.

There is more work to do here but I am reluctant to do too much as this is such a core piece of our infrastructure. I will revisit at some point in the future, when this release has been out in the wild for a while.