### PR TITLE
DEV-4026: Update MarkDups and increase memory and max heap

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
@@ -17,7 +17,7 @@ public enum HmfTool {
     HEALTH_CHECKER("3.5", Defaults.JAVA_HEAP, 32, 8, false),
     LILAC("1.6", 16, 24, 8, false),
     LINX("1.25", 8, 12, 4, false),
-    MARK_DUPS("1.1.2", 40, 64, 24, false),
+    MARK_DUPS("1.1.4", 64, 120, 24, false),
     ORANGE("3.3.1", 16, 18, 4, false),
     PAVE("1.6", 30, 40, 8, false),
     PEACH("1.7", 1, 4, 2, false),


### PR DESCRIPTION
Intended for a 5.34.6 pipeline release.