### PR TITLE
INFRA-786 Add 31SNP output to genotype stage

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/resource/RefGenome37ResourceFiles.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/resource/RefGenome37ResourceFiles.java
@@ -131,6 +131,10 @@ public class RefGenome37ResourceFiles implements ResourceFiles {
     public String genotypeSnpsDB() {
         return formPath(GENOTYPE_SNPS, "26SNPtaq.vcf");
     }
+    @Override
+    public String genotypeMipSnpsDB() {
+        return formPath(GENOTYPE_SNPS, "31SNPtaq.vcf");
+    }
     public String peachHaplotypes() {
         return formPath(PEACH, "haplotypes.37.tsv");
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/resource/RefGenome38ResourceFiles.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/resource/RefGenome38ResourceFiles.java
@@ -120,6 +120,10 @@ public class RefGenome38ResourceFiles implements ResourceFiles {
     public String genotypeSnpsDB() {
         return formPath(GENOTYPE_SNPS, "26SNPtaq.vcf");
     }
+    @Override
+    public String genotypeMipSnpsDB() {
+        return formPath(GENOTYPE_SNPS, "31SNPtaq.vcf");
+    }
     public String peachHaplotypes() {
         return formPath(PEACH, "haplotypes.38.tsv");
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/resource/ResourceFiles.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/resource/ResourceFiles.java
@@ -51,6 +51,7 @@ public interface ResourceFiles {
     String gnomadPonCache();
     String giabHighConfidenceBed();
     String genotypeSnpsDB(); // will be decommission when Sage germline covers entire genome or exome
+    String genotypeMipSnpsDB(); // comment about decommission for genotypeSnpsDB above also applies here
 
     // structural variants and virus
     String repeatMaskerDb();

--- a/cluster/src/test/java/com/hartwig/pipeline/snpgenotype/SnpGenotypeTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/snpgenotype/SnpGenotypeTest.java
@@ -2,7 +2,7 @@ package com.hartwig.pipeline.snpgenotype;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
@@ -56,11 +56,16 @@ public class SnpGenotypeTest extends StageTest<SnpGenotypeOutput, SingleSampleRu
 
     @Override
     protected List<String> expectedCommands() {
-        return Collections.singletonList(
-                "/usr/lib/jvm/jdk8u302-b08/jre/bin/java -Xmx20G -jar /opt/tools/gatk/3.8.0/GenomeAnalysisTK.jar -T UnifiedGenotyper -nct $(grep -c '^processor' /proc/cpuinfo) "
-                        + "--input_file /data/input/reference.bam -o /data/output/snp_genotype_output.vcf -L "
-                        + "/opt/resources/genotype_snps/37/26SNPtaq.vcf --reference_sequence "
-                        + "/opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta --output_mode EMIT_ALL_SITES");
+        final ArrayList<String> commands = new ArrayList<>();
+        commands.add("/usr/lib/jvm/jdk8u302-b08/jre/bin/java -Xmx20G -jar /opt/tools/gatk/3.8.0/GenomeAnalysisTK.jar -T UnifiedGenotyper -nct $(grep -c '^processor' /proc/cpuinfo) "
+                + "--input_file /data/input/reference.bam -o /data/output/snp_genotype_output.vcf -L "
+                + "/opt/resources/genotype_snps/37/26SNPtaq.vcf --reference_sequence "
+                + "/opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta --output_mode EMIT_ALL_SITES");
+        commands.add("/usr/lib/jvm/jdk8u302-b08/jre/bin/java -Xmx20G -jar /opt/tools/gatk/3.8.0/GenomeAnalysisTK.jar -T UnifiedGenotyper -nct $(grep -c '^processor' /proc/cpuinfo) "
+                + "--input_file /data/input/reference.bam -o /data/output/snp_genotype_output_mip.vcf -L "
+                + "/opt/resources/genotype_snps/37/31SNPtaq.vcf --reference_sequence "
+                + "/opt/resources/reference_genome/37/Homo_sapiens.GRCh37.GATK.illumina.fasta --output_mode EMIT_ALL_SITES");
+        return commands;
     }
 
     @Override

--- a/cluster/src/test/resources/smoke_test/reference/expected_output_files
+++ b/cluster/src/test/resources/smoke_test/reference/expected_output_files
@@ -18,6 +18,7 @@ COLO829v003R/pipeline.version
 COLO829v003R/snp_genotype/run.log
 COLO829v003R/snp_genotype/run.sh
 COLO829v003R/snp_genotype/snp_genotype_output.vcf
+COLO829v003R/snp_genotype/snp_genotype_output_mip.vcf
 amber/COLO829v003R.amber.baf.tsv.gz
 amber/COLO829v003R.amber.homozygousregion.tsv
 amber/COLO829v003R.amber.qc

--- a/cluster/src/test/resources/smoke_test/tumor-reference/expected_output_files
+++ b/cluster/src/test/resources/smoke_test/tumor-reference/expected_output_files
@@ -18,6 +18,7 @@ COLO829v003R/pipeline.version
 COLO829v003R/snp_genotype/run.log
 COLO829v003R/snp_genotype/run.sh
 COLO829v003R/snp_genotype/snp_genotype_output.vcf
+COLO829v003R/snp_genotype/snp_genotype_output_mip.vcf
 COLO829v003T/aligner/NA-1/run.log
 COLO829v003T/aligner/NA-2/run.log
 COLO829v003T/aligner/NA-3/run.log
@@ -38,6 +39,7 @@ COLO829v003T/pipeline.version
 COLO829v003T/snp_genotype/run.log
 COLO829v003T/snp_genotype/run.sh
 COLO829v003T/snp_genotype/snp_genotype_output.vcf
+COLO829v003R/snp_genotype/snp_genotype_output_mip.vcf
 amber/COLO829v003R.amber.homozygousregion.tsv
 amber/COLO829v003R.amber.snp.vcf.gz
 amber/COLO829v003R.amber.snp.vcf.gz.tbi

--- a/cluster/src/test/resources/smoke_test/tumor/expected_output_files
+++ b/cluster/src/test/resources/smoke_test/tumor/expected_output_files
@@ -18,6 +18,7 @@ COLO829v003T/flagstat/run.sh
 COLO829v003T/snp_genotype/run.log
 COLO829v003T/snp_genotype/run.sh
 COLO829v003T/snp_genotype/snp_genotype_output.vcf
+COLO829v003T/snp_genotype/snp_genotype_output_mip.vcf
 amber/COLO829v003T.amber.baf.pcf
 amber/COLO829v003T.amber.baf.tsv.gz
 amber/COLO829v003T.amber.qc


### PR DESCRIPTION
Same change that was merged into 5.33 and 5.34 hotfix branches.

- `mvn clean test` yields BUILD SUCCESS
- COLO mini hg37 from BAM runs fine with image `pipeline5-6-0-202409241531`