### PR TITLE
DEV-4111: Update Docker images in Cloud Build

### DIFF
--- a/cloudbuild-pr.yaml
+++ b/cloudbuild-pr.yaml
@@ -13,7 +13,7 @@ steps:
     volumes:
       - path: '/cache/.m2'
         name: 'm2_cache'
-  - name: eu.gcr.io/hmf-build/gcloud-jdk-mvn:1.7.4-beta.6
+  - name: eu.gcr.io/hmf-build/gcloud-jdk-mvn:1.7.5
     id: 'Build artifacts and install to Maven'
     entrypoint: mvn
     timeout: 3600s

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,7 +17,7 @@ steps:
     volumes:
       - path: '/cache/.m2'
         name: 'm2_cache'
-  - name: hartwigmedicalfoundation/docker-mvn-gcloud:3-jdk-11
+  - name: eu.gcr.io/hmf-build/gcloud-jdk-mvn:1.7.5
     id: 'Deploy artifacts to Maven repository'
     entrypoint: mvn
     timeout: 3600s

--- a/cluster/Dockerfile
+++ b/cluster/Dockerfile
@@ -1,7 +1,7 @@
 FROM google/cloud-sdk:latest
 
 RUN apt-get update
-RUN apt-get --yes install openjdk-11-jre
+RUN apt-get --yes install openjdk-17-jre
 
 ADD bin/pipeline5.sh pipeline5.sh
 ADD target/lib /usr/share/pipeline5/lib


### PR DESCRIPTION
The tag-based build was still using the Docker image that was accidentally deleted as its base. 
Also update the Docker image used from 1.7.4-beta.6 to 1.7.5.