### PR TITLE
DEV-3490 configure tag release

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+    <extension>
+        <groupId>com.google.cloud.artifactregistry</groupId>
+        <artifactId>artifactregistry-maven-wagon</artifactId>
+        <version>2.2.1</version>
+    </extension>
+</extensions>

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,7 +11,7 @@ steps:
     args: [ 'versions:set', '-DnewVersion=$TAG_NAME' ]
   - id: 'Maven build and deploy using cache'
     name: 'eu.gcr.io/hmf-build/maven-cache'
-    args: [ 'Deploy -Drelease --batch-mode' ]
+    args: [ 'deploy -Drelease --batch-mode' ]
   - id: 'Publish Docker Image'
     dir: cluster
     name: 'eu.gcr.io/hmf-build/docker-tag'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -21,4 +21,4 @@ images:
 logsBucket: 'gs://hmf-build-logs'
 timeout: 4800s
 options:
-  machineType: 'N1_HIGHCPU_32'
+  machineType: 'E2_HIGHCPU_8'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,10 +5,9 @@ steps:
   - name: gcr.io/cloud-builders/gcloud
     entrypoint: 'bash'
     args: [ '-c', "gcloud secrets versions access latest --secret=development_serviceaccount_key --format='get(payload.data)' | tr '_-' '/+' | base64 -d > cluster/google-key.json" ]
-  - name: 'maven:3-jdk-11'
-    id: 'Set version for Maven'
-    entrypoint: mvn
-    args: [ 'versions:set', '-DnewVersion=$TAG_NAME' ]
+  - name: 'eu.gcr.io/hmf-build/maven-cache/alpine-java11'
+    id: 'Set version for Maven using cache'
+    args: [ 'versions:set -DnewVersion=$TAG_NAME' ]
   - id: 'Maven build and deploy using cache'
     name: 'eu.gcr.io/hmf-build/maven-cache/alpine-java11'
     args: [ 'deploy -Drelease --batch-mode' ]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,49 +8,14 @@ steps:
   - name: 'maven:3-jdk-11'
     id: 'Set version for Maven'
     entrypoint: mvn
-    args: [ 'versions:set', '-DnewVersion=${_MAJOR_MINOR_VERSION}.$SHORT_SHA' ]
-  - name: 'gcr.io/cloud-builders/gsutil'
-    id: 'Prime Maven cache'
-    args:
-      - '-m'
-      - 'rsync'
-      - '-r'
-      - 'gs://hmf-build-caches/pipeline5/.m2'
-      - '/cache/.m2'
-    volumes:
-      - path: '/cache/.m2'
-        name: 'm2_cache'
-  - name: hartwigmedicalfoundation/docker-mvn-gcloud:3-jdk-11
-    id: 'Deploy artifacts to Maven repository'
-    entrypoint: mvn
-    timeout: 2400s
-    args:
-      - 'deploy'
-      - '-Drelease'
-      - '--batch-mode'
-    env:
-      - MAVEN_OPTS=-Dmaven.repo.local=/cache/.m2
-    volumes:
-      - path: '/cache/.m2'
-        name: 'm2_cache'
-  - name: 'gcr.io/cloud-builders/gsutil'
-    id: 'Update Maven cache after dependency resolution'
-    args:
-      - '-m'
-      - 'rsync'
-      - '-r'
-      - '/cache/.m2'
-      - 'gs://hmf-build-caches/pipeline5/.m2/'
-    volumes:
-      - path: '/cache/.m2'
-        name: 'm2_cache'
-  - name: 'gcr.io/cloud-builders/docker'
-    id: 'Build pipeline image'
-    args: [ 'build', '-t', 'eu.gcr.io/$PROJECT_ID/pipeline5:${_MAJOR_MINOR_VERSION}.$SHORT_SHA', './cluster/', '--build-arg', 'VERSION=${_MAJOR_MINOR_VERSION}.$SHORT_SHA' ]
-  - name: 'gcr.io/cloud-builders/docker'
-    id: 'Push pipeline image'
-    entrypoint: '/bin/bash'
-    args: [ '-c', "docker push eu.gcr.io/$PROJECT_ID/pipeline5:${_MAJOR_MINOR_VERSION}.$SHORT_SHA" ]
+    args: [ 'versions:set', '-DnewVersion=$TAG_NAME' ]
+  - id: 'Maven build and deploy using cache'
+    name: 'eu.gcr.io/hmf-build/maven-cache'
+    args: [ 'Deploy -Drelease --batch-mode' ]
+  - id: 'Publish Docker Image'
+    dir: cluster
+    name: 'eu.gcr.io/hmf-build/docker-tag'
+    args: [ 'eu.gcr.io/$PROJECT_ID/pipeline5', '$TAG_NAME' ]
 images:
   - eu.gcr.io/$PROJECT_ID/pipeline5
 logsBucket: 'gs://hmf-build-logs'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,7 +10,7 @@ steps:
     entrypoint: mvn
     args: [ 'versions:set', '-DnewVersion=$TAG_NAME' ]
   - id: 'Maven build and deploy using cache'
-    name: 'eu.gcr.io/hmf-build/maven-cache'
+    name: 'eu.gcr.io/hmf-build/maven-cache/alpine-java11'
     args: [ 'deploy -Drelease --batch-mode' ]
   - id: 'Publish Docker Image'
     dir: cluster

--- a/pom.xml
+++ b/pom.xml
@@ -278,11 +278,6 @@
                 <artifactId>google-storage-wagon</artifactId>
                 <version>1.0</version>
             </extension>
-            <extension>
-                <groupId>com.google.cloud.artifactregistry</groupId>
-                <artifactId>artifactregistry-maven-wagon</artifactId>
-                <version>2.1.0</version>
-            </extension>
         </extensions>
         <plugins>
             <plugin>


### PR DESCRIPTION
- configure tag relase for pipeline5
- incooporate maven cache for faster builds

Currently blocked by https://github.com/hartwigmedical/build-tools/pull/11