### PR TITLE
INFRA-345 Fix polling interval

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <compar.version>1.2</compar.version>
         <org-reflections.version>0.9.11</org-reflections.version>
         <pdl.version>1.7.2</pdl.version>
-        <hmf-cloud-sdk.version>3.0.6</hmf-cloud-sdk.version>
+        <hmf-cloud-sdk.version>3.0.8</hmf-cloud-sdk.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
Use a new hmf-cloud-sdk with a bugfix for the polling interval. The value provided with poll_interval argument should now no longer be ignored.