### PR TITLE
DEV-3243 Add temporary research starting point

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/reruns/StartingPoint.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/reruns/StartingPoint.java
@@ -23,7 +23,6 @@ import com.hartwig.pipeline.tertiary.amber.Amber;
 import com.hartwig.pipeline.tertiary.chord.Chord;
 import com.hartwig.pipeline.tertiary.cobalt.Cobalt;
 import com.hartwig.pipeline.tertiary.cuppa.Cuppa;
-import com.hartwig.pipeline.tertiary.healthcheck.HealthChecker;
 import com.hartwig.pipeline.tertiary.lilac.Lilac;
 import com.hartwig.pipeline.tertiary.lilac.LilacBamSlicer;
 import com.hartwig.pipeline.tertiary.linx.LinxGermline;
@@ -32,7 +31,6 @@ import com.hartwig.pipeline.tertiary.orange.Orange;
 import com.hartwig.pipeline.tertiary.pave.PaveGermline;
 import com.hartwig.pipeline.tertiary.pave.PaveSomatic;
 import com.hartwig.pipeline.tertiary.peach.Peach;
-import com.hartwig.pipeline.tertiary.protect.Protect;
 import com.hartwig.pipeline.tertiary.purple.Purple;
 import com.hartwig.pipeline.tertiary.rose.Rose;
 import com.hartwig.pipeline.tertiary.sigs.Sigs;
@@ -89,7 +87,9 @@ public class StartingPoint {
                         Orange.NAMESPACE,
                         Sigs.NAMESPACE,
                         Rose.NAMESPACE,
-                        VirusInterpreter.NAMESPACE)));
+                        VirusInterpreter.NAMESPACE))),
+
+        RESEARCH_AFTER_531_DIAGNOSTIC(concat(ALIGNMENT_COMPLETE.namespaces, List.of(GermlineCaller.NAMESPACE)));
 
         private final List<String> namespaces;
 


### PR DESCRIPTION
We recently disabled the germline caller in research, moving it to diagnostic. The research launcher copies the germline output along with the alignment output from the diagnostic output bucket as it always did. However since the germline stage is skipped in the research run, we don't mark the output for that stage with any datatypes. Using this new starting point will result in the datatypes for the germline being applied which should correct the problem.

A corresponding change will need to be made in the launcher code and this will fix the problem for forthcoming runs. There are some runs that have already been archived that will not be fixed, I will craft an SQL file to update the API file entries for these as the only thing missing is the datatypes (ie the archiver otherwise ran properly).

This research starting point can be removed after the next diagnostic upgrade when we will stop running the germline caller in the diagnostic pipeline.