### PR TITLE
ACTIN-818 Bump MarkDups to 1.1.4

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
@@ -1,8 +1,8 @@
 package com.hartwig.pipeline.tools;
 
-import static java.lang.String.format;
-
 import com.hartwig.computeengine.execution.vm.VmDirectories;
+
+import static java.lang.String.format;
 
 public enum HmfTool {
 
@@ -17,7 +17,7 @@ public enum HmfTool {
     HEALTH_CHECKER("3.5", Defaults.JAVA_HEAP, 32, 8, false),
     LILAC("1.6", 16, 24, 8, false),
     LINX("1.25", 8, 12, 4, false),
-    MARK_DUPS("1.1.2", 40, 120, 24, false),
+    MARK_DUPS("1.1.4", 40, 120, 24, false),
     ORANGE("3.3.0", 16, 18, 4, false),
     PAVE("1.6", 30, 40, 8, false),
     PEACH("1.8", 1, 4, 2, false),

--- a/image/create_public_image.sh
+++ b/image/create_public_image.sh
@@ -110,8 +110,7 @@ echo "$GCL instances -q delete ${source_instance} --zone=${ZONE}"
 ) > "$generated_script"
 chmod +x "$generated_script"
 
-echo "# ===================="
-echo "# Finished with setup, inspect commands:"
-echo "cat $generated_script"
-echo "# Run the generated script (and delete afterwards):"
-echo "nohup $generated_script > ${generated_script}.log &"
+echo
+echo "Imager script generated to ${generated_script}. It will not be deleted if it fails."
+$generated_script 2>&1 | tee ${generated_script}.log 
+rm $generated_script


### PR DESCRIPTION
Also revise imaging script behaviour to print out a message with details on where the script was generated to, rather than require the user to copy/paste commands to get it to run.