### PR TITLE
INFRA-1437 pipeline5 virusbreakend should not use resource config tha…

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java
@@ -25,7 +25,7 @@ public enum HmfTool {
     SIGS("1.2.1", 16, 4, false, 30),
     TEAL("1.3.3", 32, 32, false),
     V_CHORD("1.0", 4, 2, false),
-    VIRUSBREAKEND_GRIDSS("2.13.3", 64, 8, false),
+    VIRUSBREAKEND_GRIDSS("2.13.3", 64, 12, false),
     VIRUS_INTERPRETER("1.7", 8, 2, false);
 
     private static final String PILOT_VERSION = "pilot"; // will pick up the jar from /opt/toolName/pilot/toolName.jar


### PR DESCRIPTION
…t only works with n2d machines

64 GB RAM and 8 CPU cores only works on N2D machines. However, if n2d gets preempted we will switch over to another machine type, which will fail immediately since i.e. N1 machines can have max 52 GB RAM for 8 CPU cores. Therefore we should play it safe and request 12 cores (like it used to be before the latest change).