### PR TITLE
DEV-3682 Publish turquoise subject in turquoise

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
@@ -154,9 +154,7 @@ public class PipelineMain {
             apiStatusUpdateOrNot.start();
             String ini = somaticRunMetadata.isSingleSample() ? "single_sample" : arguments.shallow() ? "shallow" : "somatic";
             PipelineProperties eventSubjects = PipelineProperties.builder()
-                    .sample(somaticRunMetadata.maybeTumor()
-                            .map(SingleSampleRunMetadata::sampleName)
-                            .orElseGet(() -> somaticRunMetadata.reference().sampleName()))
+                    .sample(collectTurquoiseSubject(somaticRunMetadata))
                     .runId(arguments.sbpApiRunId())
                     .set(somaticRunMetadata.set())
                     .referenceBarcode(somaticRunMetadata.maybeReference().map(SingleSampleRunMetadata::barcode))
@@ -220,6 +218,12 @@ public class PipelineMain {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private String collectTurquoiseSubject(final SomaticRunMetadata somaticRunMetadata) {
+        return somaticRunMetadata.maybeTumor()
+                .map(SingleSampleRunMetadata::turquoiseSubject)
+                .orElseGet(() -> somaticRunMetadata.reference().turquoiseSubject());
     }
 
     @NotNull

--- a/cluster/src/main/java/com/hartwig/pipeline/input/MetadataProvider.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/input/MetadataProvider.java
@@ -32,6 +32,7 @@ public class MetadataProvider {
                         .type(SingleSampleRunMetadata.SampleType.TUMOR)
                         .barcode(barcodeOrSampleName(t))
                         .sampleName(t.name())
+                        .turquoiseSubject(t.turquoiseSubject())
                         .primaryTumorDoids(t.primaryTumorDoids())
                         .samplingDate(t.samplingDate())
                         .build()))
@@ -41,6 +42,7 @@ public class MetadataProvider {
                         .type(SingleSampleRunMetadata.SampleType.REFERENCE)
                         .barcode(barcodeOrSampleName(r))
                         .sampleName(r.name())
+                        .turquoiseSubject(r.turquoiseSubject())
                         .build()))
                 .maybeExternalIds(pipelineInput.operationalReferences())
                 .build();

--- a/cluster/src/main/java/com/hartwig/pipeline/input/SingleSampleRunMetadata.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/input/SingleSampleRunMetadata.java
@@ -29,6 +29,8 @@ public interface SingleSampleRunMetadata extends RunMetadata {
         return -1;
     }
 
+    String turquoiseSubject();
+
     String barcode();
 
     SampleType type();

--- a/cluster/src/test/java/com/hartwig/pipeline/alignment/RunTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/alignment/RunTest.java
@@ -5,8 +5,6 @@ import static com.hartwig.pipeline.testsupport.TestInputs.SET;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Optional;
-
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.input.SingleSampleRunMetadata;
 import com.hartwig.pipeline.input.SomaticRunMetadata;
@@ -24,7 +22,7 @@ public class RunTest {
     }
 
     private static SingleSampleRunMetadata sample(final SingleSampleRunMetadata.SampleType type, final String sampleId) {
-        return SingleSampleRunMetadata.builder().type(type).barcode(sampleId).bucket(BUCKET).set(SET).build();
+        return SingleSampleRunMetadata.builder().type(type).barcode(sampleId).turquoiseSubject(sampleId).bucket(BUCKET).set(SET).build();
     }
 
     @Test

--- a/cluster/src/test/java/com/hartwig/pipeline/alignment/bwa/BwaAlignerTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/alignment/bwa/BwaAlignerTest.java
@@ -48,7 +48,7 @@ public class BwaAlignerTest {
         sampleUpload = mock(SampleUpload.class);
         PipelineInput input = PipelineInput.builder()
                 .setName(TestInputs.SET)
-                .reference(SampleInput.builder().name(METADATA.sampleName()).addLanes(lane(1)).addLanes(lane(2)).build())
+                .reference(SampleInput.builder().name(METADATA.sampleName()).turquoiseSubject(METADATA.turquoiseSubject()).addLanes(lane(1)).addLanes(lane(2)).build())
                 .build();
         victim = new BwaAligner(arguments,
                 computeEngine,
@@ -101,7 +101,7 @@ public class BwaAlignerTest {
         String gsUrl = "gs://bucket/path/reference.bam";
         PipelineInput input = PipelineInput.builder()
                 .setName(METADATA.set())
-                .reference(SampleInput.builder().name(METADATA.sampleName()).bam(gsUrl).build())
+                .reference(SampleInput.builder().name(METADATA.sampleName()).turquoiseSubject(METADATA.turquoiseSubject()).bam(gsUrl).build())
                 .build();
         victim = new BwaAligner(arguments,
                 computeEngine,

--- a/cluster/src/test/java/com/hartwig/pipeline/input/MetadataProviderTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/input/MetadataProviderTest.java
@@ -64,7 +64,7 @@ public class MetadataProviderTest {
     public void shouldSetReferenceSampleWhenGiven() {
         String sampleName = "refSample";
         String barcode = "FR1234";
-        SampleInput reference = SampleInput.builder().name(sampleName).barcode(barcode).primaryTumorDoids(List.of("a", "b")).build();
+        SampleInput reference = SampleInput.builder().name(sampleName).turquoiseSubject(sampleName).barcode(barcode).primaryTumorDoids(List.of("a", "b")).build();
         pipelineInput = PipelineInput.builder().from(pipelineInput).reference(reference).build();
         victim = new MetadataProvider(arguments, pipelineInput);
         assertThat(victim.get().maybeReference()).isPresent();
@@ -82,7 +82,7 @@ public class MetadataProviderTest {
         String sampleName = "tumorSample";
         String barcode = "FR1235";
         List<String> doids = List.of("a", "b", "c");
-        SampleInput tumor = SampleInput.builder().name(sampleName).barcode(barcode).primaryTumorDoids(doids).build();
+        SampleInput tumor = SampleInput.builder().name(sampleName).turquoiseSubject(sampleName).barcode(barcode).primaryTumorDoids(doids).build();
         pipelineInput = PipelineInput.builder().from(pipelineInput).tumor(tumor).build();
         victim = new MetadataProvider(arguments, pipelineInput);
         assertThat(victim.get().maybeTumor()).isPresent();
@@ -99,7 +99,7 @@ public class MetadataProviderTest {
     public void shouldUseSampleNameAsBarcodeIfBarcodeNotSet() {
         String sampleName = "tumorSample";
         List<String> doids = List.of("a", "b", "c");
-        SampleInput tumor = SampleInput.builder().name(sampleName).primaryTumorDoids(doids).build();
+        SampleInput tumor = SampleInput.builder().name(sampleName).turquoiseSubject(sampleName).primaryTumorDoids(doids).build();
         pipelineInput = PipelineInput.builder().from(pipelineInput).tumor(tumor).build();
         victim = new MetadataProvider(arguments, pipelineInput);
         assertThat(victim.get().maybeTumor()).isPresent();

--- a/cluster/src/test/java/com/hartwig/pipeline/storage/CloudSampleUploadTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/storage/CloudSampleUploadTest.java
@@ -28,7 +28,7 @@ public class CloudSampleUploadTest {
             .laneNumber("")
             .flowCellId("")
             .build();
-    private static final SampleInput SAMPLE_ONE_LANE = SampleInput.builder().name(SAMPLE_NAME).addLanes(LANE_1).build();
+    private static final SampleInput SAMPLE_ONE_LANE = SampleInput.builder().name(SAMPLE_NAME).turquoiseSubject(SAMPLE_NAME).addLanes(LANE_1).build();
     private static final String TARGET_PATH = "gs://run/samples/TEST123/";
     private CloudCopy cloudCopy;
     private CloudSampleUpload victim;

--- a/cluster/src/test/java/com/hartwig/pipeline/testsupport/TestInputs.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/testsupport/TestInputs.java
@@ -97,8 +97,8 @@ public class TestInputs {
     public static PipelineInput pipelineInput() {
         return PipelineInput.builder()
                 .setName(SET)
-                .reference(SampleInput.builder().name(REFERENCE_SAMPLE).build())
-                .tumor(SampleInput.builder().name(TUMOR_SAMPLE).build())
+                .reference(SampleInput.builder().name(REFERENCE_SAMPLE).turquoiseSubject(REFERENCE_SAMPLE).build())
+                .tumor(SampleInput.builder().name(TUMOR_SAMPLE).turquoiseSubject(REFERENCE_SAMPLE).build())
                 .build();
     }
 
@@ -159,6 +159,7 @@ public class TestInputs {
                 .bucket(BUCKET)
                 .type(SingleSampleRunMetadata.SampleType.REFERENCE)
                 .barcode(referenceAlignmentOutput().sample())
+                .turquoiseSubject(referenceAlignmentOutput().sample())
                 .build();
     }
 
@@ -169,6 +170,7 @@ public class TestInputs {
                 .bucket(BUCKET)
                 .type(SingleSampleRunMetadata.SampleType.TUMOR)
                 .barcode(tumorAlignmentOutput().sample())
+                .turquoiseSubject(tumorAlignmentOutput().sample())
                 .primaryTumorDoids(List.of("01", "02"))
                 .samplingDate(LocalDate.of(2023, 5, 19))
                 .build();

--- a/cluster/src/test/resources/pipeline-input/with_dataset.json
+++ b/cluster/src/test/resources/pipeline-input/with_dataset.json
@@ -2,6 +2,7 @@
   "setName": "CPCT12345678",
   "tumor": {
     "name": "CPCT12345678T",
+    "turquoiseSubject": "COLO829v003T",
     "lanes": [
       {
         "directory": "bucket_name",
@@ -13,6 +14,7 @@
   },
   "reference": {
     "name": "CPCT12345678R",
+    "turquoiseSubject": "COLO829v003R",
     "lanes": [
       {
         "directory": "bucket_name",

--- a/cluster/src/test/resources/smoke_test/reference/samples.json
+++ b/cluster/src/test/resources/smoke_test/reference/samples.json
@@ -3,6 +3,7 @@
   "reference": {
     "type": "REFERENCE",
     "name": "COLO829v003R",
+    "turquoiseSubject": "COLO829v003R",
     "barcode": "FR10101010",
     "lanes": [
       {

--- a/cluster/src/test/resources/smoke_test/tumor-reference/samples.json
+++ b/cluster/src/test/resources/smoke_test/tumor-reference/samples.json
@@ -3,6 +3,7 @@
   "tumor": {
     "type": "TUMOR",
     "name": "COLO829v003T",
+    "turquoiseSubject": "COLO829v003T",
     "barcode": "FR10101011",
     "lanes": [
       {
@@ -30,6 +31,7 @@
   "reference": {
     "type": "REFERENCE",
     "name": "COLO829v003R",
+    "turquoiseSubject": "COLO829v003R",
     "barcode": "FR10101010",
     "lanes": [
       {

--- a/cluster/src/test/resources/smoke_test/tumor/samples.json
+++ b/cluster/src/test/resources/smoke_test/tumor/samples.json
@@ -3,6 +3,7 @@
   "tumor": {
     "type": "TUMOR",
     "name": "COLO829v003T",
+    "turquoiseSubject": "COLO829v003T",
     "barcode": "FR10101011",
     "lanes": [
       {

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,8 @@
         <java-client.version>1.31.1</java-client.version>
         <compar.version>1.1</compar.version>
         <org-reflections.version>0.9.11</org-reflections.version>
-        <pdl.version>1.3.0</pdl.version>
+<!--        <pdl.version>1.3.0</pdl.version>-->
+        <pdl.version>1.7.0-beta.1</pdl.version>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <java-client.version>1.31.1</java-client.version>
         <compar.version>1.1</compar.version>
         <org-reflections.version>0.9.11</org-reflections.version>
-        <pdl.version>1.7.0</pdl.version>
+        <pdl.version>1.7.1</pdl.version>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,7 @@
         <java-client.version>1.31.1</java-client.version>
         <compar.version>1.1</compar.version>
         <org-reflections.version>0.9.11</org-reflections.version>
-<!--        <pdl.version>1.3.0</pdl.version>-->
-        <pdl.version>1.7.0-beta.1</pdl.version>
+        <pdl.version>1.7.0</pdl.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
This change uses a new field from PDL `turquoiseSubject` to pass on to turquoise via the event. This allows pipeline5 to publish turquoise events using a different subject/name than what is used to generate output files.