### PR TITLE
INFRA-242 get rid of quota constrained compute engine and DEADLINE_EXCEEDED warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <compar.version>1.2</compar.version>
         <org-reflections.version>0.9.11</org-reflections.version>
         <pdl.version>1.7.2</pdl.version>
-        <hmf-cloud-sdk.version>3.0.2</hmf-cloud-sdk.version>
+        <hmf-cloud-sdk.version>3.0.3</hmf-cloud-sdk.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
Uptick to `hmf-cloud-sdk` 3.0.3 which no longer uses the `QuotaConstrainedComputeEngine`. In turn this should get rid of the `DEADLINE_EXCEEDED` warnings once and for all.