### PR TITLE
DEV-3234 Fix bug in old instance deletion

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/InstanceLifecycleManager.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/InstanceLifecycleManager.java
@@ -73,8 +73,8 @@ class InstanceLifecycleManager {
     Operation deleteOldInstancesAndStart(final Instance instance, final String vmName, final String zone) {
         findExistingInstance(vmName).ifPresent(i -> {
             try {
-                LOGGER.debug("Removing existing VM instance [{}] in [{}]", i.getName(), zone);
-                delete(vmName, zone);
+                LOGGER.debug("Removing existing VM instance [{}] in [{}]", i.getName(), i.getZone());
+                delete(i.getName(), i.getZone());
             } catch (Exception e) {
                 throw new RuntimeException("Could not delete existing [" + vmName + "] instance", e);
             }


### PR DESCRIPTION
The deletion code was incorrect because it located an old instance but then tried to delete that from the zone the new instance was going to be placed into. This would work sometimes (as there are only 3 zones in europe-west4) but not always.

With the recent change to the logging it is now obvious what was happening.