### PR TITLE
INRA-178 add more verbose failsafe logging

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/failsafe/DefaultBackoffPolicy.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/failsafe/DefaultBackoffPolicy.java
@@ -20,9 +20,11 @@ public class DefaultBackoffPolicy<R> extends RetryPolicy<R> {
         abortOn(InvalidArgumentException.class);
         onAbort(e -> LOGGER.error("Unable to submit operation", e.getFailure()));
         handle(Exception.class);
-        onFailedAttempt(rExecutionAttemptedEvent -> LOGGER.warn("[{}] failed: {}",
-                taskName,
-                rExecutionAttemptedEvent.getLastFailure().getMessage()));
+        onFailedAttempt(rExecutionAttemptedEvent ->  {
+            var lastFailure = rExecutionAttemptedEvent.getLastFailure();
+            LOGGER.warn("[{}] failed: {}", taskName, lastFailure.getMessage());
+            LOGGER.debug("[{}] Exception Stack Trace: ", taskName, lastFailure);
+        });
     }
 
     public static <R> DefaultBackoffPolicy<R> of(final String taskName) {

--- a/cluster/src/main/resources/log4j.xml
+++ b/cluster/src/main/resources/log4j.xml
@@ -25,6 +25,9 @@
     <logger name="org.apache.hadoop.util.NativeCodeLoader">
         <level value="OFF"/>
     </logger>
+    <logger name="com.hartwig.pipeline.failsafe">
+        <level value="DEBUG"/>
+    </logger>
     <root>
         <level value="WARN"/>
         <appender-ref ref="console"/>

--- a/cluster/src/test/resources/log4j.xml
+++ b/cluster/src/test/resources/log4j.xml
@@ -16,6 +16,9 @@
     <logger name="org.apache.hadoop.util.NativeCodeLoader">
         <level value="OFF"/>
     </logger>
+    <logger name="com.hartwig.pipeline.failsafe">
+        <level value="DEBUG"/>
+    </logger>
 
     <root>
         <level value="WARN"/>

--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,12 @@
                 <artifactId>compar</artifactId>
                 <version>${compar.version}</version>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-slf4j-impl</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.github.samtools</groupId>


### PR DESCRIPTION
- add debug level log statement that logs the entire exception in case of a failsafe failure.
- modify log4j configuration, setting the failsafe debugger to level DEBUG
- exclude invalid log4j binding pulled in by compar that overwrote logging config