### PR TITLE
DEV-3758: Enable Orange for targeted tumor-only runs

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/SomaticPipeline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/SomaticPipeline.java
@@ -235,7 +235,8 @@ public class SomaticPipeline {
                                         sigsOutput,
                                         resourceFiles,
                                         arguments.context(),
-                                        true)));
+                                        true,
+                                        arguments.useTargetRegions())));
                         Future<OrangeOutput> orangeNoGermlineFuture = executorService.submit(() -> stageRunner.run(metadata,
                                 new Orange(tumorMetrics,
                                         referenceMetrics,
@@ -254,7 +255,8 @@ public class SomaticPipeline {
                                         sigsOutput,
                                         resourceFiles,
                                         arguments.context(),
-                                        false)));
+                                        false,
+                                        arguments.useTargetRegions())));
                         composer.add(state.add(orangeOutputFuture.get()));
                         composer.add(state.add(orangeNoGermlineFuture.get()));
 

--- a/cluster/src/test/java/com/hartwig/pipeline/stages/StageTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/stages/StageTest.java
@@ -78,6 +78,14 @@ public abstract class StageTest<S extends StageOutput, M extends RunMetadata> {
     }
 
     @Test
+    public void declaredExpectedTumorOnlyCommands() {
+        if (!expectedTumorOnlyCommands().isEmpty()) {
+            assertThat(victim.tumorOnlyCommands(input()).stream().map(BashCommand::asBash).collect(Collectors.toList())).isEqualTo(
+                    commands(expectedTumorOnlyCommands()));
+        }
+    }
+
+    @Test
     public void declaredExpectedGermlineOnlyCommands() {
         if (!expectedReferenceOnlyCommands().isEmpty()) {
             assertThat(victim.referenceOnlyCommands(input()).stream().map(BashCommand::asBash).collect(Collectors.toList())).isEqualTo(
@@ -172,6 +180,10 @@ public abstract class StageTest<S extends StageOutput, M extends RunMetadata> {
     protected abstract String expectedRuntimeBucketName();
 
     protected abstract List<String> expectedCommands();
+
+    protected List<String> expectedTumorOnlyCommands() {
+        return Collections.emptyList();
+    }
 
     protected List<String> expectedReferenceOnlyCommands() {
         return Collections.emptyList();

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/cuppa/CuppaTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/cuppa/CuppaTest.java
@@ -98,7 +98,7 @@ public class CuppaTest extends TertiaryStageTest<CuppaOutput> {
                 + "-ref_genome_version V37 "
                 + "-sample_data_dir /data/input/results "
                 + "-output_dir /data/output",
-                "(source /opt/tools/pycuppa/2.0rc_venv/bin/activate && "
+                "(source /opt/tools/pycuppa/2.0_venv/bin/activate && "
                 + "python -m cuppa.predict --features_path /data/output/tumor.cuppa_data.tsv.gz --output_dir /data/output --sample_id tumor "
                 + "&& deactivate)");
         // @formatter:on

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/orange/OrangeTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/orange/OrangeTest.java
@@ -26,11 +26,15 @@ import org.junit.Test;
 
 public class OrangeTest extends TertiaryStageTest<OrangeOutput> {
 
-    private static BashCommand orangeCommand(Orange victim) {
+    private static BashCommand orangeTumorReferenceCommand(Orange victim) {
         return victim.tumorReferenceCommands(TestInputs.defaultSomaticRunMetadata()).get(2);
     }
 
-    private Orange constructOrange(final Pipeline.Context context, final boolean includeGermline) {
+    private static BashCommand orangeTumorOnlyCommand(Orange victim) {
+        return victim.tumorOnlyCommands(TestInputs.defaultSomaticRunMetadata()).get(2);
+    }
+
+    private Orange constructOrange(final Pipeline.Context context, final boolean includeGermline, final boolean isTargeted) {
         return new Orange(TestInputs.tumorMetricsOutput(),
                 TestInputs.referenceMetricsOutput(),
                 TestInputs.tumorFlagstatOutput(),
@@ -48,7 +52,8 @@ public class OrangeTest extends TertiaryStageTest<OrangeOutput> {
                 TestInputs.sigsOutput(),
                 TestInputs.REF_GENOME_37_RESOURCE_FILES,
                 context,
-                includeGermline);
+                includeGermline,
+                isTargeted);
     }
 
     @Override
@@ -79,21 +84,96 @@ public class OrangeTest extends TertiaryStageTest<OrangeOutput> {
 
     @Test
     public void shouldAddResearchDisclaimerWhenResearchContext() {
-        Orange victim = constructOrange(Pipeline.Context.RESEARCH, true);
-        assertThat(orangeCommand(victim).asBash()).contains("-add_disclaimer");
+        Orange victim = constructOrange(Pipeline.Context.RESEARCH, false, false);
+        assertThat(orangeTumorReferenceCommand(victim).asBash()).contains("-add_disclaimer");
+
+        victim = constructOrange(Pipeline.Context.RESEARCH, false, true);
+        assertThat(orangeTumorReferenceCommand(victim).asBash()).contains("-add_disclaimer");
+
+        victim = constructOrange(Pipeline.Context.RESEARCH, true, false);
+        assertThat(orangeTumorReferenceCommand(victim).asBash()).contains("-add_disclaimer");
+
+        victim = constructOrange(Pipeline.Context.RESEARCH, true, true);
+        assertThat(orangeTumorReferenceCommand(victim).asBash()).contains("-add_disclaimer");
+    }
+
+    @Test
+    public void shouldNotAddResearchDisclaimerWhenDiagnosticContext() {
+        Orange victim = constructOrange(Pipeline.Context.DIAGNOSTIC, false, false);
+        assertThat(orangeTumorReferenceCommand(victim).asBash()).doesNotContain("-add_disclaimer");
+
+        victim = constructOrange(Pipeline.Context.DIAGNOSTIC, false, true);
+        assertThat(orangeTumorReferenceCommand(victim).asBash()).doesNotContain("-add_disclaimer");
+
+        victim = constructOrange(Pipeline.Context.DIAGNOSTIC, true, false);
+        assertThat(orangeTumorReferenceCommand(victim).asBash()).doesNotContain("-add_disclaimer");
+
+        victim = constructOrange(Pipeline.Context.DIAGNOSTIC, true, true);
+        assertThat(orangeTumorReferenceCommand(victim).asBash()).doesNotContain("-add_disclaimer");
     }
 
     @Test
     public void shouldAddGermlineToSomaticConversionAndChangeNamespaceWhenNotIncludeGermline() {
-        Orange victim = constructOrange(Pipeline.Context.RESEARCH, false);
+        Orange victim = constructOrange(Pipeline.Context.RESEARCH, false, false);
         assertThat(victim.namespace()).isEqualTo(Orange.NAMESPACE_NO_GERMLINE);
-        assertThat(orangeCommand(victim).asBash()).contains("-convert_germline_to_somatic");
+        assertThat(orangeTumorReferenceCommand(victim).asBash()).contains("-convert_germline_to_somatic");
+
+        victim = constructOrange(Pipeline.Context.DIAGNOSTIC, false, true);
+        assertThat(victim.namespace()).isEqualTo(Orange.NAMESPACE_NO_GERMLINE);
+        assertThat(orangeTumorReferenceCommand(victim).asBash()).contains("-convert_germline_to_somatic");
+    }
+
+    @Test
+    public void shouldNotAddGermlineToSomaticConversionAndChangeNamespaceWhenNotIncludeGermline() {
+        Orange victim = constructOrange(Pipeline.Context.DIAGNOSTIC, true, false);
+        assertThat(victim.namespace()).isEqualTo(Orange.NAMESPACE);
+        assertThat(orangeTumorReferenceCommand(victim).asBash()).doesNotContain("-convert_germline_to_somatic");
+
+        victim = constructOrange(Pipeline.Context.RESEARCH, true, true);
+        assertThat(victim.namespace()).isEqualTo(Orange.NAMESPACE);
+        assertThat(orangeTumorReferenceCommand(victim).asBash()).doesNotContain("-convert_germline_to_somatic");
     }
 
     @Test
     public void shouldReturnNoFurtherOperationsWhenGermlineNotIncluded() {
-        Orange victim = constructOrange(Pipeline.Context.RESEARCH, false);
+        Orange victim = constructOrange(Pipeline.Context.RESEARCH, false, false);
         assertThat(victim.addDatatypes(defaultSomaticRunMetadata())).isEqualTo(Collections.emptyList());
+
+        victim = constructOrange(Pipeline.Context.RESEARCH, false, true);
+        assertThat(victim.addDatatypes(defaultSomaticRunMetadata())).isEqualTo(Collections.emptyList());
+    }
+
+    @Test
+    public void shouldSetRunModusByIsTargetedForTumorReference() {
+        Orange victim = constructOrange(Pipeline.Context.RESEARCH, false, false);
+        assertThat(orangeTumorReferenceCommand(victim).asBash()).contains("WGS");
+
+        victim = constructOrange(Pipeline.Context.RESEARCH, false, true);
+        assertThat(orangeTumorReferenceCommand(victim).asBash()).contains("PANEL");
+
+        victim = constructOrange(Pipeline.Context.RESEARCH, true, false);
+        assertThat(orangeTumorReferenceCommand(victim).asBash()).contains("WGS");
+
+        victim = constructOrange(Pipeline.Context.RESEARCH, true, true);
+        assertThat(orangeTumorReferenceCommand(victim).asBash()).contains("PANEL");
+    }
+
+    @Test
+    public void shouldSetRunModusByIsTargetedForTumorOnly() {
+        Orange victim = constructOrange(Pipeline.Context.RESEARCH, true, false);
+        assertThat(orangeTumorOnlyCommand(victim).asBash()).contains("WGS");
+
+        victim = constructOrange(Pipeline.Context.RESEARCH, true, true);
+        assertThat(orangeTumorOnlyCommand(victim).asBash()).contains("PANEL");
+    }
+
+    @Test
+    public void shouldSkipOrangeNoGermlineForTumorOnly() {
+        Orange victim = constructOrange(Pipeline.Context.RESEARCH, false, false);
+        assertThat(victim.tumorOnlyCommands(TestInputs.defaultSomaticRunMetadata())).isEqualTo(Collections.emptyList());
+
+        victim = constructOrange(Pipeline.Context.RESEARCH, false, true);
+        assertThat(victim.tumorOnlyCommands(TestInputs.defaultSomaticRunMetadata())).isEqualTo(Collections.emptyList());
     }
 
     @Override
@@ -113,24 +193,43 @@ public class OrangeTest extends TertiaryStageTest<OrangeOutput> {
 
     @Override
     protected Stage<OrangeOutput, SomaticRunMetadata> createVictim() {
-        return constructOrange(Pipeline.Context.DIAGNOSTIC, true);
+        return constructOrange(Pipeline.Context.DIAGNOSTIC, true, false);
     }
 
     @Override
     protected List<String> expectedCommands() {
         String jarRunCommand = toolCommand(ORANGE) + " -output_dir /data/output " + "-experiment_type WGS " + "-ref_genome_version 37 "
-                + "-tumor_sample_id tumor " + "-reference_sample_id reference " + "-doid_json /opt/resources/disease_ontology/doid.json "
-                + "-primary_tumor_doids \"01;02\" " + "-ref_sample_wgs_metrics_file /data/input/reference.wgsmetrics "
-                + "-tumor_sample_wgs_metrics_file /data/input/tumor.wgsmetrics "
-                + "-ref_sample_flagstat_file /data/input/reference.flagstat " + "-tumor_sample_flagstat_file /data/input/tumor.flagstat "
-                + "-sample_data_dir /data/input " + "-purple_dir /data/input/purple " + "-purple_plot_dir /data/input/purple/plot "
-                + "-linx_germline_dir /data/input/linx_germline " + "-linx_plot_dir /data/input/linx/plot " + "-linx_dir /data/input/linx "
-                + "-lilac_dir /data/input " + "-sage_dir /data/input " + "-pipeline_version_file /data/input/orange_pipeline.version.txt "
+                + "-doid_json /opt/resources/disease_ontology/doid.json " + "-sample_data_dir /data/input "
+                + "-purple_dir /data/input/purple " + "-purple_plot_dir /data/input/purple/plot " + "-lilac_dir /data/input "
+                + "-pipeline_version_file /data/input/orange_pipeline.version.txt "
                 + "-cohort_mapping_tsv /opt/resources/orange/cohort_mapping.tsv "
                 + "-cohort_percentiles_tsv /opt/resources/orange/cohort_percentiles.tsv "
                 + "-driver_gene_panel /opt/resources/gene_panel/37/DriverGenePanel.37.tsv "
                 + "-known_fusion_file /opt/resources/fusions/37/known_fusion_data.37.csv "
-                + "-ensembl_data_dir /opt/resources/ensembl_data_cache/37/ -sampling_date 230519";
+                + "-ensembl_data_dir /opt/resources/ensembl_data_cache/37/ " + "-tumor_sample_id tumor " + "-primary_tumor_doids \"01;02\" "
+                + "-tumor_sample_wgs_metrics_file /data/input/tumor.wgsmetrics " + "-tumor_sample_flagstat_file /data/input/tumor.flagstat "
+                + "-linx_plot_dir /data/input/linx/plot " + "-linx_dir /data/input/linx " + "-sage_dir /data/input "
+                + "-sampling_date 230519 " + "-reference_sample_id reference "
+                + "-ref_sample_wgs_metrics_file /data/input/reference.wgsmetrics "
+                + "-ref_sample_flagstat_file /data/input/reference.flagstat " + "-linx_germline_dir /data/input/linx_germline";
+
+        return Arrays.asList("mkdir -p /data/input/linx/plot", "echo '5.34' | tee /data/input/orange_pipeline.version.txt", jarRunCommand);
+    }
+
+    @Override
+    protected List<String> expectedTumorOnlyCommands() {
+        String jarRunCommand = toolCommand(ORANGE) + " -output_dir /data/output " + "-experiment_type WGS " + "-ref_genome_version 37 "
+                + "-doid_json /opt/resources/disease_ontology/doid.json " + "-sample_data_dir /data/input "
+                + "-purple_dir /data/input/purple " + "-purple_plot_dir /data/input/purple/plot " + "-lilac_dir /data/input "
+                + "-pipeline_version_file /data/input/orange_pipeline.version.txt "
+                + "-cohort_mapping_tsv /opt/resources/orange/cohort_mapping.tsv "
+                + "-cohort_percentiles_tsv /opt/resources/orange/cohort_percentiles.tsv "
+                + "-driver_gene_panel /opt/resources/gene_panel/37/DriverGenePanel.37.tsv "
+                + "-known_fusion_file /opt/resources/fusions/37/known_fusion_data.37.csv "
+                + "-ensembl_data_dir /opt/resources/ensembl_data_cache/37/ " + "-tumor_sample_id tumor " + "-primary_tumor_doids \"01;02\" "
+                + "-tumor_sample_wgs_metrics_file /data/input/tumor.wgsmetrics " + "-tumor_sample_flagstat_file /data/input/tumor.flagstat "
+                + "-linx_plot_dir /data/input/linx/plot " + "-linx_dir /data/input/linx " + "-sage_dir /data/input "
+                + "-sampling_date 230519";
 
         return Arrays.asList("mkdir -p /data/input/linx/plot", "echo '5.34' | tee /data/input/orange_pipeline.version.txt", jarRunCommand);
     }


### PR DESCRIPTION
I have tried to make sure that all combinations of targeted vs WGS and tumor-only vs tumor-and-ref do something useful without crashing.

For tumor-only runs, Orange-no-germline is still disabled, since the result would be basically the same as the "regular" Orange run.