### PR TITLE
DEV-3706: quick fix to missing linx plot

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/orange/Orange.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/orange/Orange.java
@@ -215,8 +215,11 @@ public class Orange implements Stage<OrangeOutput, SomaticRunMetadata> {
                 .ifPresent(sd -> argumentListBuilder.add("-sampling_date", DateTimeFormatter.ofPattern("yyMMdd").format(sd)));
         JavaJarCommand orangeJarCommand = new JavaJarCommand(ORANGE, argumentListBuilder.build());
 
-        return List.of(() -> "echo '" + pipelineVersion + "' | tee " + pipelineVersionFilePath,
-                orangeJarCommand);
+        return List.of(
+                new MkDirCommand(linxPlotDir),
+                () -> "echo '" + pipelineVersion + "' | tee " + pipelineVersionFilePath,
+                orangeJarCommand
+        );
     }
 
     @Override

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/orange/OrangeTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/orange/OrangeTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 public class OrangeTest extends TertiaryStageTest<OrangeOutput> {
 
     private static BashCommand orangeCommand(Orange victim) {
-        return victim.tumorReferenceCommands(TestInputs.defaultSomaticRunMetadata()).get(1);
+        return victim.tumorReferenceCommands(TestInputs.defaultSomaticRunMetadata()).get(2);
     }
 
     private Orange constructOrange(final Pipeline.Context context, final boolean includeGermline) {
@@ -135,7 +135,7 @@ public class OrangeTest extends TertiaryStageTest<OrangeOutput> {
                 + "-known_fusion_file /opt/resources/fusions/37/known_fusion_data.37.csv "
                 + "-ensembl_data_dir /opt/resources/ensembl_data_cache/37/ -sampling_date 230519";
 
-        return Arrays.asList("echo '5.34' | tee /data/input/orange_pipeline.version.txt", jarRunCommand);
+        return Arrays.asList("mkdir -p /data/input/linx/plot", "echo '5.34' | tee /data/input/orange_pipeline.version.txt", jarRunCommand);
     }
 
     @Override


### PR DESCRIPTION
Orange can't be given a plot dir arg when the folder is missing. Just create it for now.