### PR TITLE
DEV-3541 Don't add datatypes to germline Orange

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/orange/Orange.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/orange/Orange.java
@@ -33,7 +33,6 @@ import com.hartwig.pipeline.tertiary.virus.VirusInterpreterOutput;
 import com.hartwig.pipeline.tools.VersionUtils;
 
 import java.time.format.DateTimeFormatter;
-import java.util.Collections;
 import java.util.List;
 
 import static com.hartwig.pipeline.execution.vm.InputDownload.initialiseOptionalLocation;
@@ -258,14 +257,14 @@ public class Orange implements Stage<OrangeOutput, SomaticRunMetadata> {
     @Override
     public List<AddDatatype> addDatatypes(final SomaticRunMetadata metadata) {
         if (includeGermline) {
-            return Collections.emptyList();
-        } else {
             final String orangePdf = metadata.tumor().sampleName() + ORANGE_OUTPUT_PDF;
             final String orangeJson = metadata.tumor().sampleName() + ORANGE_OUTPUT_JSON;
             return List.of(new AddDatatype(DataType.ORANGE_OUTPUT_JSON,
                             metadata.barcode(),
                             new ArchivePath(Folder.root(), namespace(), orangeJson)),
                     new AddDatatype(DataType.ORANGE_OUTPUT_PDF, metadata.barcode(), new ArchivePath(Folder.root(), namespace(), orangePdf)));
+        } else {
+            return List.of();
         }
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/orange/Orange.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/orange/Orange.java
@@ -1,11 +1,5 @@
 package com.hartwig.pipeline.tertiary.orange;
 
-import static com.hartwig.pipeline.execution.vm.InputDownload.initialiseOptionalLocation;
-import static com.hartwig.pipeline.tools.HmfTool.ORANGE;
-
-import java.time.format.DateTimeFormatter;
-import java.util.List;
-
 import com.google.common.collect.ImmutableList;
 import com.hartwig.events.pipeline.Pipeline;
 import com.hartwig.pipeline.Arguments;
@@ -13,23 +7,13 @@ import com.hartwig.pipeline.ResultsDirectory;
 import com.hartwig.pipeline.calling.sage.SageOutput;
 import com.hartwig.pipeline.datatypes.DataType;
 import com.hartwig.pipeline.execution.PipelineStatus;
-import com.hartwig.pipeline.execution.vm.BashCommand;
-import com.hartwig.pipeline.execution.vm.BashStartupScript;
-import com.hartwig.pipeline.execution.vm.InputDownload;
-import com.hartwig.pipeline.execution.vm.InputDownloadIfBlobExists;
-import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinition;
-import com.hartwig.pipeline.execution.vm.VirtualMachinePerformanceProfile;
-import com.hartwig.pipeline.execution.vm.VmDirectories;
+import com.hartwig.pipeline.execution.vm.*;
 import com.hartwig.pipeline.execution.vm.java.JavaJarCommand;
 import com.hartwig.pipeline.execution.vm.unix.MkDirCommand;
 import com.hartwig.pipeline.flagstat.FlagstatOutput;
 import com.hartwig.pipeline.input.SomaticRunMetadata;
 import com.hartwig.pipeline.metrics.BamMetricsOutput;
-import com.hartwig.pipeline.output.AddDatatype;
-import com.hartwig.pipeline.output.ArchivePath;
-import com.hartwig.pipeline.output.EntireOutputComponent;
-import com.hartwig.pipeline.output.Folder;
-import com.hartwig.pipeline.output.RunLogComponent;
+import com.hartwig.pipeline.output.*;
 import com.hartwig.pipeline.resource.ResourceFiles;
 import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
@@ -39,11 +23,7 @@ import com.hartwig.pipeline.tertiary.chord.ChordOutput;
 import com.hartwig.pipeline.tertiary.cuppa.CuppaOutput;
 import com.hartwig.pipeline.tertiary.cuppa.CuppaOutputLocations;
 import com.hartwig.pipeline.tertiary.lilac.LilacOutput;
-import com.hartwig.pipeline.tertiary.linx.LinxGermline;
-import com.hartwig.pipeline.tertiary.linx.LinxGermlineOutput;
-import com.hartwig.pipeline.tertiary.linx.LinxSomatic;
-import com.hartwig.pipeline.tertiary.linx.LinxSomaticOutput;
-import com.hartwig.pipeline.tertiary.linx.LinxSomaticOutputLocations;
+import com.hartwig.pipeline.tertiary.linx.*;
 import com.hartwig.pipeline.tertiary.peach.PeachOutput;
 import com.hartwig.pipeline.tertiary.purple.Purple;
 import com.hartwig.pipeline.tertiary.purple.PurpleOutput;
@@ -51,6 +31,13 @@ import com.hartwig.pipeline.tertiary.purple.PurpleOutputLocations;
 import com.hartwig.pipeline.tertiary.sigs.SigsOutput;
 import com.hartwig.pipeline.tertiary.virus.VirusInterpreterOutput;
 import com.hartwig.pipeline.tools.VersionUtils;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+
+import static com.hartwig.pipeline.execution.vm.InputDownload.initialiseOptionalLocation;
+import static com.hartwig.pipeline.tools.HmfTool.ORANGE;
 
 @Namespace(Orange.NAMESPACE)
 public class Orange implements Stage<OrangeOutput, SomaticRunMetadata> {
@@ -270,11 +257,15 @@ public class Orange implements Stage<OrangeOutput, SomaticRunMetadata> {
 
     @Override
     public List<AddDatatype> addDatatypes(final SomaticRunMetadata metadata) {
-        final String orangePdf = metadata.tumor().sampleName() + ORANGE_OUTPUT_PDF;
-        final String orangeJson = metadata.tumor().sampleName() + ORANGE_OUTPUT_JSON;
-        return List.of(new AddDatatype(DataType.ORANGE_OUTPUT_JSON,
-                        metadata.barcode(),
-                        new ArchivePath(Folder.root(), namespace(), orangeJson)),
-                new AddDatatype(DataType.ORANGE_OUTPUT_PDF, metadata.barcode(), new ArchivePath(Folder.root(), namespace(), orangePdf)));
+        if (includeGermline) {
+            return Collections.emptyList();
+        } else {
+            final String orangePdf = metadata.tumor().sampleName() + ORANGE_OUTPUT_PDF;
+            final String orangeJson = metadata.tumor().sampleName() + ORANGE_OUTPUT_JSON;
+            return List.of(new AddDatatype(DataType.ORANGE_OUTPUT_JSON,
+                            metadata.barcode(),
+                            new ArchivePath(Folder.root(), namespace(), orangeJson)),
+                    new AddDatatype(DataType.ORANGE_OUTPUT_PDF, metadata.barcode(), new ArchivePath(Folder.root(), namespace(), orangePdf)));
+        }
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/orange/OrangeTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/orange/OrangeTest.java
@@ -1,13 +1,5 @@
 package com.hartwig.pipeline.tertiary.orange;
 
-import static com.hartwig.pipeline.testsupport.TestInputs.toolCommand;
-import static com.hartwig.pipeline.tools.HmfTool.ORANGE;
-
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-
-import java.util.Arrays;
-import java.util.List;
-
 import com.google.common.collect.ImmutableList;
 import com.hartwig.events.pipeline.Pipeline;
 import com.hartwig.pipeline.datatypes.DataType;
@@ -19,13 +11,28 @@ import com.hartwig.pipeline.output.Folder;
 import com.hartwig.pipeline.stages.Stage;
 import com.hartwig.pipeline.tertiary.TertiaryStageTest;
 import com.hartwig.pipeline.testsupport.TestInputs;
-
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.hartwig.pipeline.testsupport.TestInputs.defaultSomaticRunMetadata;
+import static com.hartwig.pipeline.testsupport.TestInputs.toolCommand;
+import static com.hartwig.pipeline.tools.HmfTool.ORANGE;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 public class OrangeTest extends TertiaryStageTest<OrangeOutput> {
 
+    private static BashCommand orangeCommand(Orange victim) {
+        return victim.tumorReferenceCommands(TestInputs.defaultSomaticRunMetadata()).get(2);
+    }
+
     @Override
     protected Stage<OrangeOutput, SomaticRunMetadata> createVictim() {
+        return constructOrange(Pipeline.Context.DIAGNOSTIC, true);
+    }
+
+    private Orange constructOrange(final Pipeline.Context context, final boolean includeGermline) {
         return new Orange(TestInputs.tumorMetricsOutput(),
                 TestInputs.referenceMetricsOutput(),
                 TestInputs.tumorFlagstatOutput(),
@@ -42,8 +49,8 @@ public class OrangeTest extends TertiaryStageTest<OrangeOutput> {
                 TestInputs.peachOutput(),
                 TestInputs.sigsOutput(),
                 TestInputs.REF_GENOME_37_RESOURCE_FILES,
-                Pipeline.Context.DIAGNOSTIC,
-                true);
+                context,
+                includeGermline);
     }
 
     @Override
@@ -109,53 +116,28 @@ public class OrangeTest extends TertiaryStageTest<OrangeOutput> {
 
     @Test
     public void shouldAddResearchDisclaimerWhenResearchContext() {
-        Orange victim = new Orange(TestInputs.tumorMetricsOutput(),
-                TestInputs.referenceMetricsOutput(),
-                TestInputs.tumorFlagstatOutput(),
-                TestInputs.referenceFlagstatOutput(),
-                TestInputs.sageSomaticOutput(),
-                TestInputs.sageGermlineOutput(),
-                TestInputs.purpleOutput(),
-                TestInputs.chordOutput(),
-                TestInputs.lilacOutput(),
-                TestInputs.linxGermlineOutput(),
-                TestInputs.linxSomaticOutput(),
-                TestInputs.cuppaOutput(),
-                TestInputs.virusInterpreterOutput(),
-                TestInputs.peachOutput(),
-                TestInputs.sigsOutput(),
-                TestInputs.REF_GENOME_37_RESOURCE_FILES,
-                Pipeline.Context.RESEARCH,
-                true);
+        Orange victim = constructOrange(Pipeline.Context.RESEARCH, true);
         assertThat(orangeCommand(victim).asBash()).contains("-add_disclaimer");
-    }
-
-    private static BashCommand orangeCommand(Orange victim) {
-        return victim.tumorReferenceCommands(TestInputs.defaultSomaticRunMetadata()).get(2);
     }
 
     @Test
     public void shouldAddGermlineToSomaticConversionAndChangeNamespaceWhenNotIncludeGermline() {
-        Orange victim = new Orange(TestInputs.tumorMetricsOutput(),
-                TestInputs.referenceMetricsOutput(),
-                TestInputs.tumorFlagstatOutput(),
-                TestInputs.referenceFlagstatOutput(),
-                TestInputs.sageSomaticOutput(),
-                TestInputs.sageGermlineOutput(),
-                TestInputs.purpleOutput(),
-                TestInputs.chordOutput(),
-                TestInputs.lilacOutput(),
-                TestInputs.linxGermlineOutput(),
-                TestInputs.linxSomaticOutput(),
-                TestInputs.cuppaOutput(),
-                TestInputs.virusInterpreterOutput(),
-                TestInputs.peachOutput(),
-                TestInputs.sigsOutput(),
-                TestInputs.REF_GENOME_37_RESOURCE_FILES,
-                Pipeline.Context.RESEARCH,
-                false);
+        Orange victim = constructOrange(Pipeline.Context.RESEARCH, false);
         assertThat(victim.namespace()).isEqualTo(Orange.NAMESPACE_NO_GERMLINE);
         assertThat(orangeCommand(victim).asBash()).contains("-convert_germline_to_somatic");
+    }
+
+    @Test
+    public void shouldReturnFurtherOperationsWhenGermlineNotIncluded() {
+        Orange victim = constructOrange(Pipeline.Context.RESEARCH, false);
+        assertThat(victim.addDatatypes(defaultSomaticRunMetadata())).isEqualTo(
+                List.of(new AddDatatype(DataType.ORANGE_OUTPUT_JSON,
+                                TestInputs.defaultSomaticRunMetadata().barcode(),
+                                new ArchivePath(Folder.root(), Orange.NAMESPACE_NO_GERMLINE, "tumor.orange.json")),
+                        new AddDatatype(DataType.ORANGE_OUTPUT_PDF,
+                                TestInputs.defaultSomaticRunMetadata().barcode(),
+                                new ArchivePath(Folder.root(), Orange.NAMESPACE_NO_GERMLINE, "tumor.orange.pdf"))));
+
     }
 
     @Override
@@ -175,11 +157,6 @@ public class OrangeTest extends TertiaryStageTest<OrangeOutput> {
 
     @Override
     protected List<AddDatatype> expectedFurtherOperations() {
-        return List.of(new AddDatatype(DataType.ORANGE_OUTPUT_JSON,
-                        TestInputs.defaultSomaticRunMetadata().barcode(),
-                        new ArchivePath(Folder.root(), Orange.NAMESPACE, "tumor.orange.json")),
-                new AddDatatype(DataType.ORANGE_OUTPUT_PDF,
-                        TestInputs.defaultSomaticRunMetadata().barcode(),
-                        new ArchivePath(Folder.root(), Orange.NAMESPACE, "tumor.orange.pdf")));
+        return List.of();
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/orange/OrangeTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/orange/OrangeTest.java
@@ -14,6 +14,7 @@ import com.hartwig.pipeline.testsupport.TestInputs;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static com.hartwig.pipeline.testsupport.TestInputs.defaultSomaticRunMetadata;
@@ -128,16 +129,9 @@ public class OrangeTest extends TertiaryStageTest<OrangeOutput> {
     }
 
     @Test
-    public void shouldReturnFurtherOperationsWhenGermlineNotIncluded() {
+    public void shouldReturnNoFurtherOperationsWhenGermlineNotIncluded() {
         Orange victim = constructOrange(Pipeline.Context.RESEARCH, false);
-        assertThat(victim.addDatatypes(defaultSomaticRunMetadata())).isEqualTo(
-                List.of(new AddDatatype(DataType.ORANGE_OUTPUT_JSON,
-                                TestInputs.defaultSomaticRunMetadata().barcode(),
-                                new ArchivePath(Folder.root(), Orange.NAMESPACE_NO_GERMLINE, "tumor.orange.json")),
-                        new AddDatatype(DataType.ORANGE_OUTPUT_PDF,
-                                TestInputs.defaultSomaticRunMetadata().barcode(),
-                                new ArchivePath(Folder.root(), Orange.NAMESPACE_NO_GERMLINE, "tumor.orange.pdf"))));
-
+        assertThat(victim.addDatatypes(defaultSomaticRunMetadata())).isEqualTo(Collections.emptyList());
     }
 
     @Override
@@ -157,6 +151,11 @@ public class OrangeTest extends TertiaryStageTest<OrangeOutput> {
 
     @Override
     protected List<AddDatatype> expectedFurtherOperations() {
-        return List.of();
+        return List.of(new AddDatatype(DataType.ORANGE_OUTPUT_JSON,
+                        TestInputs.defaultSomaticRunMetadata().barcode(),
+                        new ArchivePath(Folder.root(), Orange.NAMESPACE, "tumor.orange.json")),
+                new AddDatatype(DataType.ORANGE_OUTPUT_PDF,
+                        TestInputs.defaultSomaticRunMetadata().barcode(),
+                        new ArchivePath(Folder.root(), Orange.NAMESPACE, "tumor.orange.pdf")));
     }
 }


### PR DESCRIPTION
These files are used only by ACTIN currently and that project doesn't need the datatypes at the moment. Without this change we end up with a list of items under the key in the dataset which breaks existing clients.