### PR TITLE
ACTIN-835 Fix minor recent Pv5 merge mistakes + use AR

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/SomaticPipeline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/SomaticPipeline.java
@@ -198,7 +198,6 @@ public class SomaticPipeline {
                                 new Chord(arguments.refGenomeVersion(), purpleOutput, persistedDataset)));
                         LinxGermlineOutput linxGermlineOutput = composer.add(state.add(linxGermlineOutputFuture.get()));
                         LinxSomaticOutput linxSomaticOutput = composer.add(state.add(linxSomaticOutputFuture.get()));
-                        composer.add(state.add(tealOutputFuture.get()));
                         composer.add(state.add(healthCheckOutputFuture.get()));
 
                         Future<PeachOutput> peachOutputFuture = executorService.submit(() -> stageRunner.run(metadata,

--- a/cluster/src/main/java/com/hartwig/pipeline/tools/VersionUtils.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/VersionUtils.java
@@ -2,10 +2,8 @@ package com.hartwig.pipeline.tools;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,8 +51,13 @@ public final class VersionUtils {
     }
 
     public static List<HmfTool> inArtifactRegistry() {
-        //return List.of(HmfTool.ORANGE);
-        return Collections.emptyList();
+        return List.of(HmfTool.BAM_TOOLS,
+                HmfTool.CUPPA,
+                HmfTool.MARK_DUPS,
+                HmfTool.ORANGE,
+                HmfTool.PURPLE,
+                HmfTool.SAGE,
+                HmfTool.TEAL);
     }
 
     public static String format(final Field field) {

--- a/image/create_public_image.sh
+++ b/image/create_public_image.sh
@@ -7,6 +7,8 @@ ZONE="${LOCATION}-a"
 PROJECT="hmf-pipeline-development"
 PV5_DIR="$(dirname "$0")/.."
 PV5_JAR="${PV5_DIR}/cluster/target/cluster-local-SNAPSHOT.jar"
+VERSION_CMD="java -cp ${PV5_JAR} com.hartwig.pipeline.tools.VersionUtils"
+MVN_URL="https://europe-west4-maven.pkg.dev/hmf-build/hmf-maven/com/hartwig"
 
 tools_only=false
 
@@ -39,9 +41,14 @@ done
 set -e
 echo "Rebuilding pipeline JAR to ensure correct version"
 mvn -f "${PV5_DIR}/pom.xml" clean package -DskipTests
-version="$(java -cp ${PV5_JAR} com.hartwig.pipeline.tools.VersionUtils)"
+version="$($VERSION_CMD)"
 set +e
 [[ "$version" =~ ^5\-[0-9]+$ ]] || (echo "Got junk version: ${version}" && exit 1)
+
+declare -A tool_versions
+while read tool tool_version; do
+   tool_versions[$tool]="$tool_version"
+done <<< "$(${VERSION_CMD} tools)"
 
 echo "Building public image for pipeline version ${version}"
 image_family="pipeline5-${version}${flavour+"-$flavour"}"
@@ -72,7 +79,7 @@ echo
 echo "set -e"
 echo $GCL instances create $source_instance --description=\"Pipeline5 disk imager started $(date) by $(whoami)\" --zone=${ZONE} \
     --boot-disk-size 200 --boot-disk-type pd-ssd --machine-type n1-standard-4 --image-project=${source_project} \
-    --image-family=${source_family} --scopes=default,cloud-source-repos-ro,storage-rw \
+    --image-family=${source_family} --scopes=cloud-platform \
     --network projects/hmf-vpc-network/global/networks/vpc-network-prod-1 \
     --subnet projects/hmf-vpc-network/regions/europe-west4/subnetworks/vpc-network-subnet-pipeline-development-1
 echo "set +e"
@@ -85,6 +92,12 @@ echo "done"
 echo "set -e"
 echo "$SSH --command=\"echo $version | tee /tmp/pipeline.version\""
 echo "$GCL scp $(dirname $0)/copy_to_imager_vm/* ${source_instance}:/tmp/ ${SSH_ARGS}"
+echo "$SSH --command=\"sudo rm -rf /opt/tools/*\""
+for tool in "${!tool_versions[@]}"; do
+    tool_version="${tool_versions[$tool]}"
+    echo "$SSH --command=\"sudo /tmp/fetch_tool_from_registry.sh $tool $tool_version\""
+done
+
 
 cat $all_cmds | egrep -v  '^#|^ *$' | while read cmd
 do

--- a/image/private_resource_checkout.sh
+++ b/image/private_resource_checkout.sh
@@ -91,9 +91,9 @@ else
 fi
 
 rm -r .git/
-#find . -type f | while read f; do
-#    dirname $(echo "$f" | sed 's#^\./##')
-#done | sort -u | while read d; do
-#    [[ $d != "." ]] && rm -rf /opt/resources/$d
-#done
+find . -type f | while read f; do
+    dirname $(echo "$f" | sed 's#^\./##')
+done | sort -u | while read d; do
+    [[ $d != "." ]] && rm -rf /opt/resources/$d
+done
 tar -cf - * | tar -C /opt/resources -xv

--- a/image/tools.cmds
+++ b/image/tools.cmds
@@ -16,9 +16,6 @@ sudo unzip /opt/tools/cuppa/2.1.1/cuppa.jar pycuppa/* -d /tmp/pycuppa-2.1.1
 sudo mv /tmp/pycuppa-2.1.1/pycuppa/* /opt/tools/pycuppa/2.1.1
 sudo /tmp/mk_python_venv --no-extract-tarball pycuppa 2.1.1
 
-# NOTE: This extracts overtop the system-managed R libraries.
-sudo tar xvf /opt/tools/R/rlibs_20240122.tar -C /
-
 sudo tar xvf /opt/tools/strelka/1.0.14/strelka.tar -C /opt/tools/strelka/1.0.14/
 sudo tar xvf /opt/tools/tabix/0.2.6/tabix.tar -C /opt/tools/tabix/0.2.6/
 sudo tar xvf /opt/tools/circos/0.69.6/circos.tar -C /opt/tools/circos/0.69.6/


### PR DESCRIPTION
Probably not super-exciting, much of this is just restoring some stuff that disappeared from `master` sometime in February I think it was.

Once the changes were restored I decided to update the list of JARs that is coming from Artifact Registry too, when I first made these changes only Orange was in there but now we've got a decent-sized list. Think it would be worthwhile to continue this process and eventually mostly eliminate the `hmftools` bucket from the flow for HMF-maintained tooling.

