### PR TITLE
DEV-3247 Fallback to sample name if barcode is "NA"

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/input/MetadataProvider.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/input/MetadataProvider.java
@@ -30,7 +30,7 @@ public class MetadataProvider {
                         .bucket(arguments.outputBucket())
                         .set(setName)
                         .type(SingleSampleRunMetadata.SampleType.TUMOR)
-                        .barcode(t.barcode())
+                        .barcode(barcodeOrSampleName(t))
                         .sampleName(t.name())
                         .primaryTumorDoids(t.primaryTumorDoids())
                         .build()))
@@ -38,10 +38,14 @@ public class MetadataProvider {
                         .bucket(arguments.outputBucket())
                         .set(setName)
                         .type(SingleSampleRunMetadata.SampleType.REFERENCE)
-                        .barcode(r.barcode())
+                        .barcode(barcodeOrSampleName(r))
                         .sampleName(r.name())
                         .build()))
                 .maybeExternalIds(pipelineInput.operationalReferences())
                 .build();
+    }
+
+    private static String barcodeOrSampleName(SampleInput sampleInput) {
+        return sampleInput.barcode().equals(SampleInput.NOT_APPLICABLE) ? sampleInput.name() : sampleInput.barcode();
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/input/MetadataProviderTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/input/MetadataProviderTest.java
@@ -93,4 +93,16 @@ public class MetadataProviderTest {
         assertThat(tumorMetadata.bucket()).isEqualTo(arguments.outputBucket());
         assertThat(tumorMetadata.primaryTumorDoids()).isEqualTo(doids);
     }
+
+    @Test
+    public void shouldUseSampleNameAsBarcodeIfBarcodeNotSet() {
+        String sampleName = "tumorSample";
+        List<String> doids = List.of("a", "b", "c");
+        SampleInput tumor = SampleInput.builder().name(sampleName).primaryTumorDoids(doids).build();
+        pipelineInput = PipelineInput.builder().from(pipelineInput).tumor(tumor).build();
+        victim = new MetadataProvider(arguments, pipelineInput);
+        assertThat(victim.get().maybeTumor()).isPresent();
+        SingleSampleRunMetadata tumorMetadata = victim.get().tumor();
+        assertThat(tumorMetadata.barcode()).isEqualTo(sampleName);
+    }
 }


### PR DESCRIPTION
When the barcode is NA use the sample name. This is a minimal fix for 5.32, longer term we should make barcode an optional field in PDL and then handle without the string comparison in the pipeline.