### PR TITLE
INFRA-696 Run SnpGenotype in HG38 mode

### DIFF
--- a/cloudbuild-pr.yaml
+++ b/cloudbuild-pr.yaml
@@ -20,6 +20,7 @@ steps:
     args:
       - 'install'
       - '-Drelease'
+      - '--debug'
       - '--batch-mode'
     env:
       - MAVEN_OPTS=-Dmaven.repo.local=/cache/.m2

--- a/cloudbuild-pr.yaml
+++ b/cloudbuild-pr.yaml
@@ -13,7 +13,7 @@ steps:
     volumes:
       - path: '/cache/.m2'
         name: 'm2_cache'
-  - name: eu.gcr.io/hmf-build/gcloud-jdk-mvn:1.7.4-beta.4
+  - name: eu.gcr.io/hmf-build/gcloud-jdk-mvn:1.7.4-beta.3
     id: 'Deploy artifacts to Maven repository'
     entrypoint: mvn
     timeout: 3600s

--- a/cloudbuild-pr.yaml
+++ b/cloudbuild-pr.yaml
@@ -14,23 +14,18 @@ steps:
       - path: '/cache/.m2'
         name: 'm2_cache'
   - name: eu.gcr.io/hmf-build/gcloud-jdk-mvn:1.7.4-beta.6
-    id: 'Build and install to Maven'
+    id: 'Build artifacts and install to Maven'
     entrypoint: mvn
     timeout: 3600s
     args:
       - 'install'
       - '-Drelease'
-      - '--debug'
       - '--batch-mode'
     env:
       - MAVEN_OPTS=-Dmaven.repo.local=/cache/.m2
     volumes:
       - path: '/cache/.m2'
         name: 'm2_cache'
-  - name: gcr.io/cloud-builders/gcloud
-    id: Try to dump logs
-    entrypoint: 'bash'
-    args: [ '-c', "find /workspace/cluster/target -type f -iname '*dump*' | xargs cat" ]
   - name: 'gcr.io/cloud-builders/gsutil'
     id: 'Update Maven cache after dependency resolution'
     args:

--- a/cloudbuild-pr.yaml
+++ b/cloudbuild-pr.yaml
@@ -14,7 +14,7 @@ steps:
       - path: '/cache/.m2'
         name: 'm2_cache'
   - name: eu.gcr.io/hmf-build/gcloud-jdk-mvn:1.7.4-beta.3
-    id: 'Deploy artifacts to Maven repository'
+    id: 'Build and install to Maven'
     entrypoint: mvn
     timeout: 3600s
     args:
@@ -27,6 +27,10 @@ steps:
     volumes:
       - path: '/cache/.m2'
         name: 'm2_cache'
+  - name: gcr.io/cloud-builders/gcloud
+    id: Try to dump logs
+    entrypoint: 'bash'
+    args: [ '-c', "find /workspace/cluster/target -type f -iname '*dump*' | xargs cat" ]
   - name: 'gcr.io/cloud-builders/gsutil'
     id: 'Update Maven cache after dependency resolution'
     args:

--- a/cloudbuild-pr.yaml
+++ b/cloudbuild-pr.yaml
@@ -13,7 +13,7 @@ steps:
     volumes:
       - path: '/cache/.m2'
         name: 'm2_cache'
-  - name: maven:3-jdk-11
+  - name: eu.gcr.io/hmf-build/gcloud-jdk-mvn:1.7.4-beta.1
     id: 'Deploy artifacts to Maven repository'
     entrypoint: mvn
     timeout: 3600s

--- a/cloudbuild-pr.yaml
+++ b/cloudbuild-pr.yaml
@@ -13,7 +13,7 @@ steps:
     volumes:
       - path: '/cache/.m2'
         name: 'm2_cache'
-  - name: eu.gcr.io/hmf-build/gcloud-jdk-mvn:1.7.4-beta.3
+  - name: eu.gcr.io/hmf-build/gcloud-jdk-mvn:1.7.4-beta.6
     id: 'Build and install to Maven'
     entrypoint: mvn
     timeout: 3600s

--- a/cloudbuild-pr.yaml
+++ b/cloudbuild-pr.yaml
@@ -13,7 +13,7 @@ steps:
     volumes:
       - path: '/cache/.m2'
         name: 'm2_cache'
-  - name: hartwigmedicalfoundation/docker-mvn-gcloud:3-jdk-11
+  - name: maven:3-jdk-11
     id: 'Deploy artifacts to Maven repository'
     entrypoint: mvn
     timeout: 3600s

--- a/cloudbuild-pr.yaml
+++ b/cloudbuild-pr.yaml
@@ -13,7 +13,7 @@ steps:
     volumes:
       - path: '/cache/.m2'
         name: 'm2_cache'
-  - name: eu.gcr.io/hmf-build/gcloud-jdk-mvn:1.7.4-beta.1
+  - name: eu.gcr.io/hmf-build/gcloud-jdk-mvn:1.7.4-beta.3
     id: 'Deploy artifacts to Maven repository'
     entrypoint: mvn
     timeout: 3600s

--- a/cloudbuild-pr.yaml
+++ b/cloudbuild-pr.yaml
@@ -13,7 +13,7 @@ steps:
     volumes:
       - path: '/cache/.m2'
         name: 'm2_cache'
-  - name: eu.gcr.io/hmf-build/gcloud-jdk-mvn:1.7.4-beta.3
+  - name: eu.gcr.io/hmf-build/gcloud-jdk-mvn:1.7.4-beta.4
     id: 'Deploy artifacts to Maven repository'
     entrypoint: mvn
     timeout: 3600s

--- a/cluster/src/main/java/com/hartwig/pipeline/snpgenotype/SnpGenotype.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/snpgenotype/SnpGenotype.java
@@ -24,7 +24,6 @@ import com.hartwig.pipeline.output.Folder;
 import com.hartwig.pipeline.output.RunLogComponent;
 import com.hartwig.pipeline.output.SingleFileComponent;
 import com.hartwig.pipeline.output.StartupScriptComponent;
-import com.hartwig.pipeline.resource.RefGenomeVersion;
 import com.hartwig.pipeline.resource.ResourceFiles;
 import com.hartwig.pipeline.stages.Namespace;
 import com.hartwig.pipeline.stages.Stage;
@@ -112,6 +111,6 @@ public class SnpGenotype implements Stage<SnpGenotypeOutput, SingleSampleRunMeta
 
     @Override
     public boolean shouldRun(final Arguments arguments) {
-        return arguments.runSnpGenotyper() && arguments.refGenomeVersion().equals(RefGenomeVersion.V37);
+        return arguments.runSnpGenotyper();
     }
 }

--- a/cluster/src/test/java/com/hartwig/pipeline/smoke/SmokeTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/smoke/SmokeTest.java
@@ -28,7 +28,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +36,7 @@ import static com.hartwig.pipeline.tools.VersionUtils.imageVersion;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parallelized.class)
+//@RunWith(Parallelized.class)
 @Category(value = IntegrationTest.class)
 public class SmokeTest {
 

--- a/cluster/src/test/java/com/hartwig/pipeline/smoke/SmokeTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/smoke/SmokeTest.java
@@ -29,6 +29,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.hartwig.pipeline.resource.RefGenomeVersion.V37;
 import static com.hartwig.pipeline.tools.VersionUtils.imageVersion;
@@ -45,6 +47,8 @@ public class SmokeTest {
     protected static final String INPUT_MODE_TUMOR_REF = "tumor-reference";
     protected static final String INPUT_MODE_TUMOR_ONLY = "tumor";
     protected static final String INPUT_MODE_REF_ONLY = "reference";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SmokeTest.class);
 
     private File resultsDir;
     private String whoami;
@@ -74,6 +78,7 @@ public class SmokeTest {
 //        if (whoami.equals("root")) {
 //            return CLOUD_SDK_PATH;
 //        }
+        LOGGER.
         try {
             Process process = Runtime.getRuntime().exec(new String[] { "/usr/bin/which", "gcloud" });
             if (process.waitFor() == 0) {
@@ -129,6 +134,7 @@ public class SmokeTest {
     public void runFullPipelineAndCheckFinalStatus(final String inputMode, final PipelineStatus expectedStatus,
             @SuppressWarnings("OptionalUsedAsFieldOrParameterType") final Optional<String> targetedRegionsBed,
             final RefGenomeVersion refGenomeVersion) throws Exception {
+        LOGGER.debug("Creating pipeline main");
         PipelineMain victim = new PipelineMain();
         String fixtureDir = "smoke_test/" + inputMode + "/";
         @SuppressWarnings("deprecation")
@@ -138,6 +144,7 @@ public class SmokeTest {
         String sampleJson = Resources.testResource(fixtureDir + "samples.json");
         PipelineInput pipelineInput = PdlJsonConversion.getInstance().read(sampleJson);
         String setName = pipelineInput.setName() + "-" + runTag;
+        LOGGER.debug("Constructing arguments");
         ImmutableArguments.Builder builder = Arguments.defaultsBuilder(Arguments.DefaultsProfile.DEVELOPMENT.toString())
                 .cleanup(false)
                 .context(Pipeline.Context.PLATINUM)
@@ -154,7 +161,9 @@ public class SmokeTest {
 
         cleanupBucket(setName, arguments.outputBucket(), storage);
 
+        LOGGER.debug("Starting pipeline");
         PipelineState state = victim.start(arguments);
+        LOGGER.debug("Pipeline completed");
         assertThat(state.status()).isEqualTo(expectedStatus);
 
         File expectedFilesResource = new File(Resources.testResource(fixtureDir + "expected_output_files"));
@@ -172,6 +181,7 @@ public class SmokeTest {
     }
 
     private void cleanupBucket(final String setName, final String archiveBucket, final Storage storage) {
+        LOGGER.debug("Cleaning up bucket");
         archiveBlobs(setName, archiveBucket, storage).forEach(Blob::delete);
     }
 

--- a/cluster/src/test/java/com/hartwig/pipeline/smoke/SmokeTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/smoke/SmokeTest.java
@@ -1,19 +1,5 @@
 package com.hartwig.pipeline.smoke;
 
-import static java.lang.String.format;
-
-import static com.hartwig.pipeline.resource.RefGenomeVersion.V37;
-import static com.hartwig.pipeline.tools.VersionUtils.imageVersion;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.io.File;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
-
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Storage;
@@ -28,7 +14,12 @@ import com.hartwig.pipeline.PipelineStatus;
 import com.hartwig.pipeline.resource.RefGenomeVersion;
 import com.hartwig.pipeline.storage.StorageProvider;
 import com.hartwig.pipeline.testsupport.Resources;
-
+import java.io.File;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -38,6 +29,11 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import static com.hartwig.pipeline.resource.RefGenomeVersion.V37;
+import static com.hartwig.pipeline.tools.VersionUtils.imageVersion;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parallelized.class)
 @Category(value = IntegrationTest.class)
@@ -75,9 +71,9 @@ public class SmokeTest {
     }
 
     protected static String findCloudSdk(final String whoami) {
-        if (whoami.equals("root")) {
-            return CLOUD_SDK_PATH;
-        }
+//        if (whoami.equals("root")) {
+//            return CLOUD_SDK_PATH;
+//        }
         try {
             Process process = Runtime.getRuntime().exec(new String[] { "/usr/bin/which", "gcloud" });
             if (process.waitFor() == 0) {

--- a/cluster/src/test/java/com/hartwig/pipeline/smoke/SmokeTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/smoke/SmokeTest.java
@@ -78,13 +78,14 @@ public class SmokeTest {
 //        if (whoami.equals("root")) {
 //            return CLOUD_SDK_PATH;
 //        }
-        LOGGER.
+        LOGGER.debug("Locating Google SDK");
         try {
             Process process = Runtime.getRuntime().exec(new String[] { "/usr/bin/which", "gcloud" });
             if (process.waitFor() == 0) {
                 return new File(new String(process.getInputStream().readAllBytes())).getParent();
             }
         } catch (Exception e) {
+            LOGGER.warn("Failed to locate SDK, will use default", e);
             // Fall through to using the default
         }
         return format("/Users/%s/google-cloud-sdk/bin", whoami);

--- a/cluster/src/test/resources/log4j.xml
+++ b/cluster/src/test/resources/log4j.xml
@@ -18,7 +18,7 @@
     </logger>
 
     <root>
-        <level value="WARN"/>
+        <level value="DEBUG"/>
         <appender-ref ref="console"/>
     </root>
 

--- a/cluster/src/test/resources/log4j.xml
+++ b/cluster/src/test/resources/log4j.xml
@@ -18,7 +18,7 @@
     </logger>
 
     <root>
-        <level value="DEBUG"/>
+        <level value="WARN"/>
         <appender-ref ref="console"/>
     </root>
 

--- a/pom.xml
+++ b/pom.xml
@@ -308,9 +308,9 @@
                     <version>3.4.0</version>
                     <configuration>
                         <testFailureIgnore>true</testFailureIgnore>
-                        
                         <!--<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>-->
                         <reuseForks>true</reuseForks>
+                        <forkCount>1</forkCount>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,7 @@
                     <version>3.2.5</version>
                     <configuration>
                         <!--<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>-->
-                        <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+                        <argLine>-XX:MaxPermSize=256m</argLine>
                         <reuseForks>true</reuseForks>
                     </configuration>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -306,12 +306,12 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.4.0</version>
-                    <configuration>
-                        <testFailureIgnore>true</testFailureIgnore>
+                    <!--                    <configuration>-->
+                    <!--                        <testFailureIgnore>true</testFailureIgnore>-->
                         <!--<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>-->
-                        <reuseForks>true</reuseForks>
-                        <forkCount>1</forkCount>
-                    </configuration>
+                    <!--                        <reuseForks>true</reuseForks>-->
+                    <!--                        <forkCount>1</forkCount>-->
+                    <!--                    </configuration>-->
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <immutables.version>2.5.5</immutables.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <mockito.version>2.23.4</mockito.version>
+        <mockito.version>5.12.0</mockito.version>
         <assertj-core.version>3.8.0</assertj-core.version>
         <slf4j-api.version>1.7.25</slf4j-api.version>
         <commons-io.version>2.7</commons-io.version>

--- a/pom.xml
+++ b/pom.xml
@@ -307,6 +307,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.4.0</version>
                     <configuration>
+                        <testFailureIgnore>true</testFailureIgnore>
                         <!--<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>-->
                         <reuseForks>true</reuseForks>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,9 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.2.5</version>
                     <configuration>
-                        <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
+                        <!--<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>-->
+                        <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+                        <reuseForks>true</reuseForks>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.2.5</version>
                     <configuration>
-                        <forkCount>0</forkCount>
+                        <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -308,6 +308,7 @@
                     <version>3.4.0</version>
                     <configuration>
                         <testFailureIgnore>true</testFailureIgnore>
+                        
                         <!--<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>-->
                         <reuseForks>true</reuseForks>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -306,12 +306,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.4.0</version>
-                    <!--                    <configuration>-->
-                    <!--                        <testFailureIgnore>true</testFailureIgnore>-->
-                        <!--<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>-->
-                    <!--                        <reuseForks>true</reuseForks>-->
-                    <!--                        <forkCount>1</forkCount>-->
-                    <!--                    </configuration>-->
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -305,17 +305,16 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.5</version>
+                    <version>3.4.0</version>
                     <configuration>
                         <!--<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>-->
-                        <argLine>-XX:MaxPermSize=256m</argLine>
                         <reuseForks>true</reuseForks>
                     </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-report-plugin</artifactId>
-                    <version>3.2.5</version>
+                    <version>3.4.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -306,6 +306,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.2.5</version>
+                    <configuration>
+                        <forkCount>0</forkCount>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This change makes sure that for Targeted mode (which runs on HG38 in our production setup) also output the `snp_genotype.vcf` file with 26 or 31 SNP genotype calls. This will allow performing of snpcheck once the MIP-based snpcheck is ready for production.

Tested this change by running on TARGETED COLO from `gs://hmf-verification-data-fastq/COLO829-TARGETED/` and comparing the resulting snp genotype VCF with the same file from WGS COLO, which yielded a perfect match for all 26 positions.