### PR TITLE
DEV-3227 Increase Purple memory

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
@@ -122,7 +122,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
                 .name("purple")
                 .startupCommand(bash)
                 .namespacedResults(resultsDirectory)
-                .performanceProfile(custom(4, 24))
+                .performanceProfile(custom(4, 32))
                 .workingDiskSpaceGb(LOCAL_SSD_DISK_SPACE_GB)
                 .build();
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/purple/Purple.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/purple/Purple.java
@@ -370,7 +370,7 @@ public class Purple implements Stage<PurpleOutput, SomaticRunMetadata> {
     }
 
     private List<BashCommand> buildCommand(final List<String> arguments) {
-        return Collections.singletonList(new JavaJarCommand("purple", Versions.PURPLE, "purple.jar", "18G", arguments));
+        return Collections.singletonList(new JavaJarCommand("purple", Versions.PURPLE, "purple.jar", "31G", arguments));
     }
 
     private GoogleStorageLocation persistedOrDefault(final String sample, final String set, final String bucket,

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/purple/PurpleTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/purple/PurpleTest.java
@@ -76,7 +76,7 @@ public class PurpleTest extends TertiaryStageTest<PurpleOutput> {
     @Override
     protected List<String> expectedCommands() {
         return Collections.singletonList(
-                "java -Xmx18G -jar /opt/tools/purple/3.8.2/purple.jar "
+                "java -Xmx31G -jar /opt/tools/purple/3.8.2/purple.jar "
                         + "-amber /data/input/results "
                         + "-cobalt /data/input/results "
                         + "-ref_genome /opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta "
@@ -101,9 +101,8 @@ public class PurpleTest extends TertiaryStageTest<PurpleOutput> {
 
     @Override
     protected List<String> expectedReferenceOnlyCommands() {
-        return Collections.singletonList("java -Xmx18G -jar /opt/tools/purple/3.8.2/purple.jar "
-                        + "-amber /data/input/results "
-                        + "-cobalt /data/input/results "
+        return Collections.singletonList(
+                "java -Xmx31G -jar /opt/tools/purple/3.8.2/purple.jar " + "-amber /data/input/results " + "-cobalt /data/input/results "
                         + "-ref_genome /opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta "
                         + "-ref_genome_version V37 -driver_gene_panel /opt/resources/gene_panel/37/DriverGenePanel.37.tsv "
                         + "-ensembl_data_dir /opt/resources/ensembl_data_cache/37/ "


### PR DESCRIPTION
There is currently a run in the research environment that is failing on a Java OutOfMemoryError. 31GB worked in the diagnostic run which is using an older Purple version.