### PR TITLE
INFRA-152 germline reportability hotfix 533

### DIFF
--- a/cluster/images/create_public_image.sh
+++ b/cluster/images/create_public_image.sh
@@ -64,11 +64,15 @@ GCL="gcloud beta compute --project=${PROJECT}"
 SSH="$GCL ssh $source_instance --zone=${ZONE}"
 generated_script=$(mktemp -t image_script_generated_XXXXX.sh)
 
+# extra params for instances create below to avoid ssh issues
+# these could be removed in the future if issues are addressed
+# --network diskimager --subnet diskimager
+
 (
 echo "#!/usr/bin/env bash"
 echo
 echo "set -e"
-echo $GCL instances create $source_instance --description=\"Pipeline5 disk imager started $(date) by $(whoami)\" --zone=${ZONE} \
+echo $GCL instances create $source_instance --network diskimager --subnet diskimager --description=\"Pipeline5 disk imager started $(date) by $(whoami)\" --zone=${ZONE} \
     --boot-disk-size 200 --boot-disk-type pd-ssd --machine-type n1-highcpu-4 --image-project=${source_project} \
     --image-family=${source_family} --scopes=default,cloud-source-repos-ro
 echo sleep 10

--- a/cluster/images/tools.cmds
+++ b/cluster/images/tools.cmds
@@ -29,8 +29,6 @@ sudo tar xvf /opt/tools/R/rlibs.tar -C /
 
 sudo tar xvf /opt/tools/strelka/1.0.14/strelka.tar -C /opt/tools/strelka/1.0.14/
 sudo tar xvf /opt/tools/tabix/0.2.6/tabix.tar -C /opt/tools/tabix/0.2.6/
-sudo tar xvf /opt/tools/samtools/1.2/samtools.tar.gz -C /opt/tools/samtools/1.2/
-sudo tar xvf /opt/tools/samtools/1.9/samtools.tar.gz -C /opt/tools/samtools/1.9/
 sudo tar xvf /opt/tools/circos/0.69.6/circos.tar -C /opt/tools/circos/0.69.6/
 sudo tar xvf /opt/tools/repeatmasker/4.1.1/repeatmasker.tar -C /opt/tools/repeatmasker/4.1.1/
 sudo chmod a+x /opt/tools/kraken2/2.1.0/kraken2
@@ -49,13 +47,10 @@ sudo chmod a+x /opt/tools/gridss/2.13.2/gridsstools
 sudo chmod a+x /opt/tools/gridss/2.13.2/virusbreakend
 sudo chmod a+x /opt/tools/gridss/2.13.2/gridss_annotate_vcf_kraken2
 sudo chmod a+x /opt/tools/gridss/2.13.2/gridss_annotate_vcf_repeatmasker
-sudo chmod a+x /opt/tools/sv-prep/1.1/gridss.run.sh
 sudo chmod a+x /opt/tools/sv-prep/1.2/gridss.run.sh
 
 sudo chmod a+x /opt/tools/samtools/1.10/samtools
 sudo chmod a+x /opt/tools/samtools/1.14/samtools
-sudo chmod a+x /opt/tools/bcl2fastq/2.20.0.422/bcl2fastq
 sudo chmod a+x /opt/tools/star/2.7.3a/STAR
 sudo chmod a+x /opt/tools/rmblast/2.10.0/rmblastn
 sudo chmod a+x /opt/tools/trf/4.0.9/trf
-sudo cp -r /opt/tools/bcl2fastq/2.20.0.422/share /opt/tools/bcl2fastq/

--- a/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
@@ -17,7 +17,7 @@ public enum HmfTool {
     LILAC("1.5.2", 16, 24, 8, false),
     LINX("1.24.1", 8, 12, 4, false),
     MARK_DUPS("1.0", 16, 24, 16, false),
-    ORANGE("2.6.1", 16, 18, 4, false),
+    ORANGE("2.6.2", 16, 18, 4, false),
     PAVE("1.5.1", 16, 24, 4, false),
     PEACH("1.7", 1, 4, 2, false),
     PURPLE("3.9.2", 31, 39, 6, false),

--- a/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
@@ -20,7 +20,7 @@ public enum HmfTool {
     ORANGE("2.6.2", 16, 18, 4, false),
     PAVE("1.5.1", 16, 24, 4, false),
     PEACH("1.7", 1, 4, 2, false),
-    PURPLE("3.9.2", 31, 39, 6, false),
+    PURPLE("3.9.4", 31, 39, 6, false),
     SAGE("3.3"),
     SIGS("1.1", Defaults.JAVA_HEAP, 16, 4, false),
     SV_PREP("1.2", 48, 64, 24, false),

--- a/sample_json/coloMini.json
+++ b/sample_json/coloMini.json
@@ -1,7 +1,9 @@
 {
+  "setName": "COLO829v003",
   "tumor": {
     "type": "TUMOR",
     "name": "COLO829v003T",
+    "turquoiseSubject": "COLO829v003T",
     "lanes": [
       {
         "laneNumber": "1",
@@ -28,6 +30,7 @@
   "reference": {
     "type": "REFERENCE",
     "name": "COLO829v003R",
+    "turquoiseSubject": "COLO829v003R",
     "lanes": [
       {
         "laneNumber": "1",


### PR DESCRIPTION
Changes:
- Germline resources update (see [this commit in common public resources repo](https://source.cloud.google.com/hmf-pipeline-development/common-resources-public/+/857361bd316e68249ea18fb24f9b4bf61853a280))
- Orange update to `2.6.2` (enabling the use of added germline reporting)
- PURPLE hotfix to `3.9.4` (fixing a small issue that allowed LOW_TUMOR_VCN to be reportable)