### PR TITLE
ACTIN-786 Bump markdups memory

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
@@ -17,7 +17,7 @@ public enum HmfTool {
     HEALTH_CHECKER("3.5", Defaults.JAVA_HEAP, 32, 8, false),
     LILAC("1.6", 16, 24, 8, false),
     LINX("1.25", 8, 12, 4, false),
-    MARK_DUPS("1.1.2", 40, 64, 24, false),
+    MARK_DUPS("1.1.2", 40, 120, 24, false),
     ORANGE("3.3.0", 16, 18, 4, false),
     PAVE("1.6", 30, 40, 8, false),
     PEACH("1.8", 1, 4, 2, false),


### PR DESCRIPTION
This is where we had it before the HMF markdup implementation.