### PR TITLE
INFRA-119 fix Turqoise pubsub bug

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
@@ -200,6 +200,7 @@ public class PipelineMain {
                     apiStatusUpdateOrNot).run();
             VmExecutionLogSummary.ofFailedStages(storage, state);
             turquoise.publishComplete(state.status().toString());
+            turquoise.close();
             return state;
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/cluster/src/main/java/com/hartwig/pipeline/turquoise/PublishingTurquoise.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/turquoise/PublishingTurquoise.java
@@ -24,12 +24,19 @@ public class PublishingTurquoise implements Turquoise {
                 .build();
     }
 
+    @Override
     public void publishStarted() {
         startedEvent(properties, turquoisePublisher);
     }
 
+    @Override
     public void publishComplete(final String status) {
         completedEvent(properties, turquoisePublisher, status);
+    }
+
+    @Override
+    public void close() {
+        turquoisePublisher.shutdown();
     }
 
     private static void completedEvent(final PipelineProperties subjects, final Publisher publisher, final String status) {

--- a/cluster/src/main/java/com/hartwig/pipeline/turquoise/Turquoise.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/turquoise/Turquoise.java
@@ -4,7 +4,7 @@ import com.google.cloud.pubsub.v1.Publisher;
 import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.input.SomaticRunMetadata;
 
-public interface Turquoise {
+public interface Turquoise extends AutoCloseable {
     void publishStarted();
 
     void publishComplete(final String status);
@@ -23,6 +23,11 @@ public interface Turquoise {
             @Override
             public void publishComplete(final String status) {
                 // noop
+            }
+
+            @Override
+            public void close() {
+                publisher.shutdown();
             }
         };
     }


### PR DESCRIPTION
The `Turqouise` interface is used for publishing certain pubsub messages through a pubsub publisher. However, currently `Turqouise` implementations do not properly shutdown the publisher after using it, resulting in the following stacktrace: 

```log
SEVERE: *~*~*~ Channel ManagedChannelImpl{logId=1, target=pubsub.googleapis.com:443} was not shutdown properly!!! ~*~*~*
    Make sure to call shutdown()/shutdownNow() and wait until awaitTermination() returns true.
```

This PR addresses this:
- Make the `Turquoise` interface extend `AutoClosable`.
- Implement the `close` method in all implementaitons by calling `shutdown` on the publisher.
- Add missing `@Override` annotations, following best practices. 