### PR TITLE
INFRA-326 Allow usage of Cuppa private resource file

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
@@ -69,6 +69,7 @@ public interface Arguments extends CommonArguments {
                     .useCrams(false)
                     .useTargetRegions(false)
                     .anonymize(false)
+                    .usePrivateResources(false)
                     .context(DEFAULT_CONTEXT)
                     .sampleJson(DEFAULT_SAMPLE_JSON);
         } else if (profile.equals(DefaultsProfile.DEVELOPMENT)) {
@@ -100,6 +101,7 @@ public interface Arguments extends CommonArguments {
                     .useCrams(false)
                     .useTargetRegions(false)
                     .anonymize(false)
+                    .usePrivateResources(false)
                     .context(DEFAULT_CONTEXT)
                     .userLabel(System.getProperty("user.name"))
                     .sampleJson(DEFAULT_SAMPLE_JSON);
@@ -132,6 +134,7 @@ public interface Arguments extends CommonArguments {
                     .useCrams(false)
                     .useTargetRegions(false)
                     .anonymize(false)
+                    .usePrivateResources(false)
                     .context(DEFAULT_CONTEXT)
                     .sampleJson(DEFAULT_SAMPLE_JSON);
         } else if (profile.equals(DefaultsProfile.PUBLIC)) {
@@ -163,6 +166,7 @@ public interface Arguments extends CommonArguments {
                     .useCrams(false)
                     .useTargetRegions(false)
                     .anonymize(false)
+                    .usePrivateResources(false)
                     .context(DEFAULT_CONTEXT)
                     .sampleJson(DEFAULT_SAMPLE_JSON);
         }
@@ -210,6 +214,8 @@ public interface Arguments extends CommonArguments {
     boolean useCrams();
 
     boolean anonymize();
+
+    boolean usePrivateResources();
 
     Pipeline.Context context();
 

--- a/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
@@ -73,6 +73,7 @@ public class CommandLineOptions {
     private static final String PUBSUB_WORKFLOW_FLAG = "pubsub_workflow";
     private static final String PUBSUB_ENVIRONMENT_FLAG = "pubsub_environment";
     private static final String PUBLISH_EVENTS_ONLY_FLAG = "publish_events_only";
+    private static final String USE_PRIVATE_RESOURCES_FLAG = "use_private_resources";
 
     private static Options options() {
         return new Options().addOption(profile())
@@ -124,6 +125,7 @@ public class CommandLineOptions {
                 .addOption(useCrams())
                 .addOption(pubsubProject())
                 .addOption(anonymize())
+                .addOption(usePrivateResources())
                 .addOption(context())
                 .addOption(costCenterLabel())
                 .addOption(userLabel())
@@ -157,6 +159,10 @@ public class CommandLineOptions {
 
     private static Option anonymize() {
         return optionWithArg(ANONYMIZE_FLAG, "Use barcodes instead of sample names in files, headers and annotations");
+    }
+
+    private static Option usePrivateResources() {
+        return optionWithArg(USE_PRIVATE_RESOURCES_FLAG, "Use resources specific to private repo where applicable");
     }
 
     private static Option pubsubProject() {
@@ -324,6 +330,7 @@ public class CommandLineOptions {
                     .useCrams(booleanOptionWithDefault(commandLine, USE_CRAMS_FLAG, defaults.useCrams()))
                     .pubsubProject(pubsubProject(commandLine, defaults))
                     .anonymize(booleanOptionWithDefault(commandLine, ANONYMIZE_FLAG, defaults.anonymize()))
+                    .usePrivateResources(booleanOptionWithDefault(commandLine, USE_PRIVATE_RESOURCES_FLAG, defaults.publishEventsOnly()))
                     .context(context(commandLine, defaults))
                     .costCenterLabel(costCenterLabel(commandLine, defaults))
                     .userLabel(userLabel(commandLine, defaults))

--- a/cluster/src/main/java/com/hartwig/pipeline/SomaticPipeline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/SomaticPipeline.java
@@ -175,14 +175,12 @@ public class SomaticPipeline {
                         Future<TealOutput> tealOutputFuture = executorService.submit(() -> stageRunner.run(metadata,
                                 new Teal(pair, purpleOutput, cobaltOutput, referenceMetrics, tumorMetrics, resourceFiles,
                                         persistedDataset)));
-                        composer.add(state.add(tealOutputFuture.get()));
 
                         Future<LilacBamSliceOutput> lilacBamSliceOutputFuture = executorService.submit(() -> stageRunner.run(metadata,
                                 new LilacBamSlicer(pair, resourceFiles, persistedDataset)));
                         LilacBamSliceOutput lilacBamSliceOutput = composer.add(state.add(lilacBamSliceOutputFuture.get()));
                         Future<LilacOutput> lilacOutputFuture = executorService.submit(() -> stageRunner.run(metadata,
                                 new Lilac(lilacBamSliceOutput, resourceFiles, purpleOutput, persistedDataset)));
-                        LilacOutput lilacOutput = composer.add(state.add(lilacOutputFuture.get()));
 
                         VirusBreakendOutput virusBreakendOutput = composer.add(state.add(virusBreakendOutputFuture.get()));
                         Future<VirusInterpreterOutput> virusInterpreterOutputFuture = executorService.submit(() -> stageRunner.run(metadata,
@@ -214,8 +212,11 @@ public class SomaticPipeline {
                         VirusInterpreterOutput virusInterpreterOutput = composer.add(state.add(virusInterpreterOutputFuture.get()));
                         Future<CuppaOutput> cuppaOutputFuture = executorService.submit(() -> stageRunner.run(metadata,
                                 new Cuppa(purpleOutput, linxSomaticOutput, virusInterpreterOutput, resourceFiles, persistedDataset, arguments)));
+
                         CuppaOutput cuppaOutput = composer.add(state.add(cuppaOutputFuture.get()));
                         SigsOutput sigsOutput = composer.add(state.add(signatureOutputFuture.get()));
+                        LilacOutput lilacOutput = composer.add(state.add(lilacOutputFuture.get()));
+                        composer.add(state.add(tealOutputFuture.get()));
 
                         Future<OrangeOutput> orangeOutputFuture = executorService.submit(() -> stageRunner.run(metadata,
                                 new Orange(tumorMetrics,

--- a/cluster/src/main/java/com/hartwig/pipeline/SomaticPipeline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/SomaticPipeline.java
@@ -213,7 +213,7 @@ public class SomaticPipeline {
                         PeachOutput peachOutput = composer.add(state.add(peachOutputFuture.get()));
                         VirusInterpreterOutput virusInterpreterOutput = composer.add(state.add(virusInterpreterOutputFuture.get()));
                         Future<CuppaOutput> cuppaOutputFuture = executorService.submit(() -> stageRunner.run(metadata,
-                                new Cuppa(purpleOutput, linxSomaticOutput, virusInterpreterOutput, resourceFiles, persistedDataset)));
+                                new Cuppa(purpleOutput, linxSomaticOutput, virusInterpreterOutput, resourceFiles, persistedDataset, arguments)));
                         CuppaOutput cuppaOutput = composer.add(state.add(cuppaOutputFuture.get()));
                         SigsOutput sigsOutput = composer.add(state.add(signatureOutputFuture.get()));
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/cuppa/Cuppa.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/cuppa/Cuppa.java
@@ -54,15 +54,17 @@ public class Cuppa implements Stage<CuppaOutput, SomaticRunMetadata> {
     private final InputDownloadCommand virusInterpreterAnnotations;
     private final ResourceFiles resourceFiles;
     private final PersistedDataset persistedDataset;
+    private final Arguments arguments;
 
     public Cuppa(final PurpleOutput purpleOutput, final LinxSomaticOutput linxOutput, final VirusInterpreterOutput virusInterpreterOutput,
-            final ResourceFiles resourceFiles, final PersistedDataset persistedDataset) {
+            final ResourceFiles resourceFiles, final PersistedDataset persistedDataset, final Arguments arguments) {
         PurpleOutputLocations purpleOutputLocations = purpleOutput.outputLocations();
         this.purpleOutputDirectory = new InputDownloadCommand(purpleOutputLocations.outputDirectory());
         this.linxOutputDirectory = new InputDownloadCommand(linxOutput.linxOutputLocations().outputDirectory());
         this.virusInterpreterAnnotations = new InputDownloadCommand(virusInterpreterOutput.virusAnnotations());
         this.resourceFiles = resourceFiles;
         this.persistedDataset = persistedDataset;
+        this.arguments = arguments;
     }
 
     @Override
@@ -166,11 +168,14 @@ public class Cuppa implements Stage<CuppaOutput, SomaticRunMetadata> {
         String cuppaCvPredictionsFile = resourceFiles.cuppaCvPredictions();
 
         List<String> pycuppaPredictArguments = Lists.newArrayList(
-                format("--cv_predictions_path %s", cuppaCvPredictionsFile),
                 format("--classifier_path %s", cuppaClassifierFile),
                 format("--features_path %s", cuppaInputFeaturesFile),
                 format("--output_dir %s", VmDirectories.OUTPUT),
                 format("--sample_id %s", metadata.tumor().sampleName()));
+
+        if(arguments.usePrivateResources()){
+            pycuppaPredictArguments.add(format("--cv_predictions_path %s", cuppaCvPredictionsFile));
+        }
 
         cuppaCommands.add(new SubShellCommand(new Python3ModuleCommand("pycuppa",
                 CUPPA.runVersion(),

--- a/cluster/src/main/java/com/hartwig/pipeline/tertiary/cuppa/Cuppa.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tertiary/cuppa/Cuppa.java
@@ -4,7 +4,6 @@ import static java.lang.String.format;
 
 import static com.hartwig.pipeline.tools.HmfTool.CUPPA;
 
-import java.io.File;
 import java.util.List;
 
 import com.google.common.collect.Lists;
@@ -167,14 +166,11 @@ public class Cuppa implements Stage<CuppaOutput, SomaticRunMetadata> {
         String cuppaCvPredictionsFile = resourceFiles.cuppaCvPredictions();
 
         List<String> pycuppaPredictArguments = Lists.newArrayList(
+                format("--cv_predictions_path %s", cuppaCvPredictionsFile),
                 format("--classifier_path %s", cuppaClassifierFile),
                 format("--features_path %s", cuppaInputFeaturesFile),
                 format("--output_dir %s", VmDirectories.OUTPUT),
                 format("--sample_id %s", metadata.tumor().sampleName()));
-
-        if(new File(cuppaCvPredictionsFile).exists()){
-            pycuppaPredictArguments.add(format("--cv_predictions_path %s", cuppaCvPredictionsFile));
-        }
 
         cuppaCommands.add(new SubShellCommand(new Python3ModuleCommand("pycuppa",
                 CUPPA.runVersion(),

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/cuppa/CuppaTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/cuppa/CuppaTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 import com.hartwig.computeengine.storage.GoogleStorageLocation;
 import com.hartwig.computeengine.storage.ResultsDirectory;
+import com.hartwig.pipeline.Arguments;
 import com.hartwig.pipeline.datatypes.DataType;
 import com.hartwig.pipeline.input.SomaticRunMetadata;
 import com.hartwig.pipeline.output.AddDatatype;
@@ -86,7 +87,7 @@ public class CuppaTest extends TertiaryStageTest<CuppaOutput> {
                 linxSomaticOutput(),
                 virusInterpreterOutput(),
                 TestInputs.REF_GENOME_37_RESOURCE_FILES,
-                persistedDataset);
+                persistedDataset, Arguments.testDefaults());
     }
 
     @Override
@@ -100,7 +101,6 @@ public class CuppaTest extends TertiaryStageTest<CuppaOutput> {
                 + "-output_dir /data/output",
                 "(source /opt/tools/pycuppa/2.1.0rc_venv/bin/activate && "
                 + "python -m cuppa.predict "
-                + "--cv_predictions_path /opt/resources/cuppa/37/cuppa_cv_predictions.37.tsv.gz "
                 + "--classifier_path /opt/resources/cuppa/37/cuppa_classifier.37.pickle.gz "
                 + "--features_path /data/output/tumor.cuppa_data.tsv.gz --output_dir /data/output --sample_id tumor "
                 + "&& deactivate)");

--- a/cluster/src/test/java/com/hartwig/pipeline/tertiary/cuppa/CuppaTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/tertiary/cuppa/CuppaTest.java
@@ -99,7 +99,9 @@ public class CuppaTest extends TertiaryStageTest<CuppaOutput> {
                 + "-sample_data_dir /data/input/results "
                 + "-output_dir /data/output",
                 "(source /opt/tools/pycuppa/2.1.0rc_venv/bin/activate && "
-                + "python -m cuppa.predict --classifier_path /opt/resources/cuppa/37/cuppa_classifier.37.pickle.gz "
+                + "python -m cuppa.predict "
+                + "--cv_predictions_path /opt/resources/cuppa/37/cuppa_cv_predictions.37.tsv.gz "
+                + "--classifier_path /opt/resources/cuppa/37/cuppa_classifier.37.pickle.gz "
                 + "--features_path /data/output/tumor.cuppa_data.tsv.gz --output_dir /data/output --sample_id tumor "
                 + "&& deactivate)");
         // @formatter:on


### PR DESCRIPTION
Makes it possible for pipeline5 to run in both a public mode (using a public compute image without the private CUPPA resource file) and private mode (using a private compute image with the private CUPPA resource file)

For this I added argiment `use_private_resources`. The only downside is that to actually use the private resource file (cuppa_cv_predictions.37.tsv.gz) the argument must be provided, but this makes the intention also very clear and explicit so worth the trade-off.

Previous code tried to detect the existance of the file but that did not work since that check was executed in the k8 job instead of on the CUPPA stage VM.