### PR TITLE
DEV-3721 PAVE hotfix

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -53,4 +53,4 @@ images:
 logsBucket: 'gs://hmf-build-logs'
 timeout: 4800s
 options:
-  machineType: 'N1_HIGHCPU_32'
+  machineType: 'E2_HIGHCPU_32'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
   - name: 'maven:3-jdk-11'
     id: 'Set version for Maven'
     entrypoint: mvn
-    args: [ 'versions:set', '-DnewVersion=${_MAJOR_MINOR_VERSION}.$SHORT_SHA' ]
+    args: [ 'versions:set', '-DnewVersion=${TAG_NAME}' ]
   - name: 'gcr.io/cloud-builders/gsutil'
     id: 'Prime Maven cache'
     args:
@@ -41,15 +41,12 @@ steps:
     volumes:
       - path: '/cache/.m2'
         name: 'm2_cache'
-  - name: 'gcr.io/cloud-builders/docker'
-    id: 'Build pipeline image'
-    args: [ 'build', '-t', 'eu.gcr.io/$PROJECT_ID/pipeline5:${_MAJOR_MINOR_VERSION}.$SHORT_SHA', './cluster/', '--build-arg', 'VERSION=${_MAJOR_MINOR_VERSION}.$SHORT_SHA' ]
-  - name: 'gcr.io/cloud-builders/docker'
-    id: 'Push pipeline image'
-    entrypoint: '/bin/bash'
-    args: [ '-c', "docker push eu.gcr.io/$PROJECT_ID/pipeline5:${_MAJOR_MINOR_VERSION}.$SHORT_SHA" ]
+  - name: 'eu.gcr.io/hmf-build/docker-tag'
+    id: 'Publish Docker image'
+    dir: cluster
+    args: ['eu.gcr.io/hmf-build/pipeline5', '$TAG_NAME', 'Dockerfile', '--build-arg', 'VERSION=$TAG_NAME']
 images:
-  - eu.gcr.io/$PROJECT_ID/pipeline5
+  - eu.gcr.io/hmf-build/pipeline5
 logsBucket: 'gs://hmf-build-logs'
 timeout: 4800s
 options:

--- a/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
@@ -18,7 +18,7 @@ public enum HmfTool {
     LINX("1.24.1", 8, 12, 4, false),
     MARK_DUPS("1.0", 16, 24, 16, false),
     ORANGE("2.6.1", 16, 18, 4, false),
-    PAVE("1.5", 16, 24, 4, false),
+    PAVE("1.5.1", 16, 24, 4, false),
     PEACH("1.7", 1, 4, 2, false),
     PURPLE("3.9.2", 31, 39, 6, false),
     SAGE("3.3"),


### PR DESCRIPTION
Only update is PAVE version (was 1.5.0, becomes 1.5.1).

Also needed to update the cloudbuild to work with new (tag based) setup.