### PR TITLE
INFRA-1707 Add optional arguments to override #cpus for certain stages

### DIFF
--- a/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/Arguments.java
@@ -163,6 +163,10 @@ public interface Arguments extends CommonArguments {
 
     boolean publishEventsOnly();
 
+    Optional<Integer> stageCpusOverride();
+
+    Optional<String> stageCpusOverrideRegex();
+
     Optional<Integer> stageMemoryOverrideGb();
 
     Optional<String> stageMemoryOverrideRegex();

--- a/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/CommandLineOptions.java
@@ -74,6 +74,8 @@ public class CommandLineOptions {
     private static final String PUBLISH_EVENTS_ONLY_FLAG = "publish_events_only";
     private static final String USE_PRIVATE_RESOURCES_FLAG = "use_private_resources";
     private static final String REDO_DUPLICATE_MARKING_FLAG = "redo_duplicate_marking";
+    private static final String STAGE_CPUS_OVERRIDE_FLAG = "stage_cpus_override";
+    private static final String STAGE_CPUS_OVERRIDE_REGEX_FLAG = "stage_cpus_override_regex";
     private static final String STAGE_MEMORY_OVERRIDE_GB_FLAG = "stage_memory_override_gb";
     private static final String STAGE_MEMORY_OVERRIDE_REGEX_FLAG = "stage_memory_override_regex";
     public static final String INPUT_BAM_DIRECTORY_STRUCTURE = "input_bam_directory_structure";
@@ -137,8 +139,12 @@ public class CommandLineOptions {
                 .addOption(optionWithBooleanArg(PUBLISH_EVENTS_ONLY_FLAG,
                         "Compute nothing, only publish events for downstream consumption"))
                 .addOption(optionWithBooleanArg(REDO_DUPLICATE_MARKING_FLAG, "Redo duplicate marking on input BAM or CRAM"))
+                .addOption(optionWithArg(STAGE_CPUS_OVERRIDE_FLAG,
+                        "Override the number of cpus for a stage (specified by regex) to a specific value."))
+                .addOption(optionWithArg(STAGE_CPUS_OVERRIDE_REGEX_FLAG,
+                        "Regex to match the stage name to override the number of cpus for. This is used in conjunction with the -stage_cpus_override flag."))
                 .addOption(optionWithArg(STAGE_MEMORY_OVERRIDE_GB_FLAG,
-                        "Override the memory for a stage (specified by regex) to a specific value. "))
+                        "Override the memory for a stage (specified by regex) to a specific value."))
                 .addOption(optionWithArg(STAGE_MEMORY_OVERRIDE_REGEX_FLAG,
                         "Regex to match the stage name to override the memory for. This is used in conjunction with the -stage_memory_override_gb flag."))
                 .addOption(inputBamDirectoryStructure());
@@ -352,6 +358,8 @@ public class CommandLineOptions {
                     .pubsubTopicEnvironment(pubsubTopicEnvironment(commandLine, defaults))
                     .publishEventsOnly(booleanOptionWithDefault(commandLine, PUBLISH_EVENTS_ONLY_FLAG, defaults.publishEventsOnly()))
                     .hmfApiUrl(hmfApiUrl(commandLine, defaults))
+                    .stageCpusOverrideRegex(stageCpusOverrideRegex(commandLine))
+                    .stageCpusOverride(stageCpusOverride(commandLine))
                     .stageMemoryOverrideRegex(stageMemoryOverrideRegex(commandLine))
                     .stageMemoryOverrideGb(stageMemoryOverrideGb(commandLine))
                     .inputBamDirectoryStructure(inputBamDirectoryStructure(commandLine, defaults.inputBamDirectoryStructure()))
@@ -515,6 +523,20 @@ public class CommandLineOptions {
             return commandLine.getOptionValue(REGION_FLAG);
         }
         return defaultRegion;
+    }
+
+    private static Optional<String> stageCpusOverrideRegex(final CommandLine commandLine) {
+        if (commandLine.hasOption(STAGE_CPUS_OVERRIDE_REGEX_FLAG)) {
+            return Optional.of(commandLine.getOptionValue(STAGE_CPUS_OVERRIDE_REGEX_FLAG));
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<Integer> stageCpusOverride(final CommandLine commandLine) {
+        if (commandLine.hasOption(STAGE_CPUS_OVERRIDE_FLAG)) {
+            return Optional.of(Integer.parseInt(commandLine.getOptionValue(STAGE_CPUS_OVERRIDE_FLAG)));
+        }
+        return Optional.empty();
     }
 
     private static Optional<String> stageMemoryOverrideRegex(final CommandLine commandLine) {

--- a/cluster/src/main/java/com/hartwig/pipeline/alignment/bwa/BwaAligner.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/alignment/bwa/BwaAligner.java
@@ -1,12 +1,12 @@
 package com.hartwig.pipeline.alignment.bwa;
 
-import static java.lang.String.format;
-
 import static com.hartwig.pipeline.alignment.redux.Redux.jitterParamsTsv;
 import static com.hartwig.pipeline.alignment.redux.Redux.msTableTsv;
 import static com.hartwig.pipeline.datatypes.FileTypes.bai;
 import static com.hartwig.pipeline.datatypes.FileTypes.bam;
 import static com.hartwig.pipeline.resource.ResourceFilesFactory.buildResourceFiles;
+
+import static java.lang.String.format;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,7 +56,7 @@ import com.hartwig.pipeline.output.RunLogComponent;
 import com.hartwig.pipeline.output.SingleFileComponent;
 import com.hartwig.pipeline.resource.ResourceFiles;
 import com.hartwig.pipeline.stages.SubStageInputOutput;
-import com.hartwig.pipeline.stages.VmMemoryAdjuster;
+import com.hartwig.pipeline.stages.VmResourcesAdjuster;
 import com.hartwig.pipeline.storage.SampleUpload;
 import com.hartwig.pipeline.trace.StageTrace;
 
@@ -66,7 +66,7 @@ public class BwaAligner implements Aligner {
 
     private final Arguments arguments;
     private final ComputeEngine computeEngine;
-    private final VmMemoryAdjuster vmMemoryAdjuster;
+    private final VmResourcesAdjuster vmResourcesAdjuster;
     private final Storage storage;
     private final PipelineInput input;
     private final SampleUpload sampleUpload;
@@ -79,7 +79,7 @@ public class BwaAligner implements Aligner {
             final ExecutorService executorService, final Labels labels) {
         this.arguments = arguments;
         this.computeEngine = computeEngine;
-        this.vmMemoryAdjuster = new VmMemoryAdjuster(arguments);
+        this.vmResourcesAdjuster = new VmResourcesAdjuster(arguments);
         this.storage = storage;
         this.input = input;
         this.sampleUpload = sampleUpload;
@@ -266,7 +266,7 @@ public class BwaAligner implements Aligner {
 
     public ComputeEngineStatus runWithRetries(final SingleSampleRunMetadata metadata, final RuntimeBucket laneBucket,
             final VirtualMachineJobDefinition jobDefinition) {
-        var modifiedDefinition = vmMemoryAdjuster.overrideVmDefinition(jobDefinition);
+        var modifiedDefinition = vmResourcesAdjuster.overrideVmDefinition(jobDefinition);
         return Failsafe.with(DefaultBackoffPolicy.of(String.format("[%s] stage [%s]",
                 metadata.toString(),
                 Aligner.NAMESPACE))).get(() -> computeEngine.submit(laneBucket, modifiedDefinition));

--- a/cluster/src/main/java/com/hartwig/pipeline/stages/StageRunner.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/stages/StageRunner.java
@@ -32,7 +32,7 @@ public class StageRunner<M extends RunMetadata> {
 
     private final Storage storage;
     private final Arguments arguments;
-    private final VmMemoryAdjuster vmMemoryAdjuster;
+    private final VmResourcesAdjuster vmResourcesAdjuster;
     private final ComputeEngine computeEngine;
     private final ResultsDirectory resultsDirectory;
     private final StartingPoint startingPoint;
@@ -43,7 +43,7 @@ public class StageRunner<M extends RunMetadata> {
             final ResultsDirectory resultsDirectory, final StartingPoint startingPoint, final Labels labels, final InputMode mode) {
         this.storage = storage;
         this.arguments = arguments;
-        this.vmMemoryAdjuster = new VmMemoryAdjuster(arguments);
+        this.vmResourcesAdjuster = new VmResourcesAdjuster(arguments);
         this.computeEngine = computeEngine;
         this.resultsDirectory = resultsDirectory;
         this.startingPoint = startingPoint;
@@ -70,7 +70,7 @@ public class StageRunner<M extends RunMetadata> {
                         .addCommands(commands)
                         .addCommand(new OutputUploadCommand(GoogleStorageLocation.of(bucket.name(), resultsDirectory.path()),
                                 RuntimeFiles.typical()));
-                var jobDefinition = vmMemoryAdjuster.overrideVmDefinition(stage.vmDefinition(bash, resultsDirectory));
+                var jobDefinition = vmResourcesAdjuster.overrideVmDefinition(stage.vmDefinition(bash, resultsDirectory));
                 ComputeEngineStatus computeEngineStatus =
                         Failsafe.with(DefaultBackoffPolicy.of(String.format("[%s] stage [%s]", metadata.runName(), stage.namespace())))
                                 .get(() -> computeEngine.submit(bucket, jobDefinition));

--- a/cluster/src/main/java/com/hartwig/pipeline/stages/VmCpusAdjuster.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/stages/VmCpusAdjuster.java
@@ -1,0 +1,43 @@
+package com.hartwig.pipeline.stages;
+
+import com.hartwig.computeengine.execution.vm.VirtualMachineJobDefinition;
+import com.hartwig.computeengine.execution.vm.VirtualMachinePerformanceProfile;
+import com.hartwig.pipeline.Arguments;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class VmCpusAdjuster {
+    private static final Logger LOGGER = LoggerFactory.getLogger(VmCpusAdjuster.class);
+
+    private final Arguments arguments;
+
+    public VmCpusAdjuster(Arguments arguments) {
+        this.arguments = arguments;
+    }
+
+    public VirtualMachineJobDefinition overrideVmDefinition(VirtualMachineJobDefinition jobDefinition) {
+        if (arguments.stageCpusOverrideRegex().isEmpty() || arguments.stageCpusOverride().isEmpty()) {
+            if (arguments.stageCpusOverrideRegex().isPresent()) {
+                LOGGER.warn("Stage cpus override regex is set but no override value is provided (--stage_cpus_override).");
+            }
+            if (arguments.stageCpusOverride().isPresent()) {
+                LOGGER.warn("Stage cpus override value is set but no regex is provided (--stage_cpus_override_regex).");
+            }
+            return jobDefinition;
+        }
+        var jobName = jobDefinition.name();
+        var regex = arguments.stageCpusOverrideRegex().get();
+        if (!jobName.matches(regex)) {
+            return jobDefinition;
+        }
+        var cpus = arguments.stageCpusOverride().get();
+        var originalCpus = jobDefinition.performanceProfile().cpus().orElseThrow();
+        LOGGER.info("Overriding cpus for job [{}] to {} (original was {})", jobName, cpus, originalCpus);
+        var memoryGb = jobDefinition.performanceProfile().memoryGB().orElseThrow();
+        return VirtualMachineJobDefinition.builder()
+                .from(jobDefinition)
+                .performanceProfile(VirtualMachinePerformanceProfile.custom(cpus, memoryGb))
+                .build();
+    }
+}

--- a/cluster/src/main/java/com/hartwig/pipeline/stages/VmMemoryAdjuster.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/stages/VmMemoryAdjuster.java
@@ -1,7 +1,5 @@
 package com.hartwig.pipeline.stages;
 
-import java.util.OptionalInt;
-
 import com.hartwig.computeengine.execution.vm.VirtualMachineJobDefinition;
 import com.hartwig.computeengine.execution.vm.VirtualMachinePerformanceProfile;
 import com.hartwig.pipeline.Arguments;

--- a/cluster/src/main/java/com/hartwig/pipeline/stages/VmResourcesAdjuster.java
+++ b/cluster/src/main/java/com/hartwig/pipeline/stages/VmResourcesAdjuster.java
@@ -1,0 +1,19 @@
+package com.hartwig.pipeline.stages;
+
+import com.hartwig.computeengine.execution.vm.VirtualMachineJobDefinition;
+import com.hartwig.pipeline.Arguments;
+
+public class VmResourcesAdjuster {
+
+    private final VmCpusAdjuster cpusAdjuster;
+    private final VmMemoryAdjuster memoryAdjuster;
+
+    public VmResourcesAdjuster(Arguments arguments) {
+        this.cpusAdjuster = new VmCpusAdjuster(arguments);
+        this.memoryAdjuster = new VmMemoryAdjuster(arguments);
+    }
+
+    public VirtualMachineJobDefinition overrideVmDefinition(VirtualMachineJobDefinition jobDefinition) {
+        return memoryAdjuster.overrideVmDefinition(cpusAdjuster.overrideVmDefinition(jobDefinition));
+    }
+}

--- a/cluster/src/test/java/com/hartwig/pipeline/stages/VmCpusAdjusterTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/stages/VmCpusAdjusterTest.java
@@ -1,0 +1,86 @@
+package com.hartwig.pipeline.stages;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import com.hartwig.computeengine.execution.vm.BashStartupScript;
+import com.hartwig.computeengine.storage.ResultsDirectory;
+import com.hartwig.pipeline.Arguments;
+import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinitions;
+
+import org.junit.Test;
+
+public class VmCpusAdjusterTest {
+
+    @Test
+    public void testOverrideVmDefinition() {
+        var arguments = mock(Arguments.class);
+        when(arguments.stageCpusOverrideRegex()).thenReturn(Optional.of(".*"));
+        when(arguments.stageCpusOverride()).thenReturn(Optional.of(4));
+
+        var vmCpusAdjuster = new VmCpusAdjuster(arguments);
+
+        var peach = VirtualMachineJobDefinitions.peach(mock(BashStartupScript.class), mock(ResultsDirectory.class));
+        assertEquals(2, peach.performanceProfile().cpus().getAsInt());
+
+        var adjustedVmDefinition = vmCpusAdjuster.overrideVmDefinition(peach);
+        assertEquals(4, adjustedVmDefinition.performanceProfile().cpus().getAsInt());
+    }
+
+    @Test
+    public void testOverrideRegexDoesNotMatch() {
+        var arguments = mock(Arguments.class);
+        when(arguments.stageCpusOverrideRegex()).thenReturn(Optional.of("esvee"));
+        when(arguments.stageCpusOverride()).thenReturn(Optional.of(4));
+
+        var vmCpusAdjuster = new VmCpusAdjuster(arguments);
+
+        var peach = VirtualMachineJobDefinitions.peach(mock(BashStartupScript.class), mock(ResultsDirectory.class));
+        assertEquals(2, peach.performanceProfile().cpus().getAsInt());
+
+        var adjustedVmDefinition = vmCpusAdjuster.overrideVmDefinition(peach);
+        assertEquals(2, adjustedVmDefinition.performanceProfile().cpus().getAsInt());
+    }
+
+    @Test
+    public void testOverridesNotSet() {
+        var arguments = mock(Arguments.class);
+        when(arguments.stageCpusOverrideRegex()).thenReturn(Optional.empty());
+        when(arguments.stageCpusOverride()).thenReturn(Optional.empty());
+
+        var vmCpusAdjuster = new VmCpusAdjuster(arguments);
+
+        var peach = VirtualMachineJobDefinitions.peach(mock(BashStartupScript.class), mock(ResultsDirectory.class));
+        var adjustedVmDefinition = vmCpusAdjuster.overrideVmDefinition(peach);
+        assertEquals(2, adjustedVmDefinition.performanceProfile().cpus().getAsInt());
+    }
+
+    @Test
+    public void testRegexNotSet() {
+        var arguments = mock(Arguments.class);
+        when(arguments.stageCpusOverrideRegex()).thenReturn(Optional.empty());
+        when(arguments.stageCpusOverride()).thenReturn(Optional.of(4));
+
+        var vmCpusAdjuster = new VmCpusAdjuster(arguments);
+
+        var peach = VirtualMachineJobDefinitions.peach(mock(BashStartupScript.class), mock(ResultsDirectory.class));
+        var adjustedVmDefinition = vmCpusAdjuster.overrideVmDefinition(peach);
+        assertEquals(2, adjustedVmDefinition.performanceProfile().cpus().getAsInt());
+    }
+
+    @Test
+    public void testCpusNotSet() {
+        var arguments = mock(Arguments.class);
+        when(arguments.stageCpusOverrideRegex()).thenReturn(Optional.of(".*"));
+        when(arguments.stageCpusOverride()).thenReturn(Optional.empty());
+
+        var vmCpusAdjuster = new VmCpusAdjuster(arguments);
+
+        var peach = VirtualMachineJobDefinitions.peach(mock(BashStartupScript.class), mock(ResultsDirectory.class));
+        var adjustedVmDefinition = vmCpusAdjuster.overrideVmDefinition(peach);
+        assertEquals(2, adjustedVmDefinition.performanceProfile().cpus().getAsInt());
+    }
+}

--- a/cluster/src/test/java/com/hartwig/pipeline/stages/VmResourcesAdjusterTest.java
+++ b/cluster/src/test/java/com/hartwig/pipeline/stages/VmResourcesAdjusterTest.java
@@ -1,0 +1,74 @@
+package com.hartwig.pipeline.stages;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import com.hartwig.computeengine.execution.vm.BashStartupScript;
+import com.hartwig.computeengine.storage.ResultsDirectory;
+import com.hartwig.pipeline.Arguments;
+import com.hartwig.pipeline.execution.vm.VirtualMachineJobDefinitions;
+
+import org.junit.Test;
+
+public class VmResourcesAdjusterTest {
+
+    @Test
+    public void testOverrideCpus() {
+        var arguments = mock(Arguments.class);
+        when(arguments.stageCpusOverrideRegex()).thenReturn(Optional.of(".*"));
+        when(arguments.stageCpusOverride()).thenReturn(Optional.of(8));
+        when(arguments.stageMemoryOverrideRegex()).thenReturn(Optional.empty());
+        when(arguments.stageMemoryOverrideGb()).thenReturn(Optional.empty());
+
+        var vmResourcesAdjuster = new VmResourcesAdjuster(arguments);
+
+        var peach = VirtualMachineJobDefinitions.peach(mock(BashStartupScript.class), mock(ResultsDirectory.class));
+        assertEquals(2, peach.performanceProfile().cpus().getAsInt());
+        assertEquals(4, peach.performanceProfile().memoryGB().getAsInt());
+
+        var adjustedVmDefinition = vmResourcesAdjuster.overrideVmDefinition(peach);
+        assertEquals(8, adjustedVmDefinition.performanceProfile().cpus().getAsInt());
+        assertEquals(4, adjustedVmDefinition.performanceProfile().memoryGB().getAsInt());
+    }
+
+    @Test
+    public void testOverrideMemory() {
+        var arguments = mock(Arguments.class);
+        when(arguments.stageCpusOverrideRegex()).thenReturn(Optional.empty());
+        when(arguments.stageCpusOverride()).thenReturn(Optional.empty());
+        when(arguments.stageMemoryOverrideRegex()).thenReturn(Optional.of(".*"));
+        when(arguments.stageMemoryOverrideGb()).thenReturn(Optional.of(64));
+
+        var vmResourcesAdjuster = new VmResourcesAdjuster(arguments);
+
+        var peach = VirtualMachineJobDefinitions.peach(mock(BashStartupScript.class), mock(ResultsDirectory.class));
+        assertEquals(2, peach.performanceProfile().cpus().getAsInt());
+        assertEquals(4, peach.performanceProfile().memoryGB().getAsInt());
+
+        var adjustedVmDefinition = vmResourcesAdjuster.overrideVmDefinition(peach);
+        assertEquals(2, adjustedVmDefinition.performanceProfile().cpus().getAsInt());
+        assertEquals(64, adjustedVmDefinition.performanceProfile().memoryGB().getAsInt());
+    }
+
+    @Test
+    public void testOverrideCpusAndMemory() {
+        var arguments = mock(Arguments.class);
+        when(arguments.stageCpusOverrideRegex()).thenReturn(Optional.of(".*"));
+        when(arguments.stageCpusOverride()).thenReturn(Optional.of(8));
+        when(arguments.stageMemoryOverrideRegex()).thenReturn(Optional.of(".*"));
+        when(arguments.stageMemoryOverrideGb()).thenReturn(Optional.of(64));
+
+        var vmResourcesAdjuster = new VmResourcesAdjuster(arguments);
+
+        var peach = VirtualMachineJobDefinitions.peach(mock(BashStartupScript.class), mock(ResultsDirectory.class));
+        assertEquals(2, peach.performanceProfile().cpus().getAsInt());
+        assertEquals(4, peach.performanceProfile().memoryGB().getAsInt());
+
+        var adjustedVmDefinition = vmResourcesAdjuster.overrideVmDefinition(peach);
+        assertEquals(8, adjustedVmDefinition.performanceProfile().cpus().getAsInt());
+        assertEquals(64, adjustedVmDefinition.performanceProfile().memoryGB().getAsInt());
+    }
+}


### PR DESCRIPTION
Very similar to overriding the memory for stages. I added a second regex argument to keep everything fully backwards compatible.