### PR TITLE
INFRA-469: when a gcp request has failed, print the causes

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/failsafe/DefaultBackoffPolicy.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/failsafe/DefaultBackoffPolicy.java
@@ -20,9 +20,16 @@ public class DefaultBackoffPolicy<R> extends RetryPolicy<R> {
         abortOn(InvalidArgumentException.class);
         onAbort(e -> LOGGER.error("Unable to submit operation", e.getFailure()));
         handle(Exception.class);
-        onFailedAttempt(rExecutionAttemptedEvent -> LOGGER.warn("[{}] failed: {}",
-                taskName,
-                rExecutionAttemptedEvent.getLastFailure().getMessage()));
+        onFailedAttempt(rExecutionAttemptedEvent ->
+        {
+            // we need to keep tracing the cause to print out the real failure reason
+            Throwable lastFailure = rExecutionAttemptedEvent.getLastFailure();
+            while(lastFailure != null)
+            {
+                LOGGER.warn("[{}] failed: {}", taskName, lastFailure.getMessage());
+                lastFailure = lastFailure.getCause();
+            }
+        });
     }
 
     public static <R> DefaultBackoffPolicy<R> of(final String taskName) {


### PR DESCRIPTION
This is to fix a problem where gcp request failure just prints a `Bad request` with no reason given.