### PR TITLE
ACTIN-88 Remove erroneous "empty" cmek

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
@@ -126,7 +126,6 @@ public interface Arguments extends CommonArguments {
                     .runTertiary(true)
                     .shallow(false)
                     .setName(EMPTY)
-                    .cmek(EMPTY)
                     .outputBucket(DEFAULT_PRODUCTION_PATIENT_REPORT_BUCKET)
                     .uploadPrivateKeyPath(Optional.empty())
                     .network(DEFAULT_NETWORK)


### PR DESCRIPTION
In actin infra we don't want to use cmek. The default of empty does not function, it should really be Optional.empty.