### PR TITLE
INFRA-1615 Always use 4 local SSDs for cram2bam

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/SingleSamplePipeline.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/SingleSamplePipeline.java
@@ -101,7 +101,7 @@ public class SingleSamplePipeline {
             final PipelineState state) throws Exception {
         AlignmentOutput alignmentOutput = composer.add(state.add(aligner.run(metadata)));
         if (state.shouldProceed() && !arguments.useCrams() && alignmentOutput.alignments().path().endsWith(FileTypes.CRAM)) {
-            return state.add(stageRunner.run(metadata, new Cram2Bam(arguments, reduxFileLocator, alignmentOutput.alignments(), metadata.type())));
+            return state.add(stageRunner.run(metadata, new Cram2Bam(arguments, reduxFileLocator, alignmentOutput.alignments())));
         } else {
             return alignmentOutput;
         }

--- a/cluster/src/main/java/com/hartwig/pipeline/cram2bam/Cram2Bam.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/cram2bam/Cram2Bam.java
@@ -29,14 +29,11 @@ public class Cram2Bam implements Stage<AlignmentOutput, SingleSampleRunMetadata>
     private final Arguments arguments;
     private final ReduxFileLocator reduxFileLocator;
     private final InputDownloadCommand bamDownload;
-    private final SingleSampleRunMetadata.SampleType sampleType;
 
-    public Cram2Bam(final Arguments arguments, final ReduxFileLocator reduxFileLocator, final GoogleStorageLocation bamLocation,
-            final SingleSampleRunMetadata.SampleType sampleType) {
+    public Cram2Bam(final Arguments arguments, final ReduxFileLocator reduxFileLocator, final GoogleStorageLocation bamLocation) {
         this.arguments = arguments;
         this.reduxFileLocator = reduxFileLocator;
         this.bamDownload = new InputDownloadCommand(bamLocation);
-        this.sampleType = sampleType;
     }
 
     @Override
@@ -58,7 +55,7 @@ public class Cram2Bam implements Stage<AlignmentOutput, SingleSampleRunMetadata>
 
     @Override
     public VirtualMachineJobDefinition vmDefinition(final BashStartupScript bash, final ResultsDirectory resultsDirectory) {
-        return VirtualMachineJobDefinitions.cram2Bam(bash, resultsDirectory, sampleType, namespace());
+        return VirtualMachineJobDefinitions.cram2Bam(bash, resultsDirectory, namespace());
     }
 
     @Override

--- a/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinitions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/execution/vm/VirtualMachineJobDefinitions.java
@@ -244,15 +244,14 @@ public final class VirtualMachineJobDefinitions {
     }
 
     public static VirtualMachineJobDefinition cram2Bam(final BashStartupScript startupScript, final ResultsDirectory resultsDirectory,
-            final SingleSampleRunMetadata.SampleType sampleType, final String namespace) {
-        int numLocalSsd = sampleType.equals(SingleSampleRunMetadata.SampleType.REFERENCE) ? 2 : 4;
+            final String namespace) {
         return VirtualMachineJobDefinition.builder()
                 .imageFamily(STANDARD_IMAGE)
                 .name(namespace)
                 .namespacedResults(resultsDirectory)
                 .performanceProfile(VirtualMachinePerformanceProfile.custom(32, 32))
                 .startupCommand(startupScript)
-                .workingDiskSpaceGb(VirtualMachineJobDefinition.LOCAL_SSD_DISK_SPACE_GB * numLocalSsd)
+                .workingDiskSpaceGb(VirtualMachineJobDefinition.LOCAL_SSD_DISK_SPACE_GB * 4)
                 .build();
     }
 

--- a/cluster/src/test/java/com/hartwig/pipeline/cram2bam/Cram2BamTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/cram2bam/Cram2BamTest.java
@@ -28,10 +28,7 @@ public class Cram2BamTest extends StageTest<AlignmentOutput, SingleSampleRunMeta
     @Override
     protected Stage<AlignmentOutput, SingleSampleRunMetadata> createVictim() {
         var arguments = Arguments.testDefaultsBuilder().redoDuplicateMarking(true).build();
-        return new Cram2Bam(arguments,
-                null,
-                GoogleStorageLocation.of(TestInputs.TUMOR_BUCKET, FileTypes.bam(TestInputs.tumorSample())),
-                SingleSampleRunMetadata.SampleType.TUMOR);
+        return new Cram2Bam(arguments, null, GoogleStorageLocation.of(TestInputs.TUMOR_BUCKET, FileTypes.bam(TestInputs.tumorSample())));
     }
 
     @Override


### PR DESCRIPTION
Makes it possible to run on N2 machines too. An N2 machine with 32 vCPUs only supports 0, 4, 8, 16, or 24 local SSDs (see see https://cloud.google.com/compute/docs/disks/local-ssd#lssd_disk_options), but we selected 2 local SSDs for reference samples.