### PR TITLE
DEV-4026: Prevent some out of memory crashes

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinitions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinitions.java
@@ -212,7 +212,7 @@ public final class VirtualMachineJobDefinitions {
                 .imageFamily(STANDARD_IMAGE)
                 .name(name)
                 .namespacedResults(resultsDirectory)
-                .performanceProfile(custom(96, 128))
+                .performanceProfile(custom(64, 128))
                 .startupCommand(startupScript)
                 .build();
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
@@ -15,7 +15,7 @@ public enum HmfTool {
     GRIDSS("2.13.3", Defaults.JAVA_HEAP, 64, 24, false),
     GRIPSS("2.4", 16, 24, 4, false),
     HEALTH_CHECKER("3.5", Defaults.JAVA_HEAP, 32, 8, false),
-    LILAC("1.6", 16, 24, 8, false),
+    LILAC("1.6", 32, 40, 8, false),
     LINX("1.25", 8, 12, 4, false),
     MARK_DUPS("1.1.4", 64, 120, 24, false),
     ORANGE("3.3.1", 16, 18, 4, false),


### PR DESCRIPTION
Gave Lilac VM more RAM and heap. Reduced core count of lane alignment VM.