### PR TITLE
DEV-3688 Unify VM core and memory declarations

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinition.java
@@ -1,7 +1,16 @@
 package com.hartwig.pipeline.execution.vm;
 
 import static com.hartwig.pipeline.execution.vm.VirtualMachinePerformanceProfile.custom;
+import static com.hartwig.pipeline.tools.HmfTool.AMBER;
+import static com.hartwig.pipeline.tools.HmfTool.BAM_TOOLS;
+import static com.hartwig.pipeline.tools.HmfTool.CHORD;
 import static com.hartwig.pipeline.tools.HmfTool.COBALT;
+import static com.hartwig.pipeline.tools.HmfTool.GRIDSS;
+import static com.hartwig.pipeline.tools.HmfTool.GRIPSS;
+import static com.hartwig.pipeline.tools.HmfTool.HEALTH_CHECKER;
+import static com.hartwig.pipeline.tools.HmfTool.LINX;
+import static com.hartwig.pipeline.tools.HmfTool.PAVE;
+import static com.hartwig.pipeline.tools.HmfTool.PURPLE;
 
 import com.hartwig.pipeline.ResultsDirectory;
 import com.hartwig.pipeline.execution.JobDefinition;
@@ -15,50 +24,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
     String STANDARD_IMAGE = "pipeline5-" + VersionUtils.imageVersion();
     String HMF_IMAGE_PROJECT = "hmf-images";
     String PUBLIC_IMAGE_NAME = "hmf-public-pipeline-v1";
-
-    @Value.Derived
-    default long baseImageDiskSizeGb() {
-        return 200L;
-    }
-
-    @Value.Default
-    default String imageFamily() {
-        return STANDARD_IMAGE;
-    }
-
-    @Value.Default
-    default long workingDiskSpaceGb() {
-        return 1200L;
-    }
-
     int LOCAL_SSD_DISK_SPACE_GB = 375;
-
-    BashStartupScript startupCommand();
-
-    ResultsDirectory namespacedResults();
-
-    @Value.Derived
-    default long totalPersistentDiskSizeGb() {
-        return baseImageDiskSizeGb() + workingDiskSpaceGb();
-    }
-
-    @Value.Derived
-    default int localSsdCount() {
-        int localSsdDeviceSizeGb = LOCAL_SSD_DISK_SPACE_GB;
-
-        int floor = Math.toIntExact(workingDiskSpaceGb() / localSsdDeviceSizeGb);
-        long remainder = workingDiskSpaceGb() % localSsdDeviceSizeGb;
-        if (remainder != 0) {
-            floor++;
-        }
-        return floor;
-    }
-
-    @Override
-    @Value.Default
-    default VirtualMachinePerformanceProfile performanceProfile() {
-        return VirtualMachinePerformanceProfile.defaultVm();
-    }
 
     static ImmutableVirtualMachineJobDefinition.Builder builder() {
         return ImmutableVirtualMachineJobDefinition.builder();
@@ -104,7 +70,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
         return ImmutableVirtualMachineJobDefinition.builder()
                 .name("gridss")
                 .startupCommand(startupScript)
-                .performanceProfile(custom(24, 64))
+                .performanceProfile(custom(GRIDSS.getCpus(), GRIDSS.getMemoryGb()))
                 .namespacedResults(resultsDirectory)
                 .build();
     }
@@ -114,7 +80,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
         return ImmutableVirtualMachineJobDefinition.builder()
                 .name(name)
                 .startupCommand(startupScript)
-                .performanceProfile(custom(4, 24))
+                .performanceProfile(custom(GRIPSS.getCpus(), GRIPSS.getMemoryGb()))
                 .namespacedResults(resultsDirectory)
                 .build();
     }
@@ -124,7 +90,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
                 .name("purple")
                 .startupCommand(bash)
                 .namespacedResults(resultsDirectory)
-                .performanceProfile(custom(6, 39))
+                .performanceProfile(custom(PURPLE.getCpus(), PURPLE.getMemoryGb()))
                 .workingDiskSpaceGb(LOCAL_SSD_DISK_SPACE_GB)
                 .build();
     }
@@ -134,7 +100,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
                 .name(name)
                 .startupCommand(bash)
                 .namespacedResults(resultsDirectory)
-                .performanceProfile(custom(4, 24))
+                .performanceProfile(custom(PAVE.getCpus(), PAVE.getMemoryGb()))
                 .workingDiskSpaceGb(LOCAL_SSD_DISK_SPACE_GB)
                 .build();
     }
@@ -144,7 +110,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
                 .name("amber")
                 .startupCommand(startupScript)
                 .namespacedResults(resultsDirectory)
-                .performanceProfile(custom(16, 64))
+                .performanceProfile(custom(AMBER.getCpus(), AMBER.getMemoryGb()))
                 .build();
     }
 
@@ -153,7 +119,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
                 .name("virusbreakend")
                 .startupCommand(startupScript)
                 .namespacedResults(resultsDirectory)
-                .performanceProfile(custom(12, 64))
+                .performanceProfile(custom(GRIDSS.getCpus(), GRIDSS.getMemoryGb()))
                 .build();
     }
 
@@ -170,7 +136,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
         return ImmutableVirtualMachineJobDefinition.builder()
                 .name("bam-metrics")
                 .startupCommand(startupScript)
-                .performanceProfile(custom(16, 32))
+                .performanceProfile(custom(BAM_TOOLS.getCpus(), BAM_TOOLS.getMemoryGb()))
                 .namespacedResults(resultsDirectory)
                 .build();
     }
@@ -179,7 +145,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
         return ImmutableVirtualMachineJobDefinition.builder()
                 .name("health-checker")
                 .startupCommand(startupScript)
-                .performanceProfile(custom(8, 32))
+                .performanceProfile(custom(HEALTH_CHECKER.getCpus(), HEALTH_CHECKER.getMemoryGb()))
                 .namespacedResults(resultsDirectory)
                 .build();
     }
@@ -218,7 +184,7 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
                 .name("linx-" + type)
                 .startupCommand(startupScript)
                 .namespacedResults(resultsDirectory)
-                .performanceProfile(custom(4, 12))
+                .performanceProfile(custom(LINX.getCpus(), LINX.getMemoryGb()))
                 .workingDiskSpaceGb(LOCAL_SSD_DISK_SPACE_GB)
                 .build();
     }
@@ -228,8 +194,50 @@ public interface VirtualMachineJobDefinition extends JobDefinition<VirtualMachin
                 .name("chord")
                 .startupCommand(startupScript)
                 .namespacedResults(resultsDirectory)
-                .performanceProfile(custom(4, 12))
+                .performanceProfile(custom(CHORD.getCpus(), CHORD.getMemoryGb()))
                 .workingDiskSpaceGb(LOCAL_SSD_DISK_SPACE_GB)
                 .build();
+    }
+
+    @Value.Derived
+    default long baseImageDiskSizeGb() {
+        return 200L;
+    }
+
+    @Value.Default
+    default String imageFamily() {
+        return STANDARD_IMAGE;
+    }
+
+    @Value.Default
+    default long workingDiskSpaceGb() {
+        return 1200L;
+    }
+
+    BashStartupScript startupCommand();
+
+    ResultsDirectory namespacedResults();
+
+    @Value.Derived
+    default long totalPersistentDiskSizeGb() {
+        return baseImageDiskSizeGb() + workingDiskSpaceGb();
+    }
+
+    @Value.Derived
+    default int localSsdCount() {
+        int localSsdDeviceSizeGb = LOCAL_SSD_DISK_SPACE_GB;
+
+        int floor = Math.toIntExact(workingDiskSpaceGb() / localSsdDeviceSizeGb);
+        long remainder = workingDiskSpaceGb() % localSsdDeviceSizeGb;
+        if (remainder != 0) {
+            floor++;
+        }
+        return floor;
+    }
+
+    @Override
+    @Value.Default
+    default VirtualMachinePerformanceProfile performanceProfile() {
+        return VirtualMachinePerformanceProfile.defaultVm();
     }
 }

--- a/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
@@ -8,28 +8,25 @@ public enum HmfTool {
 
     AMBER("3.9", 32, 64, 16, false),
     BAM_TOOLS("1.1", 16, 24, 16, false),
-    CHORD("2.02_1.14"),
+    CHORD("2.02_1.14", Defaults.JAVA_HEAP, 12, 4, false),
     COBALT("1.15.2", 20, 24, 16, false),
-    CUPPA("1.8.1"),
-    GRIDSS("2.13.2"),
-    GRIPSS("2.3.5", 16, 24, 1, false),
-    HEALTH_CHECKER("3.5"),
+    CUPPA("1.8.1", Defaults.JAVA_HEAP, 16, 4, false),
+    GRIDSS("2.13.2", Defaults.JAVA_HEAP, 64, 24, false),
+    GRIPSS("2.3.5", 16, 24, 4, false),
+    HEALTH_CHECKER("3.5", Defaults.JAVA_HEAP, 32, 8, false),
     LILAC("1.5.2", 16, 24, 8, false),
-    LINX("1.24.1", 8, 16, 1, false),
+    LINX("1.24.1", 8, 12, 4, false),
     MARK_DUPS("1.0", 16, 24, 16, false),
     ORANGE("2.6.1", 16, 18, 4, false),
-    PAVE("1.5", 16, 24, 1, false),
-    PEACH("1.7"),
-    PURPLE("3.9.2", 31, 32, 8, false),
-    SAGE("3.3", 60, 64, 16, false),
-    SIGS("1.1"),
+    PAVE("1.5", 16, 24, 4, false),
+    PEACH("1.7", 1, 4, 2, false),
+    PURPLE("3.9.2", 31, 39, 6, false),
+    SAGE("3.3"),
+    SIGS("1.1", Defaults.JAVA_HEAP, 16, 4, false),
     SV_PREP("1.2", 48, 64, 24, false),
-    VIRUSBREAKEND_GRIDSS("2.13.2"),
-    VIRUS_INTERPRETER("1.3");
+    VIRUSBREAKEND_GRIDSS("2.13.2", Defaults.JAVA_HEAP, 64, 12, false),
+    VIRUS_INTERPRETER("1.3", Defaults.JAVA_HEAP, 8, 2, false);
 
-    public static final String PILOT_VERSION = "pilot"; // will pick up the jar from /opt/toolName/pilot/toolName.jar
-    private static final int DEFAULT_MAX_HEAP = 4;
-    private static final int DEFAULT_MEMORY = 8;
     private final String toolName;
     private final String version;
     private final int maxHeap;
@@ -38,7 +35,7 @@ public enum HmfTool {
     private final boolean usePilot;
 
     HmfTool(final String version) {
-        this(version, DEFAULT_MAX_HEAP, DEFAULT_MEMORY, 1, false);
+        this(version, Defaults.JAVA_HEAP, Defaults.MEMORY, Defaults.CORES, false);
     }
 
     HmfTool(final String version, final int maxHeap, final int memoryGb, final int cpus, final boolean usePilot) {
@@ -71,7 +68,7 @@ public enum HmfTool {
     }
 
     public String runVersion() {
-        return usePilot ? PILOT_VERSION : version;
+        return usePilot ? Defaults.PILOT_VERSION : version;
     }
 
     public String directory() {
@@ -88,5 +85,12 @@ public enum HmfTool {
 
     public String jarPath() {
         return format("%s/%s/%s/%s", VmDirectories.TOOLS, directory(), version, jar());
+    }
+
+    private static final class Defaults {
+        public static final String PILOT_VERSION = "pilot"; // will pick up the jar from /opt/toolName/pilot/toolName.jar
+        private static final int CORES = 1;
+        private static final int JAVA_HEAP = 4;
+        private static final int MEMORY = 8;
     }
 }


### PR DESCRIPTION
The `HmfTool` class and the VM definitions both define parameters for the VMs that our in-house tooling runs on. I noticed this while trying to increase the memory for Purple and when it wasn't working realised the situation.

Reference the HmfTool-hosted constants from within the VM definition calls whenever they exist as not doing this violates the principle of least surprise. Also I think the intent of the HmfTool class must have been to centralise the configuration as much as possible and this is a step in that direction.

I am aware this is an imperfect solution as the constants don't exist for those tools we don't maintain and a couple of the tools use different parameters depending on which "mode" they've been called in, Sage springs to mind.

I checked pretty thoroughly for references and I think I got them all but I suppose we'll find out in the SmokeTest if anything is off.