### PR TITLE
INFRA-938 Include more metadata in pipeline.complete event

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/output/PipelineCompleteEventPublisher.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/output/PipelineCompleteEventPublisher.java
@@ -107,8 +107,11 @@ public class PipelineCompleteEventPublisher implements OutputPublisher {
             outputDataset.serializeAndUpload();
             publish(PipelineComplete.builder()
                     .pipeline(ImmutablePipeline.builder()
+                            .engine(Pipeline.Engine.PIPELINE5)
+                            .molecule(Pipeline.Molecule.DNA)
                             .sample(tumorSampleName.orElseGet(refSampleName::orElseThrow))
                             .bucket(sourceBucket.getName())
+                            .rootPath(Optional.of(metadata.set()))
                             .runId(metadata.maybeExternalIds().get().runId())
                             .setId(metadata.maybeExternalIds().get().setId())
                             .context(context)

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <htsjdk.version>2.23.0</htsjdk.version>
         <org-reflections.version>0.9.11</org-reflections.version>
         <google-api-services-serviceusage.version>v1beta1-rev20200804-1.30.10</google-api-services-serviceusage.version>
-        <events.version>3.18.0</events.version>
+        <events.version>3.23.0</events.version>
         <java-client.version>1.31.1</java-client.version>
         <compar.version>1.3-beta.1</compar.version>
         <org-reflections.version>0.9.11</org-reflections.version>


### PR DESCRIPTION
Needed to locate the right pipeline in the pipeline reference data, which will replace the lists of analyses blobs. Keep the analyses blobs for now to remain backwards compatible.