### PR TITLE
INFRA-2804 Fix 6.0-hotfix build

### DIFF
--- a/cluster/Dockerfile
+++ b/cluster/Dockerfile
@@ -1,4 +1,5 @@
-FROM google/cloud-sdk:latest
+# Version 565.0.0 is the last one that supports openjdk-17
+FROM google/cloud-sdk:565.0.0
 
 RUN apt-get update
 RUN apt-get --yes install openjdk-17-jre


### PR DESCRIPTION
The `cloud-sdk:latest` image is currently based on Debian Trixie, which doesn't support openjdk-17 anymore. The buid of the Docker image therefore failed with
```
1.379 E: Package 'openjdk-17-jre' has no installation candidate
```
Solution: pin the latest image that still supports it.