### PR TITLE
INFRA-1530: Make extra Redux file findable in database structure

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
@@ -3,6 +3,7 @@ package com.hartwig.pipeline;
 import java.util.Optional;
 
 import com.hartwig.events.pipeline.Pipeline;
+import com.hartwig.pipeline.reference.api.PipelineOutputStructure;
 import com.hartwig.pipeline.resource.RefGenomeVersion;
 
 import org.immutables.value.Value;
@@ -22,6 +23,7 @@ public interface Arguments extends CommonArguments {
     RefGenomeVersion DEFAULT_REF_GENOME_VERSION = RefGenomeVersion.V37;
     int DEFAULT_MAX_CONCURRENT_LANES = 8;
     Pipeline.Context DEFAULT_CONTEXT = Pipeline.Context.DIAGNOSTIC;
+    PipelineOutputStructure DEFAULT_INPUT_BAM_DIRECTORY_STRUCTURE = PipelineOutputStructure.PIPELINE5;
 
     static ImmutableArguments.Builder builder() {
         return ImmutableArguments.builder();
@@ -66,7 +68,8 @@ public interface Arguments extends CommonArguments {
                 .anonymize(false)
                 .usePrivateResources(false)
                 .context(DEFAULT_CONTEXT)
-                .sampleJson(DEFAULT_SAMPLE_JSON);
+                .sampleJson(DEFAULT_SAMPLE_JSON)
+                .inputBamDirectoryStructure(DEFAULT_INPUT_BAM_DIRECTORY_STRUCTURE);
 
         DefaultsProfile profile = DefaultsProfile.valueOf(profileString.toUpperCase());
         if (profile.equals(DefaultsProfile.PRODUCTION)) {
@@ -163,6 +166,8 @@ public interface Arguments extends CommonArguments {
     Optional<Integer> stageMemoryOverrideGb();
 
     Optional<String> stageMemoryOverrideRegex();
+
+    PipelineOutputStructure inputBamDirectoryStructure();
 
     enum DefaultsProfile {
         PUBLIC,

--- a/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
@@ -10,6 +10,7 @@ import java.util.stream.Stream;
 
 import com.hartwig.events.pipeline.Pipeline;
 import com.hartwig.pipeline.Arguments.DefaultsProfile;
+import com.hartwig.pipeline.reference.api.PipelineOutputStructure;
 import com.hartwig.pipeline.resource.RefGenomeVersion;
 import com.hartwig.pipeline.tools.VersionUtils;
 
@@ -75,6 +76,7 @@ public class CommandLineOptions {
     private static final String REDO_DUPLICATE_MARKING_FLAG = "redo_duplicate_marking";
     private static final String STAGE_MEMORY_OVERRIDE_GB_FLAG = "stage_memory_override_gb";
     private static final String STAGE_MEMORY_OVERRIDE_REGEX_FLAG = "stage_memory_override_regex";
+    private static final String INPUT_BAM_DIRECTORY_STRUCTURE = "input_bam_directory_structure";
 
     private static Options options() {
         return new Options().addOption(profile())
@@ -138,7 +140,8 @@ public class CommandLineOptions {
                 .addOption(optionWithArg(STAGE_MEMORY_OVERRIDE_GB_FLAG,
                         "Override the memory for a stage (specified by regex) to a specific value. "))
                 .addOption(optionWithArg(STAGE_MEMORY_OVERRIDE_REGEX_FLAG,
-                        "Regex to match the stage name to override the memory for. This is used in conjunction with the -stage_memory_override_gb flag."));
+                        "Regex to match the stage name to override the memory for. This is used in conjunction with the -stage_memory_override_gb flag."))
+                .addOption(inputBamDirectoryStructure());
     }
 
     private static Option useTargetRegions() {
@@ -287,6 +290,13 @@ public class CommandLineOptions {
                 format("Publish an event for downstream DB load; has no effect unless context is [%s]", Pipeline.Context.PLATINUM));
     }
 
+    private static Option inputBamDirectoryStructure() {
+        return optionWithArg(INPUT_BAM_DIRECTORY_STRUCTURE,
+                format("Assumed format of input files for finding non-BAM Redux outputs when applicable. default [%s], values [%s]",
+                        PipelineOutputStructure.PIPELINE5,
+                        Arrays.stream(PipelineOutputStructure.values()).map(Enum::toString).sorted().collect(Collectors.joining(","))));
+    }
+
     public static Arguments from(final String[] args) throws ParseException {
         try {
             DefaultParser defaultParser = new DefaultParser();
@@ -344,6 +354,7 @@ public class CommandLineOptions {
                     .hmfApiUrl(hmfApiUrl(commandLine, defaults))
                     .stageMemoryOverrideRegex(stageMemoryOverrideRegex(commandLine))
                     .stageMemoryOverrideGb(stageMemoryOverrideGb(commandLine))
+                    .inputBamDirectoryStructure(inputBamDirectoryStructure(commandLine, defaults.inputBamDirectoryStructure()))
                     .build();
         } catch (ParseException e) {
             LOGGER.error("Could not parse command line args", e);
@@ -518,6 +529,14 @@ public class CommandLineOptions {
             return Optional.of(Integer.parseInt(commandLine.getOptionValue(STAGE_MEMORY_OVERRIDE_GB_FLAG)));
         }
         return Optional.empty();
+    }
+
+    private static PipelineOutputStructure inputBamDirectoryStructure(final CommandLine commandLine,
+            final PipelineOutputStructure defaultStructure) {
+        if (commandLine.hasOption(INPUT_BAM_DIRECTORY_STRUCTURE)) {
+            return PipelineOutputStructure.valueOf(commandLine.getOptionValue(INPUT_BAM_DIRECTORY_STRUCTURE));
+        }
+        return defaultStructure;
     }
 
     private static Option optionWithArg(final String option, final String description) {

--- a/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
@@ -76,7 +76,7 @@ public class CommandLineOptions {
     private static final String REDO_DUPLICATE_MARKING_FLAG = "redo_duplicate_marking";
     private static final String STAGE_MEMORY_OVERRIDE_GB_FLAG = "stage_memory_override_gb";
     private static final String STAGE_MEMORY_OVERRIDE_REGEX_FLAG = "stage_memory_override_regex";
-    private static final String INPUT_BAM_DIRECTORY_STRUCTURE = "input_bam_directory_structure";
+    public static final String INPUT_BAM_DIRECTORY_STRUCTURE = "input_bam_directory_structure";
 
     private static Options options() {
         return new Options().addOption(profile())

--- a/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
@@ -116,7 +116,7 @@ public class PipelineMain {
                 persistedDataset,
                 metricsOutputQueue,
                 germlineCallerOutputQueue,
-                new ReduxFileLocator(input, storage, arguments.project()));
+                new ReduxFileLocator(input, storage, arguments.project(), arguments.inputBamDirectoryStructure()));
     }
 
     public static void main(final String[] args) {

--- a/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/PipelineMain.java
@@ -20,6 +20,7 @@ import com.hartwig.events.EventPublisher;
 import com.hartwig.events.pipeline.Pipeline;
 import com.hartwig.events.pipeline.PipelineComplete;
 import com.hartwig.events.pubsub.PubsubEventBuilder;
+import com.hartwig.gcp.StorageUtil;
 import com.hartwig.pdl.PipelineInput;
 import com.hartwig.pipeline.alignment.AlignerProvider;
 import com.hartwig.pipeline.calling.germline.GermlineCallerOutput;
@@ -116,7 +117,7 @@ public class PipelineMain {
                 persistedDataset,
                 metricsOutputQueue,
                 germlineCallerOutputQueue,
-                new ReduxFileLocator(input, storage, arguments.project(), arguments.inputBamDirectoryStructure()));
+                new ReduxFileLocator(input, new StorageUtil(storage), arguments.project(), arguments.inputBamDirectoryStructure()));
     }
 
     public static void main(final String[] args) {

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/bwa/BwaAligner.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/bwa/BwaAligner.java
@@ -95,7 +95,7 @@ public class BwaAligner implements Aligner {
         if (sample.bam().isPresent() && !arguments.redoDuplicateMarking()) {
             cleanUp(trace);
             var bamLocation = sample.bam().get();
-            var reduxFileLocator = new ReduxFileLocator(input, storage, arguments.project());
+            var reduxFileLocator = new ReduxFileLocator(input, storage, arguments.project(), arguments.inputBamDirectoryStructure());
             return AlignmentOutput.builder()
                     .sample(metadata.sampleName())
                     .status(PipelineStatus.PROVIDED)

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/bwa/BwaAligner.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/bwa/BwaAligner.java
@@ -29,6 +29,7 @@ import com.hartwig.computeengine.storage.GoogleStorageLocation;
 import com.hartwig.computeengine.storage.ResultsDirectory;
 import com.hartwig.computeengine.storage.RuntimeBucket;
 import com.hartwig.computeengine.storage.RuntimeBucketOptions;
+import com.hartwig.gcp.StorageUtil;
 import com.hartwig.pdl.LaneInput;
 import com.hartwig.pdl.PipelineInput;
 import com.hartwig.pdl.SampleInput;
@@ -95,7 +96,7 @@ public class BwaAligner implements Aligner {
         if (sample.bam().isPresent() && !arguments.redoDuplicateMarking()) {
             cleanUp(trace);
             var bamLocation = sample.bam().get();
-            var reduxFileLocator = new ReduxFileLocator(input, storage, arguments.project(), arguments.inputBamDirectoryStructure());
+            var reduxFileLocator = new ReduxFileLocator(input, new StorageUtil(storage), arguments.project(), arguments.inputBamDirectoryStructure());
             return AlignmentOutput.builder()
                     .sample(metadata.sampleName())
                     .status(PipelineStatus.PROVIDED)

--- a/cluster/src/main/java/com/hartwig/pipeline/input/ReduxFileLocator.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/input/ReduxFileLocator.java
@@ -63,17 +63,19 @@ public class ReduxFileLocator {
                 .findFirst()
                 .map(it -> it.getPathOrNull(inputBamDirectoryStructure))
                 .map(PipelineFilePath::toString)
-                .orElseThrow();
+                .orElseThrow(() -> new IllegalStateException(
+                        "Path to file of type " + dataType.name() + " cannot be derived since there is no known expected format for "
+                                + bamTool.name() + " path."));
         var rootDirectory = URI.create(bamLocation).resolve("../".repeat(StringUtils.countMatches(relativeBamPath, "/")));
         var pipelineOutputLocation = new PipelineOutputTemporaryLocation(rootDirectory, inputBamDirectoryStructure);
 
-        var reduxFile =
-                PipelineFiles.get(pipelineRun, PipelineFiles.sampleTypeIs(sampleType), PipelineFiles.dataTypeIsAnyOf(dataType))
-                        .stream()
-                        .findFirst()
-                        .map(it -> it.getUriOrNull(pipelineOutputLocation))
-                        .map(URI::toString)
-                        .orElseThrow();
+        var reduxFile = PipelineFiles.get(pipelineRun, PipelineFiles.sampleTypeIs(sampleType), PipelineFiles.dataTypeIsAnyOf(dataType))
+                .stream()
+                .findFirst()
+                .map(it -> it.getUriOrNull(pipelineOutputLocation))
+                .map(URI::toString)
+                .orElseThrow(() -> new IllegalStateException("Path to file of type " + dataType.name()
+                        + " cannot be derived since there is no known expected format for such a path."));
         if (!storageUtil.exists(reduxFile)) {
             // If the file is not found, it either means the user made a mistake, or the file really does not exist.
             // In the first case, we let the user know by crashing pipeline5.

--- a/cluster/src/main/java/com/hartwig/pipeline/input/ReduxFileLocator.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/input/ReduxFileLocator.java
@@ -1,5 +1,7 @@
 package com.hartwig.pipeline.input;
 
+import static com.hartwig.pipeline.CommandLineOptions.INPUT_BAM_DIRECTORY_STRUCTURE;
+
 import java.net.URI;
 
 import com.google.cloud.storage.Storage;
@@ -26,10 +28,10 @@ public class ReduxFileLocator {
     private final String project;
     private final PipelineOutputStructure inputBamDirectoryStructure;
 
-    public ReduxFileLocator(final PipelineInput input, final Storage storage, final String project,
+    public ReduxFileLocator(final PipelineInput input, final StorageUtil storageUtil, final String project,
             final PipelineOutputStructure inputBamDirectoryStructure) {
         this.input = input;
-        this.storageUtil = new StorageUtil(storage);
+        this.storageUtil = storageUtil;
         this.project = project;
         this.inputBamDirectoryStructure = inputBamDirectoryStructure;
     }
@@ -77,8 +79,10 @@ public class ReduxFileLocator {
             // In the first case, we let the user know by crashing pipeline5.
             // In the second case, the user should redo marking duplicates to generate the file.
             throw new IllegalStateException(("Duplicate marking output file not found. Expected at location: '%s'. "
-                                             + "If this is intentional, consider enabling the '--redo_duplicate_marking' flag.").formatted(
-                    reduxFile));
+                    + "If these files exist in a different location, consider changing the '--%s' argument from '%s' to something more appropriate. "
+                    + "If these files don't exist, consider enabling the '--redo_duplicate_marking' flag.").formatted(reduxFile,
+                    INPUT_BAM_DIRECTORY_STRUCTURE,
+                    inputBamDirectoryStructure));
         }
         return GoogleStorageLocation.from(reduxFile, project);
     }

--- a/cluster/src/main/java/com/hartwig/pipeline/input/ReduxFileLocator.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/input/ReduxFileLocator.java
@@ -7,23 +7,31 @@ import com.hartwig.computeengine.storage.GoogleStorageLocation;
 import com.hartwig.gcp.StorageUtil;
 import com.hartwig.pdl.PipelineInput;
 import com.hartwig.pdl.SampleInput;
+import com.hartwig.pipeline.reference.api.DataType;
 import com.hartwig.pipeline.reference.api.Pipeline;
+import com.hartwig.pipeline.reference.api.PipelineFilePath;
 import com.hartwig.pipeline.reference.api.PipelineFiles;
 import com.hartwig.pipeline.reference.api.PipelineOutputStructure;
 import com.hartwig.pipeline.reference.api.PipelineOutputTemporaryLocation;
 import com.hartwig.pipeline.reference.api.PipelineRun;
 import com.hartwig.pipeline.reference.api.SampleType;
+import com.hartwig.pipeline.reference.api.Tool;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class ReduxFileLocator {
 
     private final PipelineInput input;
     private final StorageUtil storageUtil;
     private final String project;
+    private final PipelineOutputStructure inputBamDirectoryStructure;
 
-    public ReduxFileLocator(final PipelineInput input, final Storage storage, final String project) {
+    public ReduxFileLocator(final PipelineInput input, final Storage storage, final String project,
+            final PipelineOutputStructure inputBamDirectoryStructure) {
         this.input = input;
         this.storageUtil = new StorageUtil(storage);
         this.project = project;
+        this.inputBamDirectoryStructure = inputBamDirectoryStructure;
     }
 
     public GoogleStorageLocation locateJitterParamsFile(SingleSampleRunMetadata metadata) {
@@ -43,9 +51,19 @@ public class ReduxFileLocator {
         var reference = metadata.type().equals(SingleSampleRunMetadata.SampleType.REFERENCE) ? metadata.sampleName() : "___";
         var pipelineRun = new PipelineRun(Pipeline.DNA_6_0, tumor, reference);
         var sampleType = metadata.type().equals(SingleSampleRunMetadata.SampleType.TUMOR) ? SampleType.TUMOR : SampleType.REFERENCE;
-        // We assume the default output format for pipeline5, both the BAM and the CRAM file are 2 levels below the pipeline output root.
-        var pipelineOutputLocation =
-                new PipelineOutputTemporaryLocation(URI.create(bamLocation).resolve("../../"), PipelineOutputStructure.PIPELINE5);
+
+        var bamTool = bamLocation.endsWith(".cram") ? Tool.CRAM : Tool.ALIGNER;
+        var relativeBamPath = PipelineFiles.get(pipelineRun,
+                        PipelineFiles.sampleTypeIs(sampleType),
+                        PipelineFiles.dataTypeIsAnyOf(DataType.ALIGNED_READS),
+                        PipelineFiles.toolIsAnyOf(bamTool))
+                .stream()
+                .findFirst()
+                .map(it -> it.getPathOrNull(inputBamDirectoryStructure))
+                .map(PipelineFilePath::toString)
+                .orElseThrow();
+        var rootDirectory = URI.create(bamLocation).resolve("../".repeat(StringUtils.countMatches(relativeBamPath, "/")));
+        var pipelineOutputLocation = new PipelineOutputTemporaryLocation(rootDirectory, inputBamDirectoryStructure);
 
         var reduxFile =
                 PipelineFiles.get(pipelineRun, PipelineFiles.sampleTypeIs(sampleType), PipelineFiles.dataTypeIsAnyOf(dataType))

--- a/cluster/src/test/java/com/hartwig/pipeline/input/ReduxFileLocatorTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/input/ReduxFileLocatorTest.java
@@ -1,0 +1,181 @@
+package com.hartwig.pipeline.input;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.hartwig.computeengine.storage.ImmutableGoogleStorageLocation;
+import com.hartwig.gcp.StorageUtil;
+import com.hartwig.pdl.ImmutablePipelineInput;
+import com.hartwig.pdl.PipelineInput;
+import com.hartwig.pdl.SampleInput;
+import com.hartwig.pipeline.Arguments;
+import com.hartwig.pipeline.reference.api.PipelineOutputStructure;
+import com.hartwig.pipeline.testsupport.TestInputs;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ReduxFileLocatorTest {
+    private StorageUtil storageUtil;
+    private String project;
+
+    @Before
+    public void setup() {
+        storageUtil = mock(StorageUtil.class);
+        project = Arguments.testDefaults().project();
+    }
+
+    @Test
+    public void shouldDeriveFilesCorrectlyForPipeline5TumorBam() {
+        var sampleName = TestInputs.tumorSample();
+        var metadata = TestInputs.tumorRunMetadata();
+        var pipelineInput =
+                createTestPipelineInput(sampleName, String.format("gs://bucket/run/%s/aligner/%s.bam", sampleName, sampleName), true);
+
+        var expectedJitterOutput = createExpectedOutput(String.format("run/%s/aligner/%s.jitter_params.tsv", sampleName, sampleName));
+        var expectedMsTableOutput = createExpectedOutput(String.format("run/%s/aligner/%s.ms_table.tsv.gz", sampleName, sampleName));
+
+        assertFilePathsDerivedCorrectly(expectedJitterOutput,
+                expectedMsTableOutput,
+                pipelineInput,
+                metadata,
+                PipelineOutputStructure.PIPELINE5);
+    }
+
+    @Test
+    public void shouldDeriveFilesCorrectlyForPipeline5RefBam() {
+        var sampleName = TestInputs.referenceSample();
+        var metadata = TestInputs.referenceRunMetadata();
+        var pipelineInput =
+                createTestPipelineInput(sampleName, String.format("gs://bucket/run/%s/aligner/%s.bam", sampleName, sampleName), false);
+
+        var expectedJitterOutput = createExpectedOutput(String.format("run/%s/aligner/%s.jitter_params.tsv", sampleName, sampleName));
+        var expectedMsTableOutput = createExpectedOutput(String.format("run/%s/aligner/%s.ms_table.tsv.gz", sampleName, sampleName));
+
+        assertFilePathsDerivedCorrectly(expectedJitterOutput,
+                expectedMsTableOutput,
+                pipelineInput,
+                metadata,
+                PipelineOutputStructure.PIPELINE5);
+    }
+
+    @Test
+    public void shouldDeriveFilesCorrectlyForPipeline5TumorCram() {
+        var sampleName = TestInputs.tumorSample();
+        var metadata = TestInputs.tumorRunMetadata();
+        var pipelineInput =
+                createTestPipelineInput(sampleName, String.format("gs://bucket/run/%s/cram/%s.cram", sampleName, sampleName), true);
+
+        var expectedJitterOutput = createExpectedOutput(String.format("run/%s/aligner/%s.jitter_params.tsv", sampleName, sampleName));
+        var expectedMsTableOutput = createExpectedOutput(String.format("run/%s/aligner/%s.ms_table.tsv.gz", sampleName, sampleName));
+
+        assertFilePathsDerivedCorrectly(expectedJitterOutput,
+                expectedMsTableOutput,
+                pipelineInput,
+                metadata,
+                PipelineOutputStructure.PIPELINE5);
+    }
+
+    @Test
+    public void shouldDeriveFilesCorrectlyForPipeline5ReferenceCram() {
+        var sampleName = TestInputs.referenceSample();
+        var metadata = TestInputs.referenceRunMetadata();
+        var pipelineInput =
+                createTestPipelineInput(sampleName, String.format("gs://bucket/run/%s/cram/%s.cram", sampleName, sampleName), false);
+
+        var expectedJitterOutput = createExpectedOutput(String.format("run/%s/aligner/%s.jitter_params.tsv", sampleName, sampleName));
+        var expectedMsTableOutput = createExpectedOutput(String.format("run/%s/aligner/%s.ms_table.tsv.gz", sampleName, sampleName));
+
+        assertFilePathsDerivedCorrectly(expectedJitterOutput,
+                expectedMsTableOutput,
+                pipelineInput,
+                metadata,
+                PipelineOutputStructure.PIPELINE5);
+    }
+
+    @Test
+    public void shouldDeriveFilesCorrectlyForDatabaseTumorCram() {
+        var sampleName = TestInputs.tumorSample();
+        var metadata = TestInputs.tumorRunMetadata();
+        var pipelineInput =
+                createTestPipelineInput(sampleName, String.format("gs://bucket/%s/tumor/alignments/%s.cram", sampleName, sampleName), true);
+
+        var expectedJitterOutput = createExpectedOutput(String.format("%s/tumor/alignments/%s.jitter_params.tsv", sampleName, sampleName));
+        var expectedMsTableOutput = createExpectedOutput(String.format("%s/tumor/alignments/%s.ms_table.tsv.gz", sampleName, sampleName));
+
+        assertFilePathsDerivedCorrectly(expectedJitterOutput,
+                expectedMsTableOutput,
+                pipelineInput,
+                metadata,
+                PipelineOutputStructure.DATABASE);
+    }
+
+    @Test
+    public void shouldDeriveFilesCorrectlyForDatabaseReferenceCram() {
+        var sampleName = TestInputs.referenceSample();
+        var metadata = TestInputs.referenceRunMetadata();
+        var pipelineInput = createTestPipelineInput(sampleName,
+                String.format("gs://bucket/%s/reference/alignments/%s.cram", sampleName, sampleName),
+                false);
+
+        var expectedJitterOutput =
+                createExpectedOutput(String.format("%s/reference/alignments/%s.jitter_params.tsv", sampleName, sampleName));
+        var expectedMsTableOutput =
+                createExpectedOutput(String.format("%s/reference/alignments/%s.ms_table.tsv.gz", sampleName, sampleName));
+
+        assertFilePathsDerivedCorrectly(expectedJitterOutput,
+                expectedMsTableOutput,
+                pipelineInput,
+                metadata,
+                PipelineOutputStructure.DATABASE);
+    }
+
+    @Test
+    public void shouldThrowErrorIfFileDoesNotExist() {
+        var sampleName = TestInputs.referenceSample();
+        var metadata = TestInputs.referenceRunMetadata();
+        var pipelineInput = createTestPipelineInput(sampleName,
+                String.format("gs://bucket/%s/reference/alignments/%s.cram", sampleName, sampleName),
+                false);
+
+        var victim = new ReduxFileLocator(pipelineInput, storageUtil, project, PipelineOutputStructure.PIPELINE5);
+
+        assertThatThrownBy(() -> victim.locateJitterParamsFile(metadata)).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> victim.locateMsTableFile(metadata)).isInstanceOf(IllegalStateException.class);
+    }
+
+    private void assertFilePathsDerivedCorrectly(final ImmutableGoogleStorageLocation expectedJitterOutput,
+            final ImmutableGoogleStorageLocation expectedMsTableOutput, final ImmutablePipelineInput pipelineInput,
+            final SingleSampleRunMetadata metadata, PipelineOutputStructure outputStructure) {
+        when(storageUtil.exists("gs://" + expectedJitterOutput.bucket() + "/" + expectedJitterOutput.path())).thenReturn(true);
+        when(storageUtil.exists("gs://" + expectedMsTableOutput.bucket() + "/" + expectedMsTableOutput.path())).thenReturn(true);
+
+        var victim = new ReduxFileLocator(pipelineInput, storageUtil, project, outputStructure);
+
+        assertThat(victim.locateJitterParamsFile(metadata)).isEqualTo(expectedJitterOutput);
+        assertThat(victim.locateMsTableFile(metadata)).isEqualTo(expectedMsTableOutput);
+    }
+
+    @NotNull
+    private ImmutableGoogleStorageLocation createExpectedOutput(final String filePath) {
+        return ImmutableGoogleStorageLocation.builder().bucket("bucket").path(filePath).billingProject(project).build();
+    }
+
+    @NotNull
+    private static ImmutablePipelineInput createTestPipelineInput(final String sampleName, final String inputFile, final boolean isTumor) {
+        if (isTumor) {
+            return PipelineInput.builder()
+                    .setName(TestInputs.SET)
+                    .tumor(SampleInput.builder().name(sampleName).bam(inputFile).build())
+                    .build();
+        } else {
+            return PipelineInput.builder()
+                    .setName(TestInputs.SET)
+                    .reference(SampleInput.builder().name(sampleName).bam(inputFile).build())
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
Requires new argument `input_bam_directory_structure` to be set to `DATABASE` to trigger the new behaviour.

In testruns runs could be started from both `DATABASE` and `PIPELINE5` formatted directories.