### PR TITLE
INFRA-396 534 various tool bugfixes

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
@@ -18,14 +18,14 @@ public enum HmfTool {
     LILAC("1.6", 16, 24, 8, false),
     LINX("1.25", 8, 12, 4, false),
     MARK_DUPS("1.1.2", 40, 64, 24, false),
-    ORANGE("3.2.0", 16, 18, 4, false),
+    ORANGE("3.3.1", 16, 18, 4, false),
     PAVE("1.6", 30, 40, 8, false),
     PEACH("1.7", 1, 4, 2, false),
     PURPLE("4.0", 30, 40, 8, false),
     SAGE("3.4", 48, 64, 24, false),
     SIGS("1.2", Defaults.JAVA_HEAP, 16, 4, false),
     SV_PREP("1.2.3", 48, 64, 24, false),
-    TEAL("1.2.1", 30, 32, 16, false),
+    TEAL("1.2.2", 30, 32, 16, false),
     VIRUSBREAKEND_GRIDSS("2.13.3", Defaults.JAVA_HEAP, 64, 12, false),
     VIRUS_INTERPRETER("1.3", Defaults.JAVA_HEAP, 8, 2, false);
 

--- a/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
@@ -9,7 +9,7 @@ public enum HmfTool {
     AMBER("4.0", 20, 24, 16, false),
     BAM_TOOLS("1.2", 16, 24, 16, false),
     CHORD("2.02_1.14", Defaults.JAVA_HEAP, 12, 4, false),
-    CIDER("1.0.3", 12, 16, 4, false),
+    CIDER("1.0.3", 16, 24, 4, false),
     COBALT("1.16", 20, 24, 16, false),
     CUPPA("2.1.1", Defaults.JAVA_HEAP, 16, 4, false),
     GRIDSS("2.13.3", Defaults.JAVA_HEAP, 64, 24, false),


### PR DESCRIPTION
A hotfixed CUPPA is already added to 5.34 by Luan, this commit also updates Orange and TEAL and increases the memory for CIDER a bit.