### PR TITLE
DEV-3483 Demote retried operation logging to warn

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/InstanceLifecycleManager.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/InstanceLifecycleManager.java
@@ -142,7 +142,7 @@ class InstanceLifecycleManager {
         return Failsafe.with(new RetryPolicy<>().handle(Exception.class)
                 .withDelay(Duration.ofSeconds(pollInterval))
                 .withMaxRetries(MAX_RETRIES)
-                .onFailedAttempt(rExecutionAttemptedEvent -> LOGGER.error("[{}] failed: {}",
+                .onFailedAttempt(rExecutionAttemptedEvent -> LOGGER.warn("[{}] failed but will be retried: {}",
                         opName,
                         rExecutionAttemptedEvent.getLastFailure().getMessage()))).get(operationCheckedSupplier);
     }


### PR DESCRIPTION
The changes that resulted in adding the retries have been battle-tested in production and I'm confident we've got a correct implementation so we can avoid alerting on it every time now.