### PR TITLE
DEV-3490 update release method

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,9 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+    <extension>
+        <!-- ensures that Maven can download artifacts from Artifact Registry, including the parent pom -->
+        <groupId>com.google.cloud.artifactregistry</groupId>
+        <artifactId>artifactregistry-maven-wagon</artifactId>
+        <version>2.2.1</version>
+    </extension>
+</extensions>

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -46,6 +46,6 @@ steps:
     dir: cluster
     args: ['eu.gcr.io/hmf-build/pipeline5', '$TAG_NAME']
 images:
-  - eu.gcr.io/$PROJECT_ID/pipeline5
+  - eu.gcr.io/hmf-build/pipeline5
 logsBucket: 'gs://hmf-build-logs'
 timeout: 4800s

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -43,6 +43,7 @@ steps:
         name: 'm2_cache'
   - name: 'eu.gcr.io/hmf-build/docker-tag'
     id: 'Publish Docker image'
+    dir: cluster
     args: ['eu.gcr.io/hmf-build/pipeline5', '$TAG_NAME']
 images:
   - eu.gcr.io/$PROJECT_ID/pipeline5

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -44,7 +44,7 @@ steps:
   - name: 'eu.gcr.io/hmf-build/docker-tag'
     id: 'Publish Docker image'
     dir: cluster
-    args: ['eu.gcr.io/hmf-build/pipeline5', '$TAG_NAME', 'Dockerfile', '$TAG_NAME']
+    args: ['eu.gcr.io/hmf-build/pipeline5', '$TAG_NAME', 'Dockerfile', '--build-arg', 'VERSION=$TAG_NAME']
 images:
   - eu.gcr.io/hmf-build/pipeline5
 logsBucket: 'gs://hmf-build-logs'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -48,5 +48,3 @@ images:
   - eu.gcr.io/$PROJECT_ID/pipeline5
 logsBucket: 'gs://hmf-build-logs'
 timeout: 4800s
-options:
-  machineType: 'E2_HIGHCPU_16'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -44,7 +44,7 @@ steps:
   - name: 'eu.gcr.io/hmf-build/docker-tag'
     id: 'Publish Docker image'
     dir: cluster
-    args: ['eu.gcr.io/hmf-build/pipeline5', '$TAG_NAME']
+    args: ['eu.gcr.io/hmf-build/pipeline5', '$TAG_NAME', 'Dockerfile', '$TAG_NAME']
 images:
   - eu.gcr.io/hmf-build/pipeline5
 logsBucket: 'gs://hmf-build-logs'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
   - name: 'maven:3-jdk-11'
     id: 'Set version for Maven'
     entrypoint: mvn
-    args: [ 'versions:set', '-DnewVersion=${_MAJOR_MINOR_VERSION}.$SHORT_SHA' ]
+    args: [ 'versions:set', '-DnewVersion=${TAG_NAME}' ]
   - name: 'gcr.io/cloud-builders/gsutil'
     id: 'Prime Maven cache'
     args:
@@ -41,13 +41,9 @@ steps:
     volumes:
       - path: '/cache/.m2'
         name: 'm2_cache'
-  - name: 'gcr.io/cloud-builders/docker'
-    id: 'Build pipeline image'
-    args: [ 'build', '-t', 'eu.gcr.io/$PROJECT_ID/pipeline5:${_MAJOR_MINOR_VERSION}.$SHORT_SHA', './cluster/', '--build-arg', 'VERSION=${_MAJOR_MINOR_VERSION}.$SHORT_SHA' ]
-  - name: 'gcr.io/cloud-builders/docker'
-    id: 'Push pipeline image'
-    entrypoint: '/bin/bash'
-    args: [ '-c', "docker push eu.gcr.io/$PROJECT_ID/pipeline5:${_MAJOR_MINOR_VERSION}.$SHORT_SHA" ]
+  - name: 'eu.gcr.io/hmf-build/docker-tag'
+    id: 'Publish Docker image'
+    args: ['eu.gcr.io/hmf-build/pipeline5', '$TAG_NAME']
 images:
   - eu.gcr.io/$PROJECT_ID/pipeline5
 logsBucket: 'gs://hmf-build-logs'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -49,4 +49,4 @@ images:
 logsBucket: 'gs://hmf-build-logs'
 timeout: 4800s
 options:
-  machineType: 'N1_HIGHCPU_32'
+  machineType: 'E2_HIGHCPU_16'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -49,3 +49,5 @@ images:
   - eu.gcr.io/hmf-build/pipeline5
 logsBucket: 'gs://hmf-build-logs'
 timeout: 4800s
+options:
+  machineType: 'E2_HIGHCPU_32'

--- a/cluster/src/test/java/com/hartwig/pipeline/smoke/SmokeTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/smoke/SmokeTest.java
@@ -41,7 +41,6 @@ import org.junit.runner.RunWith;
 
 @RunWith(Parallelized.class)
 @Category(value = IntegrationTest.class)
-@Ignore
 public class SmokeTest {
 
     protected static final String FILE_ENCODING = "UTF-8";

--- a/cluster/src/test/java/com/hartwig/pipeline/smoke/SmokeTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/smoke/SmokeTest.java
@@ -41,6 +41,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(Parallelized.class)
 @Category(value = IntegrationTest.class)
+@Ignore
 public class SmokeTest {
 
     protected static final String FILE_ENCODING = "UTF-8";

--- a/pom.xml
+++ b/pom.xml
@@ -330,10 +330,6 @@
     </reporting>
 
     <distributionManagement>
-        <snapshotRepository>
-            <id>artifact-registry</id>
-            <url>artifactregistry://europe-west4-maven.pkg.dev/hmf-build/hmf-maven</url>
-        </snapshotRepository>
         <repository>
             <id>artifact-registry</id>
             <url>artifactregistry://europe-west4-maven.pkg.dev/hmf-build/hmf-maven</url>

--- a/pom.xml
+++ b/pom.xml
@@ -278,11 +278,6 @@
                 <artifactId>google-storage-wagon</artifactId>
                 <version>1.0</version>
             </extension>
-            <extension>
-                <groupId>com.google.cloud.artifactregistry</groupId>
-                <artifactId>artifactregistry-maven-wagon</artifactId>
-                <version>2.1.0</version>
-            </extension>
         </extensions>
         <plugins>
             <plugin>
@@ -335,9 +330,13 @@
     </reporting>
 
     <distributionManagement>
+        <snapshotRepository>
+            <id>artifact-registry</id>
+            <url>artifactregistry://europe-west4-maven.pkg.dev/hmf-build/hmf-maven</url>
+        </snapshotRepository>
         <repository>
-            <id>hmf-release</id>
-            <url>gs://hmf-maven-repository/release</url>
+            <id>artifact-registry</id>
+            <url>artifactregistry://europe-west4-maven.pkg.dev/hmf-build/hmf-maven</url>
         </repository>
     </distributionManagement>
 


### PR DESCRIPTION
- Update cloud build to use `docker-tag` and `$TAG_NAME`.
- Add mvn `extension.xml` file to ensure ide support for downloading sources and documentation.
- Change deployment location to artifact registry.