### PR TITLE
ACTIN-688: Upgrade various tools in pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,6 @@ running then commit those back to the repo.
 ### Disk Images
 
 Pv5 uses a custom disk image to launch the VMs that implement the stages it runs. When components are upgraded or if resources
-change a new image must be created, by the developer. See `cluster/images/README.md` for specifics.
+change a new image must be created, by the developer. See `image/README.md` for specifics.
 
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
@@ -1,13 +1,13 @@
 package com.hartwig.pipeline.tools;
 
-import com.hartwig.computeengine.execution.vm.VmDirectories;
-
 import static java.lang.String.format;
+
+import com.hartwig.computeengine.execution.vm.VmDirectories;
 
 public enum HmfTool {
 
     AMBER("4.0", 20, 24, 16, false),
-    BAM_TOOLS("1.2", 16, 24, 16, false),
+    BAM_TOOLS("1.2.1", 16, 24, 16, false),
     CHORD("2.02_1.14", Defaults.JAVA_HEAP, 12, 4, false),
     CIDER("1.0.3", 12, 16, 4, false),
     COBALT("1.16", 20, 24, 16, false),
@@ -18,14 +18,14 @@ public enum HmfTool {
     LILAC("1.6", 16, 24, 8, false),
     LINX("1.25", 8, 12, 4, false),
     MARK_DUPS("1.1.2", 40, 64, 24, false),
-    ORANGE("3.2.0", 16, 18, 4, false),
+    ORANGE("3.3.0", 16, 18, 4, false),
     PAVE("1.6", 30, 40, 8, false),
     PEACH("1.8", 1, 4, 2, false),
-    PURPLE("4.0", 30, 40, 8, false),
-    SAGE("3.4", 48, 64, 24, false),
-    SIGS("1.2", Defaults.JAVA_HEAP, 16, 4, false),
+    PURPLE("4.0.2", 30, 40, 8, false),
+    SAGE("3.4.1", 48, 64, 24, false),
+    SIGS("1.2.1", Defaults.JAVA_HEAP, 16, 4, false),
     SV_PREP("1.2.3", 48, 64, 24, false),
-    TEAL("1.2.1", 30, 32, 16, false),
+    TEAL("1.2.2", 30, 32, 16, false),
     VIRUSBREAKEND_GRIDSS("2.13.3", Defaults.JAVA_HEAP, 64, 12, false),
     VIRUS_INTERPRETER("1.3", Defaults.JAVA_HEAP, 8, 2, false);
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tools/VersionUtils.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/VersionUtils.java
@@ -66,7 +66,7 @@ public final class VersionUtils {
     }
 
     public static String imageVersion() {
-        return "5-35";
+        return "5-34";
     }
 
     public static void main(final String[] args) {

--- a/cluster/src/main/java/com/hartwig/pipeline/tools/VersionUtils.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/VersionUtils.java
@@ -66,7 +66,7 @@ public final class VersionUtils {
     }
 
     public static String imageVersion() {
-        return "5-34";
+        return "5-35";
     }
 
     public static void main(final String[] args) {


### PR DESCRIPTION
The latest commit of this branch (5.35.0-beta.1) has been tested using pipeline image `pipeline5-5-35-202403061046`

COLO has been run and compared with 5.34.1 using compar, results in gs://hmf-crunch-experiments/240308_kd_verification_pipeline_v5_35_0, differences have been deemed acceptable.
